### PR TITLE
Fixes to Z abilities for Lunara, Medivh, and Rehgar

### DIFF
--- a/hero/lunara.json
+++ b/hero/lunara.json
@@ -52,6 +52,12 @@
         "description": "Your Basic Attacks and damaging Abilities poison their target, dealing 34 (+5% per level) damage a second for 3 seconds. Every additional application increases the duration by 3 seconds, up to a maximum of 9 seconds.",
         "trait": true,
         "abilityId": "Lunara|D1"
+      },
+      {
+        "name": "Dryad's Swiftness",
+        "description": "Lunara moves 20% faster by leaping short distances.",
+        "hotkey": "Z",
+        "abilityId": "Lunara|Z1"
       }
     ]
   },

--- a/hero/medivh.json
+++ b/hero/medivh.json
@@ -51,6 +51,7 @@
         "name": "Raven Form",
         "description": "Instead of mounting, Medivh can transform into a raven, increasing Movement Speed by 20%. While transformed, Medivh can see and fly over all terrain and is immune to all effects.",
         "hotkey": "Z",
+        "trait": true,
         "abilityId": "Medivh|Z1"
       }
     ]

--- a/hero/rehgar.json
+++ b/hero/rehgar.json
@@ -51,6 +51,7 @@
         "name": "Ghost Wolf",
         "description": "Instead of using a mount, you transform into a Ghost Wolf with 20% increased Movement Speed. Basic Attacks in Ghost Wolf form cause you to lunge at your target and deal 75% bonus damage. Dealing damage, using Abilities, and channeling cancels Ghost Wolf form.",
         "hotkey": "Z",
+        "trait": true,
         "abilityId": "Rehgar|Z1",
         "cooldown": 1
       }


### PR DESCRIPTION
- Added Lunara's "Dryad's Swiftness" (not sure if there is a proper way to mark it as being on Z and passive at the same time, so ignored it for now)
- Marked Medivh's "Raven Form" and Rehgar's "Ghost Wolf" as traits (they are displayed in-game on their D buttons too, so that should be reasonable)