### PR TITLE
Add new ability UIDs

### DIFF
--- a/hero/abathur.json
+++ b/hero/abathur.json
@@ -22,6 +22,7 @@
   "abilities": {
     "Abathur": [
       {
+        "uid": "9c810ae",
         "name": "Symbiote",
         "description": "Spawn and attach a Symbiote to a target ally or Structure. While active, Abathur controls the Symbiote, gaining access to new Abilities. The Symbiote is able to gain XP from nearby enemy deaths.",
         "hotkey": "Q",
@@ -31,6 +32,7 @@
         "type": "basic"
       },
       {
+        "uid": "82a0b5c",
         "name": "Toxic Nest",
         "description": "Spawn a mine that becomes active after a short time. Deals 153 (+4% per level) damage and reveals the enemy for 4 seconds. Lasts 90 seconds.  Stores up to 3 charges.",
         "hotkey": "W",
@@ -40,6 +42,7 @@
         "type": "basic"
       },
       {
+        "uid": "a6eb53a",
         "name": "Evolve Monstrosity",
         "description": "Turn an allied Minion or Locust into a Monstrosity. When enemy Minions near the Monstrosity die, it gains 2% Health and 2% Basic Attack damage, stacking up to 40 times.  The Monstrosity can be healed by Carapace and has the ability to Burrow to a visible location every 80 seconds.  Using Symbiote on the Monstrosity allows Abathur to control it, in addition to Symbiote's normal benefits.  This Ability can be reactivated to automatically cast Symbiote on his Monstrosity.",
         "hotkey": "R",
@@ -49,6 +52,7 @@
         "type": "heroic"
       },
       {
+        "uid": "a4dc837",
         "name": "Ultimate Evolution",
         "description": "Clone target allied Hero and control it for 20 seconds. Abathur has perfected the clone, granting it 20% Spell Power, 20% bonus Attack Damage, and 10% bonus Movement Speed. Cannot use their Heroic Ability.",
         "hotkey": "R",
@@ -58,6 +62,7 @@
         "type": "heroic"
       },
       {
+        "uid": "75fc9a2",
         "name": "Locust Strain",
         "description": "Spawns a Locust to attack down the nearest lane every 15 seconds. Locusts last for 16 seconds, have 316 (+4% per level) health and deal 46 (+4% per level) damage with each Basic Attack.",
         "trait": true,
@@ -67,6 +72,7 @@
         "type": "trait"
       },
       {
+        "uid": "f3ed2ec",
         "name": "Deep Tunnel",
         "description": "Quickly tunnel to a visible location",
         "hotkey": "Z",
@@ -78,6 +84,7 @@
     ],
     "0": [
       {
+        "uid": "ad3fb1f",
         "name": "Stab",
         "description": "Shoots a spike towards target area that deals 119 (+4% per level) damage to the first enemy it contacts.",
         "hotkey": "Q",
@@ -87,6 +94,7 @@
         "type": "subunit"
       },
       {
+        "uid": "82650ee",
         "name": "Spike Burst",
         "description": "Deals 120 (+4% per level) damage to nearby enemies.",
         "hotkey": "W",
@@ -96,6 +104,7 @@
         "type": "subunit"
       },
       {
+        "uid": "a8f01c1",
         "name": "Carapace",
         "description": "Shields the assisted ally for 150 (+4% per level). Allied Heroes are healed for 22 (+4% per level) Health per second while the Shield is active. Lasts for 6 seconds.",
         "hotkey": "E",
@@ -105,6 +114,7 @@
         "type": "subunit"
       },
       {
+        "uid": "7c6b61b",
         "name": "Deep Tunnel",
         "description": "Order your Evolved Monstrosity to quickly tunnel to a visible location",
         "hotkey": "Z",

--- a/hero/alarak.json
+++ b/hero/alarak.json
@@ -21,6 +21,7 @@
   "abilities": {
     "Alarak": [
       {
+        "uid": "1b96dbd",
         "name": "Discord Strike",
         "description": "After a 0.5 second delay, enemies in front of Alarak take 175 (+4% per level) damage and are silenced for 1.5 seconds.",
         "hotkey": "Q",
@@ -31,6 +32,7 @@
         "type": "basic"
       },
       {
+        "uid": "e9f3fa3",
         "name": "Telekinesis",
         "description": "Vector Targeting Create a force, pushing Alarak and all enemies hit from the targeted point towards the targeted direction. Deals 48 (+4% per level) damage to enemies.",
         "hotkey": "W",
@@ -41,6 +43,7 @@
         "type": "basic"
       },
       {
+        "uid": "aeb7b52",
         "name": "Lightning Surge",
         "description": "Deal 62 (+4% per level) damage to an enemy and an additional 100% damage to enemies between Alarak and the target. Restore 70 (+4% per level) health for each Hero hit.",
         "hotkey": "E",
@@ -51,6 +54,7 @@
         "type": "basic"
       },
       {
+        "uid": "3b76d00",
         "name": "Counter-Strike",
         "description": "Alarak targets an area and channels for 1 second, becoming Protected and Unstoppable. After, if he took damage from an enemy Hero, he sends a shockwave that deals 275 (+4% per level) damage.",
         "hotkey": "R",
@@ -61,6 +65,7 @@
         "type": "heroic"
       },
       {
+        "uid": "c6f73c4",
         "name": "Deadly Charge",
         "description": "After channeling, Alarak charges forward dealing 200 (+4% per level) damage to all enemies in his path. Distance is increased based on the amount of time channeled, up to 1.5 seconds.  Issuing a Move order while this is channeling will cancel it at no cost. Taking damage will interrupt the channeling.",
         "hotkey": "R",
@@ -71,6 +76,7 @@
         "type": "heroic"
       },
       {
+        "uid": "74c559f",
         "name": "Sadism",
         "description": "Alarak's Ability damage and self-healing are increased by 100% against enemy Heroes.  Repeatable Quest: Takedowns increase Sadism by 3%, up to 30%. Sadism gained from Takedowns is lost on death.",
         "trait": true,

--- a/hero/alexstrasza.json
+++ b/hero/alexstrasza.json
@@ -20,6 +20,7 @@
   "abilities": {
     "Alexstrasza": [
       {
+        "uid": "b7c5d9e",
         "name": "Gift of Life",
         "description": "Sacrifice 15% of Alexstrasza's current Health, healing an allied Hero for 150% of that amount.  Dragonqueen: Breath of Life Cooldown greatly reduced and does not cost Health.",
         "hotkey": "Q",
@@ -29,6 +30,7 @@
         "type": "basic"
       },
       {
+        "uid": "cf4e573",
         "name": "Abundance",
         "description": "Plant a seed of healing that blooms after 3 seconds, healing nearby allied Heroes for 20% of their maximum Health.  Dragonqueen: Preservation Heal area and amount greatly increased.",
         "hotkey": "W",
@@ -39,6 +41,7 @@
         "type": "basic"
       },
       {
+        "uid": "9a18508",
         "name": "Flame Buffet",
         "description": "Launch a fireball, Burning enemies hit for 75 (+4% per level) damage over 5.5 seconds.  Hitting enemies that are already Burning deals 125 (+4% per level) bonus damage upon impact, Slows them by 40% decaying over 2 seconds, and refunds the Mana cost.  Dragonqueen: Wing Buffet Damage and Knockback enemies in an arc.",
         "hotkey": "E",
@@ -49,6 +52,7 @@
         "type": "basic"
       },
       {
+        "uid": "5c6e17b",
         "name": "Life-Binder",
         "description": "Bind Alexstrasza's life force with an allied Hero. Both her and her target are healed for 480 (+4% per level) Health over 2 seconds. Afterwards, the Hero with a lower percentage of Health is healed to the same Health percentage as the other Hero.",
         "hotkey": "R",
@@ -59,6 +63,7 @@
         "type": "heroic"
       },
       {
+        "uid": "d250be7",
         "name": "Cleansing Flame",
         "description": "After 1.25 seconds, take to the sky and drop 5 fireballs over 6 seconds at the position of the mouse cursor. Fireballs deal 135 (+4% per level) damage to enemies and heal allied Heroes for 300 (+4% per level) Health.  2 seconds after dropping all fireballs, Alexstrasza lands at the position of the mouse cursor.",
         "hotkey": "R",
@@ -69,6 +74,7 @@
         "type": "heroic"
       },
       {
+        "uid": "e9f0c50",
         "name": "Dragonqueen",
         "description": "After 1.25 seconds, transform into a dragon and gain 500 (+4% per level) Health.  While Dragonqueen is active, Alexstrasza's Abilities are empowered, and her Basic Attacks deal 143 (+4% per level) damage and heal allied Heroes for 43 (+4% per level) in an arc in front of her. Additionally, the duration of incoming Stuns, Roots, and Slows, is reduced by 50%.  Lasts 15 seconds.",
         "hotkey": "D",
@@ -81,6 +87,7 @@
     ],
     "AlexstraszaDragon": [
       {
+        "uid": "5ed3eb0",
         "name": "Breath of Life",
         "description": "Heal an allied Hero for 20% of Alexstrasza's current Health.",
         "hotkey": "Q",
@@ -90,6 +97,7 @@
         "type": "subunit"
       },
       {
+        "uid": "ea7d594",
         "name": "Preservation",
         "description": "Plant a seed of healing that blooms after 3 seconds, healing nearby allied Heroes for 30% of their maximum Health.",
         "hotkey": "W",
@@ -99,6 +107,7 @@
         "type": "subunit"
       },
       {
+        "uid": "5e392ea",
         "name": "Wing Buffet",
         "description": "Deal 150 (+4% per level) damage to enemies in an area, knocking them back and Slowing them by 50% for 3 seconds.",
         "hotkey": "E",
@@ -108,6 +117,7 @@
         "type": "subunit"
       },
       {
+        "uid": "4125e5b",
         "name": "Cleansing Flame",
         "description": "Take to the sky and drop 5 fireballs over 6 seconds at the position of the mouse cursor. Fireballs deal 135 (+4% per level) damage to enemies and heal allied Heroes for 300 (+4% per level) Health.  2 seconds after dropping all fireballs, Alexstrasza lands at the position of the mouse cursor.",
         "hotkey": "R",

--- a/hero/ana.json
+++ b/hero/ana.json
@@ -22,6 +22,7 @@
   "abilities": {
     "Ana": [
       {
+        "uid": "1544659",
         "name": "Healing Dart",
         "description": "Fire a dart which heals the first allied Hero hit for 195 (+4% per level) Health. Does not affect full Health Heroes.",
         "hotkey": "Q",
@@ -32,6 +33,7 @@
         "type": "basic"
       },
       {
+        "uid": "1590783",
         "name": "Biotic Grenade",
         "description": "Toss a grenade at the target area. Allied Heroes hit are healed for 152 (+4% per level) Health and receive 25% increased healing from Ana for 4 seconds. Enemies hit take 60 (+4% per level) damage and receive 100% less healing for 2 seconds.",
         "hotkey": "W",
@@ -42,6 +44,7 @@
         "type": "basic"
       },
       {
+        "uid": "61433a4",
         "name": "Sleep Dart",
         "description": "Fire a dart that puts the first enemy Hero hit to Sleep, Stunning them for 3 seconds. Sleep's effects end instantly if the target takes damage after the first 0.5 seconds.  Cannot be used on Vehicles.",
         "hotkey": "E",
@@ -52,6 +55,7 @@
         "type": "basic"
       },
       {
+        "uid": "08549fe",
         "name": "Eye of Horus",
         "description": "Assume a sniping position, gaining the ability to fire up to 6 specialized rounds with unlimited range. Rounds pierce allied and enemy Heroes but collide with enemy Structures in their path. Allies are healed for 225 (+4% per level) and enemies are damaged for 135 (+4% per level). Deals 50% less damage to Structures.  Ana is unable to move while Eye of Horus is active.",
         "hotkey": "R",
@@ -62,6 +66,7 @@
         "type": "heroic"
       },
       {
+        "uid": "a9a7caf",
         "name": "Nano Boost",
         "description": "Instantly boost an allied Hero, restoring 200 Mana. For the next 8 seconds, they gain 30% Spell Power and their Basic Ability cooldowns recharge 150% faster.  Cannot be used on Ana.",
         "hotkey": "R",
@@ -72,6 +77,7 @@
         "type": "heroic"
       },
       {
+        "uid": "ff47987",
         "name": "Shrike",
         "description": "Basic Attacks apply a Dose to enemies, dealing an additional 40 (+4% per level) damage over 5 seconds, and stacking up to 5 times. Every 0.5 seconds, Ana is healed for 50% of the damage dealt by Shrike.  Aim Down Sights  Activating Shrike reduces your Movement Speed by 25%, but increases the Range of Healing Dart and Sleep Dart by 25% while also allowing them to pierce one Hero. Lasts until canceled.",
         "trait": true,

--- a/hero/anduin.json
+++ b/hero/anduin.json
@@ -21,6 +21,7 @@
   "abilities": {
     "Anduin": [
       {
+        "uid": "802a33e",
         "name": "Flash Heal",
         "description": "Cast for 0.75 seconds to heal an allied Hero for 260 (+4% per level).",
         "hotkey": "Q",
@@ -31,6 +32,7 @@
         "type": "basic"
       },
       {
+        "uid": "d989498",
         "name": "Divine Star",
         "description": "Send light that deals 140 (+4% per level) damage to enemies and then returns to Anduin, healing allied Heroes for 130 (+4% per level) in a wider path. Healing increases by 25% per enemy Hero hit.",
         "hotkey": "W",
@@ -41,6 +43,7 @@
         "type": "basic"
       },
       {
+        "uid": "c40938f",
         "name": "Chastise",
         "description": "Shove a swell of light forward, dealing 145 (+4% per level) damage to the first enemy Hero hit and Rooting them for 1.25 seconds.",
         "hotkey": "E",
@@ -51,6 +54,7 @@
         "type": "basic"
       },
       {
+        "uid": "7e2826e",
         "name": "Holy Word: Salvation",
         "description": "After 0.5 seconds, Channel to invoke the Light for 3 seconds. While nearby, allied Heroes heal for up to 25% of their max Health and are Protected.",
         "hotkey": "R",
@@ -61,6 +65,7 @@
         "type": "heroic"
       },
       {
+        "uid": "ffadaf9",
         "name": "Lightbomb",
         "description": "Imbue an allied Hero with the Light. After 1.5 seconds, it explodes, dealing 150 (+4% per level) damage to enemies and Stunning them for 1.25 seconds.  The target gains a Shield that absorbs 165 (+4% per level) damage per enemy Hero hit. Lasts for 5 seconds.",
         "hotkey": "R",
@@ -71,6 +76,7 @@
         "type": "heroic"
       },
       {
+        "uid": "70dbcbd",
         "name": "Leap of Faith",
         "description": "Faith instantly pulls an allied Hero to Anduin's location, granting them Unstoppable while they travel.",
         "trait": true,

--- a/hero/anubarak.json
+++ b/hero/anubarak.json
@@ -22,6 +22,7 @@
   "abilities": {
     "Anub'arak": [
       {
+        "uid": "b2732b2",
         "name": "Impale",
         "description": "Deals 90 (+4% per level) damage. Stuns for 1 second.",
         "hotkey": "Q",
@@ -32,6 +33,7 @@
         "type": "basic"
       },
       {
+        "uid": "7ba9477",
         "name": "Harden Carapace",
         "description": "Gain a Shield that grants 40 Spell Armor and absorbs 315 (+4% per level) damage over 3 seconds.",
         "hotkey": "W",
@@ -42,6 +44,7 @@
         "type": "basic"
       },
       {
+        "uid": "fe6aaf9",
         "name": "Burrow Charge",
         "description": "Burrow to the target location, dealing 91 (+4% per level) damage and briefly stunning enemies in a small area upon surfacing, slowing them by 25% for 2.5 seconds.  Burrow Charge can be reactivated to surface early.",
         "hotkey": "E",
@@ -52,6 +55,7 @@
         "type": "basic"
       },
       {
+        "uid": "70ba35f",
         "name": "Locust Swarm",
         "description": "Deal 62 (+4% per level) damage per second to nearby enemies. Each enemy damaged restores 21 (+4% per level) Health. Lasts 6 seconds.",
         "hotkey": "R",
@@ -62,6 +66,7 @@
         "type": "heroic"
       },
       {
+        "uid": "3b2098b",
         "name": "Cocoon",
         "description": "Wraps target enemy Hero in a cocoon, rendering them unable to act or be targeted for 7 seconds. Allies of the Hero can attack the cocoon to break it and free them early.",
         "hotkey": "R",
@@ -72,6 +77,7 @@
         "type": "heroic"
       },
       {
+        "uid": "680f5d4",
         "name": "Scarab Host",
         "description": "Using an Ability spawns a Beetle which lasts for 8 seconds, attacking nearby enemies for 20 (+4% per level) damage.",
         "trait": true,

--- a/hero/artanis.json
+++ b/hero/artanis.json
@@ -22,6 +22,7 @@
   "abilities": {
     "Artanis": [
       {
+        "uid": "c569089",
         "name": "Blade Dash",
         "description": "Dash forward and deal 57 (+4% per level) damage to enemies, then return and deal 171 (+4% per level) damage. Every enemy hit reduces the cooldown on Shield Overload by 1 second, and Heroes by 2 seconds.",
         "hotkey": "Q",
@@ -32,6 +33,7 @@
         "type": "basic"
       },
       {
+        "uid": "74e9d34",
         "name": "Twin Blades",
         "description": "Artanis's next Basic Attack immediately causes him to charge a short distance and strike the enemy 2 times.",
         "hotkey": "W",
@@ -42,6 +44,7 @@
         "type": "basic"
       },
       {
+        "uid": "b04f75c",
         "name": "Phase Prism",
         "description": "Fire a Phase Prism that deals 66 (+4% per level) damage to the first Hero hit and swaps Artanis's position with theirs. Can be used during Blade Dash.",
         "hotkey": "E",
@@ -52,6 +55,7 @@
         "type": "basic"
       },
       {
+        "uid": "5c93f95",
         "name": "Purifier Beam",
         "description": "Target an enemy Hero with an orbital beam from the Spear of Adun, dealing 184 (+4% per level) damage per second for 8 seconds. The beam will chase the target as they move.  Unlimited range.",
         "hotkey": "R",
@@ -62,6 +66,7 @@
         "type": "heroic"
       },
       {
+        "uid": "15c0925",
         "name": "Suppression Pulse",
         "description": "Fire a large area pulse from the Spear of Adun, dealing 114 (+4% per level) damage and Blinding enemies for 4 seconds. Unlimited range.",
         "hotkey": "R",
@@ -72,6 +77,7 @@
         "type": "heroic"
       },
       {
+        "uid": "3691f55",
         "name": "Shield Overload",
         "description": "After taking damage while below 75% Health, Artanis gains a 375 (+4% per level) Shield for 5 seconds. Basic Attacks lower the cooldown of Shield Overload by 4 seconds.",
         "trait": true,

--- a/hero/arthas.json
+++ b/hero/arthas.json
@@ -21,6 +21,7 @@
   "abilities": {
     "Arthas": [
       {
+        "uid": "08af6cf",
         "name": "Death Coil",
         "description": "Deals 164 (+4% per level) damage to target enemy.  Can be self-cast to heal for 262 (+4% per level) Health.",
         "hotkey": "Q",
@@ -31,6 +32,7 @@
         "type": "basic"
       },
       {
+        "uid": "a4f68c5",
         "name": "Howling Blast",
         "description": "Root enemies within the target area for 1.25 seconds and deals 68 (+4% per level) damage.",
         "hotkey": "W",
@@ -41,6 +43,7 @@
         "type": "basic"
       },
       {
+        "uid": "1930221",
         "name": "Frozen Tempest",
         "description": "Deal 40 (+4% per level) damage per second to nearby enemies and Slow their Movement Speed by 10% per second, stacking up to 40%. Heroes hit also have their Attack Speed Slowed by 10% per second, stacking up to 40%. Frozen Tempest's effects last for 1.5 seconds.",
         "hotkey": "E",
@@ -52,6 +55,7 @@
         "type": "basic"
       },
       {
+        "uid": "1ad376e",
         "name": "Army of the Dead",
         "description": "Summons Ghouls that last 15 seconds. Sacrifice Ghouls to heal for 267 (+4% per level) Health.",
         "hotkey": "R",
@@ -62,6 +66,7 @@
         "type": "heroic"
       },
       {
+        "uid": "7ed0261",
         "name": "Summon Sindragosa",
         "description": "Deals 230 (+4% per level) damage and Slows enemies by 60% for 4 seconds. Also disables Minions, Mercenaries, Monsters and Structures for 20 seconds.",
         "hotkey": "R",
@@ -72,6 +77,7 @@
         "type": "heroic"
       },
       {
+        "uid": "3f03735",
         "name": "Frostmourne Hungers",
         "description": "Activate to make Arthas's next Basic Attack strike immediately and deal 99 (+4% per level) increased damage. Dealing damage restores 30 Mana.",
         "hotkey": "D",

--- a/hero/auriel.json
+++ b/hero/auriel.json
@@ -20,6 +20,7 @@
   "abilities": {
     "Auriel": [
       {
+        "uid": "4548738",
         "name": "Sacred Sweep",
         "description": "Sweep the area with sacred power, dealing 45 (+4% per level) damage to enemies and an additional 180 (+4% per level) damage to enemies caught in the center.",
         "hotkey": "Q",
@@ -29,6 +30,7 @@
         "type": "basic"
       },
       {
+        "uid": "2a9f4a1",
         "name": "Ray of Heaven",
         "description": "Consume Auriel's stored energy and heal allied Heroes in the area for the amount of energy consumed.",
         "hotkey": "W",
@@ -38,6 +40,7 @@
         "type": "basic"
       },
       {
+        "uid": "3d53c98",
         "name": "Detainment Strike",
         "description": "Deal 55 (+4% per level) damage to the first enemy Hero hit and knock them back. If they collide with terrain, they are also stunned for 1.25 seconds and take an additional 165 (+4% per level) damage.",
         "hotkey": "E",
@@ -47,6 +50,7 @@
         "type": "basic"
       },
       {
+        "uid": "2936574",
         "name": "Crystal Aegis",
         "description": "Place an allied Hero into Stasis for 2 seconds. Upon expiration, Crystal Aegis deals 255 (+4% per level) damage to all nearby enemies.",
         "hotkey": "R",
@@ -56,6 +60,7 @@
         "type": "heroic"
       },
       {
+        "uid": "7ab1c33",
         "name": "Resurrect",
         "description": "Channel on the spirit of a dead ally for 0.5 seconds. After a 5 second delay, they are brought back to life with 50% of their maximum Health at the location where they died.",
         "hotkey": "R",
@@ -65,6 +70,7 @@
         "type": "heroic"
       },
       {
+        "uid": "ed0440b",
         "name": "Bestow Hope",
         "description": "Passive: 40% of the damage Auriel deals to Heroes and 10% dealt to non-Heroes is stored as energy.  Bestow an allied Hero with Hope.  While they remain near Auriel, damage they deal causes her to gain energy. Auriel can only have Bestow Hope on 1 ally at a time.  Auriel can store up to 475 (+4% per level) energy.",
         "hotkey": "D",

--- a/hero/azmodan.json
+++ b/hero/azmodan.json
@@ -21,6 +21,7 @@
   "abilities": {
     "Azmodan": [
       {
+        "uid": "0e3d7cc",
         "name": "Globe of Annihilation",
         "description": "Shoot a globe of destruction, dealing 184 (+2.5% per level) damage on impact.  Quest: Hitting a Hero or killing a Minion within 1.5 seconds of being hit by Globe of Annihilation grants 2 Annihilation.  Reward: Each stack of Annihilation increases the damage of Globe of Annihilation by 1, up to 400.",
         "hotkey": "Q",
@@ -31,6 +32,7 @@
         "type": "basic"
       },
       {
+        "uid": "6614286",
         "name": "Summon Demon Warrior",
         "description": "Spawn a Demon Warrior that marches forward. Warriors deal 30 (+4% per level) damage per Attack and 16 (+4% per level) damage to nearby enemies every second. Lasts for 10 seconds.  Usable while Channeling All Shall Burn.",
         "hotkey": "W",
@@ -41,6 +43,7 @@
         "type": "basic"
       },
       {
+        "uid": "22972a8",
         "name": "All Shall Burn",
         "description": "Channel a beam of death on an enemy, dealing 120 (+4% per level) damage per second for 2.5 seconds. If the Channel lasts its full duration, deal an extra 320 (+4% per level) damage to the target.  Azmodan's Movement Speed is reduced by 30% while Channeling.",
         "hotkey": "E",
@@ -51,6 +54,7 @@
         "type": "basic"
       },
       {
+        "uid": "89a7253",
         "name": "Tide of Sin",
         "description": "Activate to make the next Globe of Annihilation cost no Mana and deal 50% more damage.  Usable while Channeling All Shall Burn.",
         "hotkey": "R",
@@ -61,6 +65,7 @@
         "type": "heroic"
       },
       {
+        "uid": "23a07b5",
         "name": "Demonic Invasion",
         "description": "Rain a small army of Demonic Grunts down on enemies, dealing 65 (+4% per level) damage per impact. Grunts deal 42 (+4% per level) damage, have 750 (+4% per level) Health and last up to 10 seconds. When Grunts die they explode, dealing 98 (+4% per level) damage to nearby enemies.  Usable while Channeling All Shall Burn.",
         "hotkey": "R",
@@ -71,6 +76,7 @@
         "type": "heroic"
       },
       {
+        "uid": "b9c69d6",
         "name": "Demon Lieutenant",
         "description": "Summon a Demon Lieutenant at any allied Mercenary, Minion, or Azmodan Demon. The Lieutenant will cast Demonic Smite every 7 seconds, instantly killing an enemy Minion. Lasts 20 seconds.  Usable while Channeling All Shall Burn.",
         "hotkey": "D",

--- a/hero/blaze.json
+++ b/hero/blaze.json
@@ -22,6 +22,7 @@
   "abilities": {
     "Blaze": [
       {
+        "uid": "79dd19e",
         "name": "Flame Stream",
         "description": "Fire two streams that deal 83 (+4% per level) damage to enemies hit. Flame Stream Ignites Oil Spills it comes in contact with.",
         "hotkey": "Q",
@@ -32,6 +33,7 @@
         "type": "basic"
       },
       {
+        "uid": "c1de3c2",
         "name": "Oil Spill",
         "description": "Vector Targeting Dispense a slick of oil that lasts for 5 seconds and Slows enemies that come in contact with it by 50%.  Oil Spills are Ignited for 2.5 seconds when hit by Flame Stream. Ignited Oil Spills no longer Slow enemies, but instead deal 16 (+4% per level) damage to them every 0.3 seconds. Additionally, Blaze is healed for 49 (+4% per level) Health every 0.3 seconds while standing in Ignited Oil Spills.  Stores up to 2 charges.",
         "hotkey": "W",
@@ -42,6 +44,7 @@
         "type": "basic"
       },
       {
+        "uid": "dc9f00e",
         "name": "Jet Propulsion",
         "description": "After 0.5 seconds, charge forward. Colliding with an enemy Hero deals 52 (+4% per level) damage to all nearby enemy Heroes and Stuns them for 1.25 seconds.",
         "hotkey": "E",
@@ -52,6 +55,7 @@
         "type": "basic"
       },
       {
+        "uid": "1cbba8c",
         "name": "Bunker Drop",
         "description": "After 0.5 seconds, deploy and enter a Bunker with 1435 (+4% per level) Health. Blaze and his allies can enter and exit the Bunker at will. While in the Bunker, occupants gain access to Flamethrower, dealing 170 (+4% per level) damage to enemies in a line.  Exiting the Bunker grants 25 Armor for 2 seconds. Bunkers last 10 seconds, or until destroyed.",
         "hotkey": "R",
@@ -62,6 +66,7 @@
         "type": "heroic"
       },
       {
+        "uid": "ae32a5a",
         "name": "Combustion",
         "description": "Channel for up to 2.6 seconds. Upon ending, Slow nearby enemies by 60% and deal 55 (+4% per level) damage to them every 0.5 seconds. Combustion's Slow and damage over time duration is extended the longer Blaze Channels, from 1 second up to 5 seconds.  Blaze's Movement Speed is reduced by 40% while Channeling.",
         "hotkey": "R",
@@ -72,6 +77,7 @@
         "type": "heroic"
       },
       {
+        "uid": "3655207",
         "name": "Pyromania",
         "description": "Gain 40 Armor and deal 40 (+4% per level) damage to nearby enemies every 0.5 seconds for 4 seconds.  Each Hero hit by Flame Stream reduces Pyromania's cooldown by 5 seconds.",
         "hotkey": "D",

--- a/hero/brightwing.json
+++ b/hero/brightwing.json
@@ -23,6 +23,7 @@
   "abilities": {
     "Brightwing": [
       {
+        "uid": "6600b75",
         "name": "Arcane Flare",
         "description": "Shoot a flare dealing 75 (+4% per level) damage to enemies hit, and an additional 105 (+4% per level) damage to enemies in the center. If a Hero is hit by the center, Soothing Mist's passive healing instantly activates.",
         "hotkey": "Q",
@@ -33,6 +34,7 @@
         "type": "basic"
       },
       {
+        "uid": "d16c27c",
         "name": "Polymorph",
         "description": "Polymorph a target for 1.5 seconds, Slowing their Movement Speed by 25% and Silencing them. Targets are not able to attack while Polymorphed.",
         "hotkey": "W",
@@ -43,6 +45,7 @@
         "type": "basic"
       },
       {
+        "uid": "a11fbbd",
         "name": "Pixie Dust",
         "description": "Increase target Hero's Movement Speed by 20%, and grant them 25 Spell Armor for 3 seconds, reducing Spell damage taken by 25%.",
         "hotkey": "E",
@@ -53,6 +56,7 @@
         "type": "basic"
       },
       {
+        "uid": "a555f95",
         "name": "Blink Heal",
         "description": "Teleport to a nearby ally. When teleporting to a Hero, heal them for 200 (+4% per level).  Stores up to 2 charges.",
         "hotkey": "R",
@@ -63,6 +67,7 @@
         "type": "heroic"
       },
       {
+        "uid": "2340658",
         "name": "Emerald Wind",
         "description": "After 0.5 seconds, create an expanding nova of wind, dealing 225 (+4% per level) damage and pushing enemies away.",
         "hotkey": "R",
@@ -73,6 +78,7 @@
         "type": "heroic"
       },
       {
+        "uid": "74c3767",
         "name": "Soothing Mist",
         "description": "Activate to remove all Stun, Root, Slow, and Silence effects from nearby allied Heroes.  Passive: Brightwing heals nearby allied Heroes for 105 (+4% per level) every 4 seconds",
         "hotkey": "D",
@@ -83,6 +89,7 @@
         "type": "trait"
       },
       {
+        "uid": "311e94c",
         "name": "Phase Shift",
         "description": "After 2 seconds, teleport to an allied Hero and heal them for 20% of their maximum Health.",
         "hotkey": "Z",

--- a/hero/cassia.json
+++ b/hero/cassia.json
@@ -20,6 +20,7 @@
   "abilities": {
     "Cassia": [
       {
+        "uid": "03938ff",
         "name": "Lightning Fury",
         "description": "Hurl a lightning javelin that deals 175 (+4% per level) damage to the first enemy hit and splits into two lightning bolts that deal 175 (+4% per level) damage to enemies in their path.",
         "hotkey": "Q",
@@ -30,6 +31,7 @@
         "type": "basic"
       },
       {
+        "uid": "ec8544d",
         "name": "Blinding Light",
         "description": "After 0.5 seconds, deal 50 (+4% per level) damage and Blind enemies in the target area for 2 seconds.  Passive: Cassia deals 20% increased damage to Blinded targets.",
         "hotkey": "W",
@@ -40,6 +42,7 @@
         "type": "basic"
       },
       {
+        "uid": "1b1bb51",
         "name": "Fend",
         "description": "Charge at an enemy, and upon arriving channel for up to 1.5 seconds, dealing 78 (+4% per level) damage to enemies in front of Cassia every 0.25 seconds. Deals 50% reduced damage to non-Heroes.",
         "hotkey": "E",
@@ -50,6 +53,7 @@
         "type": "basic"
       },
       {
+        "uid": "99c5b26",
         "name": "Ball Lightning",
         "description": "Throw a ball of lightning at an enemy Hero that bounces up to 6 times between nearby enemy Heroes and Cassia, dealing 180 (+4% per level) damage to enemies hit.",
         "hotkey": "R",
@@ -60,6 +64,7 @@
         "type": "heroic"
       },
       {
+        "uid": "2cac811",
         "name": "Valkyrie",
         "description": "Summon a Valkyrie that rushes to Cassia after 0.75 seconds, pulling the first enemy Hero hit, dealing 225 (+4% per level) damage and Stunning them for 0.5 seconds at the end of her path. The Valkyrie knocks back all other enemy Heroes in her way.",
         "hotkey": "R",
@@ -70,6 +75,7 @@
         "type": "heroic"
       },
       {
+        "uid": "a4ba49f",
         "name": "Avoidance",
         "description": "While moving unmounted, Cassia gains 40 Physical Armor against Heroic Basic Attacks, reducing the damage taken by 40%.",
         "trait": true,

--- a/hero/chen.json
+++ b/hero/chen.json
@@ -22,6 +22,7 @@
   "abilities": {
     "Chen": [
       {
+        "uid": "202372d",
         "name": "Flying Kick",
         "description": "Kick through target enemy, dealing 120 (+4% per level) damage.",
         "hotkey": "Q",
@@ -32,6 +33,7 @@
         "type": "basic"
       },
       {
+        "uid": "8661e12",
         "name": "Keg Smash",
         "description": "Deal 50 (+4% per level) damage and soak enemies in Brew for 3 seconds, Slowing them by 10%. After 1.25 seconds, the Slow is increased to 40%.  After being used, this ability becomes Breath of Fire.  Breath of Fire Deal damage and Ignite Brew-soaked enemies.",
         "hotkey": "W",
@@ -42,6 +44,7 @@
         "type": "basic"
       },
       {
+        "uid": "168e272",
         "name": "Breath of Fire",
         "description": "Breathe a cone of flames, dealing 85 (+4% per level) damage. Enemies that are soaked in Brew are Ignited, dealing 165 (+4% per level) additional damage over 3 seconds and adding 1.5 seconds to the duration of the Slow from Keg Smash.   After being used or after 6 seconds, this ability becomes Keg Smash.  Keg Smash Damage and Slow enemies.",
         "hotkey": "W",
@@ -52,6 +55,7 @@
         "type": "basic"
       },
       {
+        "uid": "db53a29",
         "name": "Wandering Keg",
         "description": "Roll around inside an Unstoppable barrel with 70% increased Movement Speed and 25 Armor, dealing 59 (+4% per level) damage to enemies in the way and knocking them back. Lasts for 5 seconds.",
         "hotkey": "R",
@@ -61,6 +65,7 @@
         "type": "heroic"
       },
       {
+        "uid": "4d90b68",
         "name": "Storm, Earth, Fire",
         "description": "After 1 second, Chen splits into three elemental spirits for 12 seconds, each with 70% of Chen's maximum Health and a unique Ability.  The last spirit Ability that is cast is empowered. If all three spirits are killed, Chen will die as well.  Storm can grant the spirits a Shield.  Earth can leap to an area and Slow enemies.  Fire can grant the spirits Attack Speed, damage.",
         "hotkey": "R",
@@ -70,6 +75,7 @@
         "type": "heroic"
       },
       {
+        "uid": "ca6467f",
         "name": "Fortifying Brew",
         "description": "Chen drinks from his keg, gaining 50 Brew and 180 (+4% per level) temporary Shields per second, up to a maximum of 540 (+4% per level) while drinking. Shields persist for 4 seconds after he stops drinking.",
         "hotkey": "D",
@@ -80,6 +86,7 @@
         "type": "trait"
       },
       {
+        "uid": "8340c2e",
         "name": "Stagger",
         "description": "Damage taken over the next 3 seconds is prevented.  Once this effect ends, Chen receives 75% of the damage taken over 5 seconds.  This damage cannot be modified.",
         "hotkey": "E",
@@ -91,6 +98,7 @@
     ],
     "ChenStormEarthFire": [
       {
+        "uid": "c56f29d",
         "name": "Fire",
         "description": "Increase the Attack Speed and Basic Attack damage of the spirits by 50% for 5 seconds.  If this is the final Ability cast, the Attack Speed and damage bonus is increased to 75% and the spirits gain 50% Movement Speed for its duration.",
         "hotkey": "E",
@@ -100,6 +108,7 @@
         "type": "subunit"
       },
       {
+        "uid": "2abec17",
         "name": "Earth",
         "description": "Fire and Earth leap to the target location, dealing 32 (+4% per level) damage and Slowing enemies in a large area by 70% for 1.5 seconds.  If this is the final Ability cast, increase the damage dealt by 300% and instead of Slowing, the leap Roots enemy Heroes hit for 1.75 seconds.",
         "hotkey": "W",
@@ -109,6 +118,7 @@
         "type": "subunit"
       },
       {
+        "uid": "02dd017",
         "name": "Storm",
         "description": "The spirits gain a Shield for 400 (+4% per level) over 3 seconds.  If this is the final Ability cast, the shield amount is increased to 750 (+4% per level) with no limited duration, and the duration of Storm, Earth, Fire is increased by 5 seconds.",
         "hotkey": "Q",

--- a/hero/chogall.json
+++ b/hero/chogall.json
@@ -23,6 +23,7 @@
   "abilities": {
     "Cho": [
       {
+        "uid": "a68a82e",
         "name": "Surging Fist",
         "description": "Activate to begin charging Surging Fist. Activate again to dash forward, knocking aside enemies and dealing 46 (+4% per level) damage. The dash range increases by up to 250%, depending on how long it is charged.",
         "hotkey": "Q",
@@ -32,6 +33,7 @@
         "type": "basic"
       },
       {
+        "uid": "7b37529",
         "name": "Consuming Blaze",
         "description": "Ignite nearby enemies, dealing 150 (+4% per level) damage over 5 seconds. Basic Attacking burning enemies re-Ignites them. Cho is healed for 40 (+4% per level) when an enemy is Ignited.",
         "hotkey": "W",
@@ -41,6 +43,7 @@
         "type": "basic"
       },
       {
+        "uid": "1840b85",
         "name": "Rune Bomb",
         "description": "Roll a bomb dealing 91 (+4% per level) damage to enemies in its path. Gall can use Runic Blast to detonate it to deal 210 (+4% per level) damage in an area.",
         "hotkey": "E",
@@ -50,6 +53,7 @@
         "type": "basic"
       },
       {
+        "uid": "995e072",
         "name": "Hammer of Twilight",
         "description": "Activate to swing the Hammer of Twilight, dealing 150 (+4.5% per level) damage, pushing enemies away, and Stunning them for 0.75 seconds.  Passive: Cho's Basic Attacks deal 25% increased damage.",
         "hotkey": "R",
@@ -59,6 +63,7 @@
         "type": "heroic"
       },
       {
+        "uid": "5e16468",
         "name": "Upheaval",
         "description": "After 1 second, pull enemies towards Cho'gall, slowing them by 25% for 3 seconds and dealing 175 (+4% per level) damage.",
         "hotkey": "R",
@@ -68,6 +73,7 @@
         "type": "heroic"
       },
       {
+        "uid": "bda088b",
         "name": "Ogre Hide",
         "description": "Activate to gain 25 Armor, but reduce Gall's damage by 25%.",
         "hotkey": "D",

--- a/hero/chromie.json
+++ b/hero/chromie.json
@@ -18,6 +18,7 @@
   "abilities": {
     "Chromie": [
       {
+        "uid": "185d1c3",
         "name": "Sand Blast",
         "description": "After 0.5 seconds, fire a missile that deals 305 (+4% per level) damage to the first enemy hit. Deals 50% damage to Structures.  Casting Sand Blast leaves an Echo behind that mimics Chromie's Sand Blast and Basic Attack, dealing 40% damage. Maximum of 1 Echo active at a time.",
         "hotkey": "Q",
@@ -28,6 +29,7 @@
         "type": "basic"
       },
       {
+        "uid": "17c6861",
         "name": "Dragon's Breath",
         "description": "Vector Targeting Launch 3 blasts into the air that land every 0.75 seconds towards the targeted direction, dealing 204 (+4% per level) damage each.",
         "hotkey": "W",
@@ -38,6 +40,7 @@
         "type": "basic"
       },
       {
+        "uid": "9d35e5f",
         "name": "Time Trap",
         "description": "Place a Time Trap that arms and Stealths after 2 seconds. Chromie's Trait can be activated to detonate the trap, placing all nearby allied or enemy Heroes in Time Stop for 2 seconds. Maximum of 1 trap active at a time.",
         "hotkey": "E",
@@ -48,6 +51,7 @@
         "type": "basic"
       },
       {
+        "uid": "aee5d5d",
         "name": "Temporal Loop",
         "description": "Choose an enemy Hero. After 3 seconds, they are teleported back to the location where Temporal Loop was cast on them.  Basic Abilities recharge 500% faster for 3 seconds after casting Temporal Loop.",
         "hotkey": "R",
@@ -58,6 +62,7 @@
         "type": "heroic"
       },
       {
+        "uid": "918f88d",
         "name": "Slowing Sands",
         "description": "Summon a sand vortex that Slows enemies by 5% every 0.25 seconds, up to 70%.",
         "hotkey": "R",
@@ -69,6 +74,7 @@
         "type": "heroic"
       },
       {
+        "uid": "6519614",
         "name": "Timewalker",
         "description": "Chromie has traveled to the future, and as such, will learn her Talents 2 levels earlier than her teammates!  Detonate Time Trap  Detonates active Time Traps.",
         "trait": true,

--- a/hero/deckard.json
+++ b/hero/deckard.json
@@ -21,6 +21,7 @@
   "abilities": {
     "Deckard": [
       {
+        "uid": "23299d2",
         "name": "Healing Potion",
         "description": "Throw a Healing Potion on the ground that heals the first allied Hero that comes in contact with it for 270 (+4% per level).  Limit 5 active Potions.",
         "hotkey": "Q",
@@ -31,6 +32,7 @@
         "type": "basic"
       },
       {
+        "uid": "1500465",
         "name": "Horadric Cube",
         "description": "Release the Horadric Cube. After 0.5 seconds it explodes, dealing 80 (+4% per level) damage to all enemies in the area and Slowing them by 35% for 1.75 seconds.",
         "hotkey": "W",
@@ -41,6 +43,7 @@
         "type": "basic"
       },
       {
+        "uid": "079c0f4",
         "name": "Scroll Of Sealing",
         "description": "Unfurl an enchanted scroll over 2.25 seconds, forming a triangle that deals 150 (+4% per level) damage to enemies inside and Roots them for 1.5 seconds.",
         "hotkey": "E",
@@ -51,6 +54,7 @@
         "type": "basic"
       },
       {
+        "uid": "ddc1c81",
         "name": "Stay Awhile and Listen",
         "description": "After 1 second, Channel for 3 seconds, putting enemy Heroes in front of Deckard to Sleep while Channeling, and for 2 seconds after.  Enemies can only be put to Sleep once per cast, and Sleep's effects end instantly if they take damage.",
         "hotkey": "R",
@@ -61,6 +65,7 @@
         "type": "heroic"
       },
       {
+        "uid": "865504f",
         "name": "Lorenado",
         "description": "Vector Targeting After 1 second, create a twirling tome tornado that travels towards the targeted direction, continually knocking away enemies that come into contact with it.",
         "hotkey": "R",
@@ -71,6 +76,7 @@
         "type": "heroic"
       },
       {
+        "uid": "b87d628",
         "name": "Fortitude of the Faithful",
         "description": "When at least 1 other allied Hero is nearby, Deckard gains 10 Armor and his Basic Abilities recharge 50% faster.",
         "trait": true,

--- a/hero/dehaka.json
+++ b/hero/dehaka.json
@@ -23,6 +23,7 @@
   "abilities": {
     "Dehaka": [
       {
+        "uid": "51bc862",
         "name": "Drag",
         "description": "Dehaka lashes out his tongue, dealing 160 (+4% per level) damage to the first enemy hit, Stunning and dragging them with him for 1.75 seconds.  If Dehaka is Stunned or Silenced while using Drag, the effect ends.",
         "hotkey": "Q",
@@ -33,6 +34,7 @@
         "type": "basic"
       },
       {
+        "uid": "0abfb4a",
         "name": "Dark Swarm",
         "description": "Deal 47 (+4% per level) damage every 0.5 seconds to nearby enemies for 3.5 seconds. While active, you are able to move through units. Can be cast during Drag and Burrow.",
         "hotkey": "W",
@@ -43,6 +45,7 @@
         "type": "basic"
       },
       {
+        "uid": "8b762c0",
         "name": "Burrow",
         "description": "Burrow into the ground, entering Stasis and becoming Invulnerable for 2 seconds.",
         "hotkey": "E",
@@ -53,6 +56,7 @@
         "type": "basic"
       },
       {
+        "uid": "c5527a4",
         "name": "Isolation",
         "description": "Launch biomass that hits the first enemy Hero dealing 200 (+4% per level) damage, revealing, Silencing, and Slowing them 30% for 3 seconds. Additionally, their vision radius is greatly reduced for 6 seconds.",
         "hotkey": "R",
@@ -63,6 +67,7 @@
         "type": "heroic"
       },
       {
+        "uid": "b975167",
         "name": "Adaptation",
         "description": "After 4 seconds, heal for 100% of the damage Dehaka took over this period.",
         "hotkey": "R",
@@ -73,6 +78,7 @@
         "type": "heroic"
       },
       {
+        "uid": "ed6ae16",
         "name": "Essence Collection",
         "description": "Heal Dehaka for 29 (+4% per level) Health per stored Essence over 5 seconds. Can be cast during Drag and Burrow.  Passive: Gain 10 Essence from Takedowns and 2 Essence from nearby Minions dying. Maximum of 50 Essence.",
         "hotkey": "D",
@@ -83,6 +89,7 @@
         "type": "trait"
       },
       {
+        "uid": "0dce7a8",
         "name": "Brushstalker",
         "description": "Activate to burrow to a bush on the Battleground.  Passive: Gain 20% movement speed while in a bush and for 2 seconds after leaving.",
         "hotkey": "Z",

--- a/hero/diablo.json
+++ b/hero/diablo.json
@@ -21,6 +21,7 @@
   "abilities": {
     "Diablo": [
       {
+        "uid": "c859827",
         "name": "Shadow Charge",
         "description": "Charge an enemy, knocking them back, dealing 40 (+4% per level) damage and gaining 15% Movement Speed for 2 seconds. If the enemy hits terrain, they are Stunned for 1 second and take an additional 120 (+4% per level) damage.",
         "hotkey": "Q",
@@ -31,6 +32,7 @@
         "type": "basic"
       },
       {
+        "uid": "fb53a0d",
         "name": "Fire Stomp",
         "description": "Unleashes fire waves toward the targeted area that deal 12 (+4% per level) damage each. Once they reach maximum range they return, dealing an additional 36 (+4% per level) damage. Diablo heals for 130% of the damage dealt to Heroes.",
         "hotkey": "W",
@@ -41,6 +43,7 @@
         "type": "basic"
       },
       {
+        "uid": "aff7968",
         "name": "Overpower",
         "description": "Grabs the target and slams it behind Diablo, dealing 73 (+4% per level) damage and Stunning for 0.25 seconds.",
         "hotkey": "E",
@@ -51,6 +54,7 @@
         "type": "basic"
       },
       {
+        "uid": "83fdc9f",
         "name": "Apocalypse",
         "description": "Create a demonic rune under each enemy Hero on the battleground. After 1.75 seconds the rune explodes dealing 137 (+4% per level) damage and Stunning them for 1.75 seconds.",
         "hotkey": "R",
@@ -61,6 +65,7 @@
         "type": "heroic"
       },
       {
+        "uid": "96b2559",
         "name": "Lightning Breath",
         "description": "After 0.5 seconds, become Unstoppable and Channel for up to 4 seconds, dealing 50 (+4% per level) damage every 0.25 seconds to enemies in front of Diablo. Enemies affected are Slowed by 4% for 2 seconds, up to 40%.  Lightning Breath's direction changes with your mouse cursor position.",
         "hotkey": "R",
@@ -71,6 +76,7 @@
         "type": "heroic"
       },
       {
+        "uid": "1a8084f",
         "name": "Black Soulstone",
         "description": "Repeatable Quest: Gain 10 Souls per Hero killed and 1 Soul per Minion, up to 100. For each Soul, gain 0.4% maximum Health. If Diablo has 100 Souls upon dying, he will resurrect in 5 seconds but lose 100 Souls.",
         "trait": true,

--- a/hero/dva.json
+++ b/hero/dva.json
@@ -20,6 +20,7 @@
   "abilities": {
     "D.Va": [
       {
+        "uid": "113bf0d",
         "name": "Boosters",
         "description": "Increase D.Va's Movement Speed by 125% for 2 seconds. Enemies that are hit take 135 (+4% per level) damage and are knocked away.  D.Va cannot be Slowed while Boosters are active, and each enemy can only be hit once per use.",
         "hotkey": "Q",
@@ -29,6 +30,7 @@
         "type": "basic"
       },
       {
+        "uid": "728a060",
         "name": "Defense Matrix",
         "description": "Channel a defensive field in the target direction for 3 seconds, reducing the damage dealt by enemy Heroes inside it by 75%. The Mech can move while channeling, but cannot turn.  Damage dealt to the Mech from enemies within Defense Matrix still grants the same amount of Self-Destruct Charge.",
         "hotkey": "W",
@@ -38,6 +40,7 @@
         "type": "basic"
       },
       {
+        "uid": "2f4bf70",
         "name": "Self-Destruct",
         "description": "Eject from the Mech, setting it to self-destruct after 4 seconds. Deals 1200 (+4% per level) to 400 (+4% per level) damage in a large area, depending on distance from center. Only deals 50% damage against Structures.  Gain 1% Charge for every 2 seconds spent Basic Attacking, and 30% Charge per 100% of Mech Health lost.",
         "hotkey": "E",
@@ -46,6 +49,7 @@
         "type": "basic"
       },
       {
+        "uid": "ccb521e",
         "name": "Big Shot",
         "description": "Deal 250 (+4% per level) damage to all enemies in a line. The cooldown of Call Mech is reduced by 8 seconds for each enemy Hero hit.  Requires Pilot Mode.",
         "hotkey": "R",
@@ -55,6 +59,7 @@
         "type": "heroic"
       },
       {
+        "uid": "a56988e",
         "name": "Mech Mode",
         "description": "When D.Va's Mech dies, she is ejected out after 0.75 seconds and can continue to fight. D.Va's Mech only awards 50% of a normal Hero's experience upon dying.",
         "trait": true,
@@ -63,6 +68,7 @@
         "type": "trait"
       },
       {
+        "uid": "4969200",
         "name": "Mechanized Walker",
         "description": "While in her Mech, D.Va can shoot while moving, but her base Movement Speed is reduced by 15%.",
         "hotkey": "Z",
@@ -71,6 +77,7 @@
         "type": "mount"
       },
       {
+        "uid": "115b944",
         "name": "Pilot Mode",
         "description": "Basic Attacks reduce the cooldown of Call Mech by 0.5 seconds. As a Pilot, D.Va only awards 50% of a normal Hero's experience upon dying.",
         "trait": true,
@@ -79,6 +86,7 @@
         "type": "trait"
       },
       {
+        "uid": "e84f915",
         "name": "Bunny Hop",
         "description": "D.Va's Mech becomes Unstoppable and stomps every 0.5 seconds, dealing 60 (+4% per level) damage and Slowing enemies by 40%. Lasts 4 seconds.  Requires Mech Mode.",
         "hotkey": "R",
@@ -90,6 +98,7 @@
     ],
     "0": [
       {
+        "uid": "8103aa1",
         "name": "Call Mech",
         "description": "Call a new Mech and enter Mech Mode.  Basic Attacks lower this cooldown by 0.5 seconds each.",
         "hotkey": "E",
@@ -99,6 +108,7 @@
         "type": "subunit"
       },
       {
+        "uid": "f14b14e",
         "name": "Torpedo Dash",
         "description": "Dash towards the target location, passing through enemies along the way.",
         "hotkey": "Q",
@@ -108,6 +118,7 @@
         "type": "subunit"
       },
       {
+        "uid": "a000597",
         "name": "Concussive Pulse",
         "description": "Deal 141 (+4% per level) damage to enemies in a cone and knock them back.",
         "hotkey": "W",

--- a/hero/etc.json
+++ b/hero/etc.json
@@ -23,6 +23,7 @@
   "abilities": {
     "E.T.C.": [
       {
+        "uid": "0292d79",
         "name": "Powerslide",
         "description": "Slide to a location dealing 91 (+4% per level) damage and stunning enemies hit for 1.25 second.",
         "hotkey": "Q",
@@ -33,6 +34,7 @@
         "type": "basic"
       },
       {
+        "uid": "4353106",
         "name": "Face Melt",
         "description": "Deals 68 (+4% per level) damage to nearby enemies, knocking them back.",
         "hotkey": "W",
@@ -43,6 +45,7 @@
         "type": "basic"
       },
       {
+        "uid": "b9e6751",
         "name": "Guitar Solo",
         "description": "Regenerate 66 (+4% per level) Health per second for 4 seconds.",
         "hotkey": "E",
@@ -53,6 +56,7 @@
         "type": "basic"
       },
       {
+        "uid": "016f0ee",
         "name": "Mosh Pit",
         "description": "After 0.75 seconds, channel to stun nearby enemies for 4 seconds.",
         "hotkey": "R",
@@ -63,6 +67,7 @@
         "type": "heroic"
       },
       {
+        "uid": "c8bd85b",
         "name": "Stage Dive",
         "description": "Leap to target location, landing after 2.75 seconds, dealing 330 (+4% per level) damage to enemies in the area, and slowing them by 50% for 3 seconds.",
         "hotkey": "R",
@@ -73,6 +78,7 @@
         "type": "heroic"
       },
       {
+        "uid": "c9addce",
         "name": "Rockstar",
         "description": "After E.T.C. uses a Basic or Heroic ability, he gains 25 Armor for 2 seconds.  This effect does not stack with itself.",
         "trait": true,

--- a/hero/falstad.json
+++ b/hero/falstad.json
@@ -21,6 +21,7 @@
   "abilities": {
     "Falstad": [
       {
+        "uid": "ecd777f",
         "name": "Hammerang",
         "description": "Throw out a Hammer that returns to Falstad, dealing 121 (+4% per level) damage and slowing enemies by 25% for 2 seconds.",
         "hotkey": "Q",
@@ -31,6 +32,7 @@
         "type": "basic"
       },
       {
+        "uid": "df83282",
         "name": "Lightning Rod",
         "description": "Deal 107 (+4% per level) damage to an enemy, and an additional 75 (+4% per level) damage per second for 4 seconds while close to the target.",
         "hotkey": "W",
@@ -41,6 +43,7 @@
         "type": "basic"
       },
       {
+        "uid": "d4771fe",
         "name": "Barrel Roll",
         "description": "Dashes forward and grants a 171 (+4% per level) point Shield for 3 seconds.",
         "hotkey": "E",
@@ -51,6 +54,7 @@
         "type": "basic"
       },
       {
+        "uid": "f76343f",
         "name": "Hinterland Blast",
         "description": "After 1 second, deal 475 (+4.75% per level) damage to enemies within a long line. The cooldown is reduced by 25 seconds for every enemy Hero hit.",
         "hotkey": "R",
@@ -61,6 +65,7 @@
         "type": "heroic"
       },
       {
+        "uid": "6bd6556",
         "name": "Mighty Gust",
         "description": "Push enemies away, and slow their Movement Speed by 40% decaying over 4 seconds.",
         "hotkey": "R",
@@ -71,6 +76,7 @@
         "type": "heroic"
       },
       {
+        "uid": "052c116",
         "name": "Flight",
         "description": "Instead of mounting, Falstad can fly a great distance over terrain.",
         "hotkey": "Z",
@@ -80,6 +86,7 @@
         "type": "mount"
       },
       {
+        "uid": "3a376a9",
         "name": "Tailwind",
         "description": "Gain 15% increased Movement Speed after not taking damage for 6 seconds.",
         "trait": true,

--- a/hero/fenix.json
+++ b/hero/fenix.json
@@ -20,6 +20,7 @@
   "abilities": {
     "Fenix": [
       {
+        "uid": "b24a7df",
         "name": "Plasma Cutter",
         "description": "Create a laser beam at the target point that circles around Fenix twice, dealing 135 (+4% per level) damage to enemies hit and Slowing them by 25% for 4 seconds.",
         "hotkey": "Q",
@@ -29,6 +30,7 @@
         "type": "basic"
       },
       {
+        "uid": "ce8f347",
         "name": "Weapon Mode: Repeater Cannon",
         "description": "Basic Attack speed increased by 150%.  Activate to change to Weapon Mode: Phase Bomb, increasing Basic Attack range and damage, and causing Basic Attacks to splash.",
         "hotkey": "W",
@@ -37,6 +39,7 @@
         "type": "basic"
       },
       {
+        "uid": "291ccac",
         "name": "Warp",
         "description": "Warp to a targeted location, phasing out after 0.5 seconds, and arriving 0.75 seconds later.",
         "hotkey": "E",
@@ -46,6 +49,7 @@
         "type": "basic"
       },
       {
+        "uid": "ea70829",
         "name": "Purification Salvo",
         "description": "Channel for 1.5 seconds, sweeping a laser in front of Fenix that locks onto enemy Heroes. Once Channeling finishes, fire 5 missiles at each locked Hero, dealing 79 (+4% per level) damage each. Deals 50% increased damage to Slowed targets.",
         "hotkey": "R",
@@ -55,6 +59,7 @@
         "type": "heroic"
       },
       {
+        "uid": "4781e49",
         "name": "Planet Cracker",
         "description": "After 0.5 seconds, Channel a powerful beam that spans across the battleground for 4 seconds, dealing 112 (+4% per level) damage every 0.25 seconds to non-Structure enemies hit.",
         "hotkey": "R",
@@ -64,6 +69,7 @@
         "type": "heroic"
       },
       {
+        "uid": "d2658c2",
         "name": "Shield Capacitor",
         "description": "Fenix has a permanent 760 (+4% per level) Shield which regenerates at 10% per second after not taking damage for 5 seconds.",
         "trait": true,
@@ -74,6 +80,7 @@
     ],
     "FenixPhaseBomb": [
       {
+        "uid": "9bb3ae7",
         "name": "Weapon Mode: Phase Bomb",
         "description": "Basic Attacks have 1.25 increased range, deal 25% more damage, and splash to nearby enemies.  Activate to change to Weapon Mode: Repeater Cannon, increasing Basic Attack speed.",
         "hotkey": "W",

--- a/hero/gall.json
+++ b/hero/gall.json
@@ -18,6 +18,7 @@
   "abilities": {
     "Gall": [
       {
+        "uid": "b20ba22",
         "name": "Shadowflame",
         "description": "Deal 135 (+5% per level) damage to enemies in the area.",
         "hotkey": "Q",
@@ -27,6 +28,7 @@
         "type": "basic"
       },
       {
+        "uid": "e0f8884",
         "name": "Dread Orb",
         "description": "Throw a bomb that will bounce three times, dealing 126 (+5% per level) damage to enemies.",
         "hotkey": "W",
@@ -36,6 +38,7 @@
         "type": "basic"
       },
       {
+        "uid": "462aca7",
         "name": "Runic Blast",
         "description": "Detonate Cho's Rune Bomb, dealing 210 (+4% per level) damage around it.",
         "hotkey": "E",
@@ -45,6 +48,7 @@
         "type": "basic"
       },
       {
+        "uid": "cc8b7ee",
         "name": "Shadow Bolt Volley",
         "description": "After 1 second, unleash 20 Shadow Bolts over 4 seconds, each dealing 87 (+4% per level) damage to the first target hit. The bolts fire towards your mouse.",
         "hotkey": "R",
@@ -54,6 +58,7 @@
         "type": "heroic"
       },
       {
+        "uid": "224e63c",
         "name": "Twisting Nether",
         "description": "After 1 second, nearby enemies are slowed by 50% while Gall channels, up to 5 seconds. Activate to deal 353 (+5% per level) damage.",
         "hotkey": "R",
@@ -63,6 +68,7 @@
         "type": "heroic"
       },
       {
+        "uid": "450eca7",
         "name": "Ogre Rage",
         "description": "Activate to increase Gall's damage by 25%, but reduce Cho's Armor by 25.  Passive: Gall is permanently immune to Stun and Silence effects.",
         "hotkey": "D",
@@ -73,6 +79,7 @@
         "type": "trait"
       },
       {
+        "uid": "c4791e7",
         "name": "Shove",
         "description": "Nudge Cho a small distance and grant him 25% Movement Speed for 2 seconds.",
         "hotkey": "Z",
@@ -82,6 +89,7 @@
         "type": "mount"
       },
       {
+        "uid": "349b09b",
         "name": "Eye of Kilrogg",
         "description": "Place an eye, granting vision of a large area around it for 45 seconds. The eye can be killed by enemies with 2 Basic Attacks. Stores up to 2 charges.",
         "hotkey": "1",

--- a/hero/garrosh.json
+++ b/hero/garrosh.json
@@ -21,6 +21,7 @@
   "abilities": {
     "Garrosh": [
       {
+        "uid": "bc66e97",
         "name": "Groundbreaker",
         "description": "Deal 81 (+4% per level) damage to enemies in an area. Heroes hit on the outer edge are Stunned for 0.5 seconds and then Slowed by 40% for 2 seconds.",
         "hotkey": "Q",
@@ -31,6 +32,7 @@
         "type": "basic"
       },
       {
+        "uid": "8ccf1fe",
         "name": "Bloodthirst",
         "description": "Deal 156 (+4% per level) damage to an enemy and heal for 10% of Garrosh's missing Health. Healing is increased by 100% against Heroes.",
         "hotkey": "W",
@@ -41,6 +43,7 @@
         "type": "basic"
       },
       {
+        "uid": "8b0f1d7",
         "name": "Wrecking Ball",
         "description": "Throw a nearby enemy Hero, Minion, or Mercenary to the target location, dealing 91 (+4% per level) damage to enemies near the impact and Slowing them by 30% for 2.5 seconds.",
         "hotkey": "E",
@@ -51,6 +54,7 @@
         "type": "basic"
       },
       {
+        "uid": "86b16f6",
         "name": "Warlord's Challenge",
         "description": "Silence nearby Heroes and force them to attack Garrosh for 2 seconds.",
         "hotkey": "R",
@@ -61,6 +65,7 @@
         "type": "heroic"
       },
       {
+        "uid": "525e948",
         "name": "Decimate",
         "description": "Deal 50 (+4% per level) damage to nearby enemies and Slow them by 40% for 1.5 seconds. Deals 100% more damage to Heroes, and each Hero hit reduces the cooldown by 1 second.  Stores up to 3 charges.",
         "hotkey": "R",
@@ -71,6 +76,7 @@
         "type": "heroic"
       },
       {
+        "uid": "a3605a7",
         "name": "Armor Up",
         "description": "Garrosh gains 1 Armor for every 2% of maximum Health missing.",
         "trait": true,

--- a/hero/gazlowe.json
+++ b/hero/gazlowe.json
@@ -22,6 +22,7 @@
   "abilities": {
     "Gazlowe": [
       {
+        "uid": "c70bdc5",
         "name": "Rock-It! Turret",
         "description": "Creates a turret that deals 62 (+4% per level) damage. Lasts for 30 seconds.  Stores up to 2 charges.",
         "hotkey": "Q",
@@ -32,6 +33,7 @@
         "type": "basic"
       },
       {
+        "uid": "9b1ddd5",
         "name": "Deth Lazor",
         "description": "Charged attack that deals 137 (+4% per level) damage to enemies in a line. Damage and range increase the longer the Ability is charged, up to 100% after 3 seconds.  Deth Lazor can be channeled indefinitely.",
         "hotkey": "W",
@@ -42,6 +44,7 @@
         "type": "basic"
       },
       {
+        "uid": "2b1f1d9",
         "name": "Xplodium Charge",
         "description": "Places a bomb that deals 233 (+4% per level) damage to enemies within target area after 2.5 seconds, stunning them for 1.75 seconds.",
         "hotkey": "E",
@@ -52,6 +55,7 @@
         "type": "basic"
       },
       {
+        "uid": "7674f64",
         "name": "Grav-O-Bomb 3000",
         "description": "After a 2 second delay, pull enemies toward the center of an area and deal 251 (+4% per level) damage.",
         "hotkey": "R",
@@ -62,6 +66,7 @@
         "type": "heroic"
       },
       {
+        "uid": "66818b8",
         "name": "Robo-Goblin",
         "description": "Activate to gain 40 Armor and 30% Movement Speed for 4 seconds.  Passive: Basic Attacks deal 100% bonus damage.",
         "hotkey": "R",
@@ -71,6 +76,7 @@
         "type": "heroic"
       },
       {
+        "uid": "dd49e53",
         "name": "Salvager",
         "description": "Destroyed enemy Structures and Rock-it! Turrets drop Scrap. Collecting Scrap restores 30 Mana and causes Abilities to recharge three times as fast over 3 seconds.  Activate Salvager to dismantle a target Rock-it! Turret and turn it into Scrap.",
         "hotkey": "D",
@@ -80,6 +86,7 @@
         "type": "trait"
       },
       {
+        "uid": "1cfd392",
         "name": "Focus Turrets!",
         "description": "Orders any nearby Rock-It! Turrets to focus the target.",
         "hotkey": "1",

--- a/hero/genji.json
+++ b/hero/genji.json
@@ -21,6 +21,7 @@
   "abilities": {
     "Genji": [
       {
+        "uid": "b02b4cf",
         "name": "Shuriken",
         "description": "Throw 3 Shuriken in a spread pattern, each dealing 65 (+4% per level) damage to the first enemy hit.  Stores up to 3 charges.  Shuriken's cooldown replenishes all charges at the same time.",
         "hotkey": "Q",
@@ -31,6 +32,7 @@
         "type": "basic"
       },
       {
+        "uid": "e3695ec",
         "name": "Deflect",
         "description": "Channel for 1.25 seconds, becoming Protected and blocking damage. Any damage blocked while channeling causes Genji to throw a Kunai toward the nearest enemy, prioritizing Heroes and dealing 55 (+4% per level) damage.  Total Damage Deflected: 0",
         "hotkey": "W",
@@ -41,6 +43,7 @@
         "type": "basic"
       },
       {
+        "uid": "18d4acf",
         "name": "Swift Strike",
         "description": "Dash forward, dealing 190 (+4% per level) damage to all enemies in a line. Enemy Heroes that die within 1.5 seconds of being hit with Swift Strike cause the cooldown and mana cost to be refunded.",
         "hotkey": "E",
@@ -51,6 +54,7 @@
         "type": "basic"
       },
       {
+        "uid": "3d18aab",
         "name": "Dragonblade",
         "description": "Unleash the Dragonblade for 8 seconds. While active, Dragonblade can be reactivated to lunge forward and slash in a huge arc, dealing 240 (+4% per level) damage.",
         "hotkey": "R",
@@ -61,6 +65,7 @@
         "type": "heroic"
       },
       {
+        "uid": "d577507",
         "name": "X-Strike",
         "description": "Perform two slashes dealing 135 (+4% per level) damage. The slashes detonate after 1.25 seconds causing an additional 270 (+4% per level) damage to enemies in their area.",
         "hotkey": "R",
@@ -71,6 +76,7 @@
         "type": "heroic"
       },
       {
+        "uid": "20bf795",
         "name": "Cyber Agility",
         "description": "Activate to jump to the target area.",
         "hotkey": "D",

--- a/hero/greymane.json
+++ b/hero/greymane.json
@@ -22,6 +22,7 @@
   "abilities": {
     "Greymane": [
       {
+        "uid": "dcb7e59",
         "name": "Gilnean Cocktail",
         "description": "Hurl a flask that deals 55 (+4% per level) damage to the first enemy hit and explodes for 220 (+4% per level) damage to enemies in a cone behind them.  Worgen: Razor Swipe Swipe forward, damaging enemies hit.",
         "hotkey": "Q",
@@ -32,6 +33,7 @@
         "type": "basic"
       },
       {
+        "uid": "0b51f72",
         "name": "Inner Beast",
         "description": "Gain 50% Attack Speed for 3 seconds. Basic Attacks refresh this duration, and reduce the cooldown of Inner Beast by 0.5 seconds.",
         "hotkey": "W",
@@ -42,6 +44,7 @@
         "type": "basic"
       },
       {
+        "uid": "eb4795d",
         "name": "Darkflight",
         "description": "Shapeshift into a Worgen and leap at an enemy dealing 88 (+4% per level) damage.  Worgen: Disengage Roll away and shapeshift into a Human.",
         "hotkey": "E",
@@ -52,6 +55,7 @@
         "type": "basic"
       },
       {
+        "uid": "435df61",
         "name": "Go for the Throat",
         "description": "Leap at an enemy Hero and shapeshift into a Worgen, slashing for 355 (+4% per level) damage. If this kills them, the Ability can be used a second time within 10 seconds for free.",
         "hotkey": "R",
@@ -62,6 +66,7 @@
         "type": "heroic"
       },
       {
+        "uid": "0059168",
         "name": "Cursed Bullet",
         "description": "Greymane shapeshifts into a Human and fires a bullet that hits the first enemy Hero in its path, dealing 40% of their current Health in damage.  Does not affect Vehicles.",
         "hotkey": "R",
@@ -72,6 +77,7 @@
         "type": "heroic"
       },
       {
+        "uid": "bf6ce9e",
         "name": "Curse of the Worgen",
         "description": "Greymane can use certain Abilities to shapeshift between a Human and a Worgen.  While Human, Greymane's Basic Attacks are ranged.  While Worgen, Greymane gains 10 Armor, and his Basic Attacks become melee but deal 40% more damage.",
         "trait": true,
@@ -82,6 +88,7 @@
     ],
     "GreymaneWorgenForm": [
       {
+        "uid": "a3476c2",
         "name": "Razor Swipe",
         "description": "Swipe in the targeted direction, dealing 126 (+4% per level) damage to enemies hit.  Human: Gilnean Cocktail Damage the first enemy hit and deal heavy damage behind them.",
         "hotkey": "Q",
@@ -92,6 +99,7 @@
         "type": "subunit"
       },
       {
+        "uid": "4602adf",
         "name": "Disengage",
         "description": "Roll away and shapeshift into a Human.  Human: Darkflight Leap at an enemy and shapeshift into a Worgen.",
         "hotkey": "E",

--- a/hero/guldan.json
+++ b/hero/guldan.json
@@ -20,6 +20,7 @@
   "abilities": {
     "Gul'dan": [
       {
+        "uid": "c450c34",
         "name": "Fel Flame",
         "description": "Release a wave of flame, dealing 200 (+4.5% per level) damage to enemies.",
         "hotkey": "Q",
@@ -30,6 +31,7 @@
         "type": "basic"
       },
       {
+        "uid": "8737073",
         "name": "Drain Life",
         "description": "Drain the life from an enemy over 3 seconds, dealing 132 (+4% per level) damage per second and healing Gul'dan for 188 (+4% per level) Health per second.",
         "hotkey": "W",
@@ -39,6 +41,7 @@
         "type": "basic"
       },
       {
+        "uid": "6bdcadc",
         "name": "Corruption",
         "description": "Call forth three bursts of shadow energy, dealing 204 (+4.5% per level) damage over 6 seconds. Corruption can stack up to 3 times on an enemy.",
         "hotkey": "E",
@@ -49,6 +52,7 @@
         "type": "basic"
       },
       {
+        "uid": "1654a2c",
         "name": "Horrify",
         "description": "After 0.5 seconds, deal 120 (+4% per level) damage to enemy Heroes in an area and Fear them for 2 seconds. While Feared, Heroes are Silenced and are forced to run away from Horrify's center.",
         "hotkey": "R",
@@ -59,6 +63,7 @@
         "type": "heroic"
       },
       {
+        "uid": "ee5e369",
         "name": "Rain of Destruction",
         "description": "After 1.5 seconds, summon a rain of meteors in an area for 7 seconds. Each meteor deals 165 (+4% per level) damage in a small area.",
         "hotkey": "R",
@@ -69,6 +74,7 @@
         "type": "heroic"
       },
       {
+        "uid": "947bc86",
         "name": "Life Tap",
         "description": "Gul'dan does not regenerate Mana.  Activate to restore 25% of Gul'dan's Mana.",
         "hotkey": "D",

--- a/hero/hanzo.json
+++ b/hero/hanzo.json
@@ -20,6 +20,7 @@
   "abilities": {
     "Hanzo": [
       {
+        "uid": "0fbc39f",
         "name": "Storm Bow",
         "description": "Activate to charge an arrow that deals 291 (+4% per level) damage to the first enemy hit. Storm Bow's range increases the longer it is Channeled.",
         "hotkey": "Q",
@@ -30,6 +31,7 @@
         "type": "basic"
       },
       {
+        "uid": "3548759",
         "name": "Scatter Arrow",
         "description": "Fire an arrow that deals 88 (+4% per level) to the first enemy Hero hit. Scatter Arrow can collide with terrain and Structures, splitting into 5 arrows that travel extra distance, ricochet up to 4 additional times, and deal 88 (+4% per level) damage each to the first enemy hit.",
         "hotkey": "W",
@@ -40,6 +42,7 @@
         "type": "basic"
       },
       {
+        "uid": "1e95798",
         "name": "Sonic Arrow",
         "description": "Fire an arrow that grants vision in a large area for 5 seconds. Enemies inside are revealed for 1 second. If Sonic Arrow lands directly on an enemy, it deals 165 (+4% per level) damage to them and follows them as they move.",
         "hotkey": "E",
@@ -50,6 +53,7 @@
         "type": "basic"
       },
       {
+        "uid": "667b317",
         "name": "Dragonstrike",
         "description": "After 1.5 seconds, summon a pair of Spirit Dragons which travel forward, dealing 70 (+4% per level) damage every 0.25 seconds to enemy Heroes in its area.  Enemies in the center take 50% increased damage.",
         "hotkey": "R",
@@ -60,6 +64,7 @@
         "type": "heroic"
       },
       {
+        "uid": "d37df44",
         "name": "Dragon's Arrow",
         "description": "Fire a missile that travels across the battleground. Explodes upon hitting an enemy Hero, dealing 130 (+4% per level) damage to all nearby enemies and Stunning them for 0.5 seconds.  After traveling a medium distance, the damage is increased to 260 (+4% per level) and the Stun duration to 1.25 seconds.  After traveling a long distance, the damage is increased to 390 (+4% per level) and the Stun duration to 2 seconds.",
         "hotkey": "R",
@@ -70,6 +75,7 @@
         "type": "heroic"
       },
       {
+        "uid": "87dc3d5",
         "name": "Natural Agility",
         "description": "Jump over unpathable terrain or Structures, up to a maximum range.",
         "hotkey": "D",

--- a/hero/illidan.json
+++ b/hero/illidan.json
@@ -22,6 +22,7 @@
   "abilities": {
     "Illidan": [
       {
+        "uid": "e4d7a7d",
         "name": "Dive",
         "description": "Dive at the target, dealing 66 (+4% per level) damage and flipping to the other side of the target.",
         "hotkey": "Q",
@@ -31,6 +32,7 @@
         "type": "basic"
       },
       {
+        "uid": "3efe928",
         "name": "Sweeping Strike",
         "description": "Dash towards target point, dealing 119 (+4% per level) damage to enemies along the way. Hitting an enemy increases Illidan's Basic Attack damage by 35% for 3 seconds.",
         "hotkey": "W",
@@ -40,6 +42,7 @@
         "type": "basic"
       },
       {
+        "uid": "142d7a7",
         "name": "Evasion",
         "description": "Evade enemy Basic Attacks for 2.5 seconds.",
         "hotkey": "E",
@@ -49,6 +52,7 @@
         "type": "basic"
       },
       {
+        "uid": "735a3eb",
         "name": "The Hunt",
         "description": "Charge to target unit, dealing 251 (+4% per level) damage on impact and stunning for 1 second.",
         "hotkey": "R",
@@ -58,6 +62,7 @@
         "type": "heroic"
       },
       {
+        "uid": "dbf3940",
         "name": "Metamorphosis",
         "description": "Transform into Demon Form at the target location, dealing 46 (+4% per level) damage in the area. Temporarily increases maximum Health by 220 (+4% per level) for each Hero hit by the initial impact. Lasts for 18 seconds.",
         "hotkey": "R",
@@ -67,6 +72,7 @@
         "type": "heroic"
       },
       {
+        "uid": "69ec116",
         "name": "Betrayer's Thirst",
         "description": "Basic Attacks heal for 30% of damage dealt and reduce Ability cooldowns by 1 second.",
         "trait": true,

--- a/hero/imperius.json
+++ b/hero/imperius.json
@@ -21,6 +21,7 @@
   "abilities": {
     "Imperius": [
       {
+        "uid": "fa58df2",
         "name": "Celestial Charge",
         "description": "Lunge towards a targeted direction and stab, dealing 35 (+4% per level) damage. If an enemy Hero is hit, Channel to Stun for 1 second and deal 70 (+4% per level) additional damage when it fully finishes.",
         "hotkey": "Q",
@@ -31,6 +32,7 @@
         "type": "basic"
       },
       {
+        "uid": "caa3920",
         "name": "Solarion's Fire",
         "description": "Release a fiery wave that deals 100 (+4% per level) damage. Enemies hit by the center take 50% bonus damage and are Slowed by 40% for 3 seconds.",
         "hotkey": "W",
@@ -41,6 +43,7 @@
         "type": "basic"
       },
       {
+        "uid": "fbe9031",
         "name": "Molten Armor",
         "description": "Shroud Imperius in flames for 3 seconds, striking a nearby enemy for 19 (+4% per level) damage every 0.25 seconds. Imperius heals for 50% of the damage dealt, increased to 100% against Heroes.",
         "hotkey": "E",
@@ -51,6 +54,7 @@
         "type": "basic"
       },
       {
+        "uid": "d880ca7",
         "name": "Angelic Armaments",
         "description": "Summon a ring of blazing swords that grants 1000 (+4% per level) Shield for 3 seconds.  If the Shield lasts the full duration, this ability can be reactivated within 5 seconds to launch 6 swords toward an area, each dealing 140 (+4% per level) damage to the first enemy hit.",
         "hotkey": "R",
@@ -61,6 +65,7 @@
         "type": "heroic"
       },
       {
+        "uid": "1ad7970",
         "name": "Wrath of the Angiris",
         "description": "After 0.75 seconds, charge in the target direction, lifting the first enemy Hero hit into the Heavens. While in the air, Imperius can steer the landing location by moving.  After 2 seconds, slam the target into the ground, dealing 375 (+4% per level) damage and Stunning them for 1 second.",
         "hotkey": "R",
@@ -71,6 +76,7 @@
         "type": "heroic"
       },
       {
+        "uid": "bd732d6",
         "name": "Valorous Brand",
         "description": "Each Basic Ability marks enemy Heroes hit for 10 seconds. Basic Attacks consume the target's marks, dealing 20% bonus damage per mark and healing for 70 (+4% per level) per mark.",
         "trait": true,

--- a/hero/jaina.json
+++ b/hero/jaina.json
@@ -20,6 +20,7 @@
   "abilities": {
     "Jaina": [
       {
+        "uid": "0c6f9e6",
         "name": "Frostbolt",
         "description": "Deal 184 (+4% per level) damage and Chill the target.",
         "hotkey": "Q",
@@ -30,6 +31,7 @@
         "type": "basic"
       },
       {
+        "uid": "2eb6b76",
         "name": "Blizzard",
         "description": "Bombard an area with 3 waves of ice, dealing 142 (+4% per level) damage each. Damaged enemies are Chilled.",
         "hotkey": "W",
@@ -40,6 +42,7 @@
         "type": "basic"
       },
       {
+        "uid": "24404be",
         "name": "Cone of Cold",
         "description": "Deal 220 (+4% per level) damage and Chill targets.",
         "hotkey": "E",
@@ -50,6 +53,7 @@
         "type": "basic"
       },
       {
+        "uid": "c1309e2",
         "name": "Summon Water Elemental",
         "description": "Summon a Water Elemental at target location. The Water Elemental's Basic Attacks deal 62 (+4% per level) damage, splash for 25% damage and Chill. The Ability can be reactivated to retarget the Water Elemental.  Lasts 20 seconds.",
         "hotkey": "R",
@@ -60,6 +64,7 @@
         "type": "heroic"
       },
       {
+        "uid": "36b5187",
         "name": "Ring of Frost",
         "description": "After a 1.5 second delay, create a Ring of Frost in an area that deals 310 (+4% per level) damage and Roots enemies for 3 seconds. The ring persists for 3 seconds afterward, Chilling any enemies who touch it.",
         "hotkey": "R",
@@ -70,6 +75,7 @@
         "type": "heroic"
       },
       {
+        "uid": "25fea55",
         "name": "Frostbite",
         "description": "Jaina's Abilities Chill targets, Slowing them by 25% and amplifying damage taken from her Abilities by 50%. Lasts 4 seconds.  Quest: Deal 15,000 Ability damage to Chilled Heroes.  Reward: Unlock the Improved Ice Block Ability, allowing Jaina to become temporarily Invulnerable.",
         "trait": true,
@@ -78,6 +84,7 @@
         "type": "trait"
       },
       {
+        "uid": "346dd30",
         "name": "Improved Ice Block",
         "description": "Activate to place Jaina in Stasis and gain Invulnerability for 2.5 seconds. When this effect expires, nearby enemies are Chilled.",
         "hotkey": "1",

--- a/hero/johanna.json
+++ b/hero/johanna.json
@@ -20,6 +20,7 @@
   "abilities": {
     "Johanna": [
       {
+        "uid": "6a776cd",
         "name": "Punish",
         "description": "Step forward dealing 113 (+4% per level) damage and Slowing enemies by 60% decaying over 2 seconds.",
         "hotkey": "Q",
@@ -30,6 +31,7 @@
         "type": "basic"
       },
       {
+        "uid": "2df3893",
         "name": "Condemn",
         "description": "After 1 second, Johanna pulls nearby enemies toward her, stunning them for 0.25 seconds and dealing 58 (+4% per level) damage. Deals 200% increased damage to Minions and Mercenaries.",
         "hotkey": "W",
@@ -40,6 +42,7 @@
         "type": "basic"
       },
       {
+        "uid": "a18dc5a",
         "name": "Shield Glare",
         "description": "Deal 59 (+4% per level) damage to enemies and Blind them for 1.5 seconds.",
         "hotkey": "E",
@@ -50,6 +53,7 @@
         "type": "basic"
       },
       {
+        "uid": "2b16e94",
         "name": "Falling Sword",
         "description": "Johanna leaps towards an area.  While in the air, she can steer the landing location by moving.  After 2 seconds Johanna lands, dealing 210 (+4% per level) damage to nearby enemies, Stunning them for 0.2 seconds, and Slowing them by 50% for 3 seconds.",
         "hotkey": "R",
@@ -60,6 +64,7 @@
         "type": "heroic"
       },
       {
+        "uid": "53cf2ec",
         "name": "Blessed Shield",
         "description": "Deal 114 (+4% per level) damage and Stun the first enemy hit for 1.5 seconds. Blessed Shield then bounces to 2 nearby enemies, dealing 57 (+4% per level) damage and Stunning them for 0.75 seconds.",
         "hotkey": "R",
@@ -70,6 +75,7 @@
         "type": "heroic"
       },
       {
+        "uid": "31937f2",
         "name": "Iron Skin",
         "description": "Activate to grant Johanna a Shield that absorbs 674 (+4% per level) damage for 4 seconds. While this Shield is active, Johanna is Unstoppable.",
         "hotkey": "D",

--- a/hero/junkrat.json
+++ b/hero/junkrat.json
@@ -19,6 +19,7 @@
   "abilities": {
     "Junkrat": [
       {
+        "uid": "9f5e4c7",
         "name": "Frag Launcher",
         "description": "Launch a grenade that explodes at the end of its path or upon hitting an enemy, dealing 128 (+4% per level) damage to nearby enemies. Grenades can ricochet off of terrain. Deals 50% less damage to Structures.  Stores up to 4 charges. Frag Launcher's cooldown replenishes all charges at the same time.",
         "hotkey": "Q",
@@ -28,6 +29,7 @@
         "type": "basic"
       },
       {
+        "uid": "c8a0317",
         "name": "Concussion Mine",
         "description": "Place a mine on the ground. Junkrat's Trait can be activated to detonate the mine, dealing 180 (+4% per level) damage to nearby enemies and knocking them back. Junkrat can also be affected by Concussion Mine, but takes no damage.  Limit 1 active mine.",
         "hotkey": "W",
@@ -37,6 +39,7 @@
         "type": "basic"
       },
       {
+        "uid": "af4c53c",
         "name": "Steel Trap",
         "description": "Place a trap on the ground that arms after 2 seconds. Deals 130 (+4% per level) damage to the first enemy that walks over it and Roots them for 2 seconds.  Limit 1 active trap.",
         "hotkey": "E",
@@ -46,6 +49,7 @@
         "type": "basic"
       },
       {
+        "uid": "844ea2c",
         "name": "RIP-Tire",
         "description": "Create a motorized bomb with 530 (+4% per level) Health that lasts 15 seconds. While active, Junkrat is immobile but gains control of RIP-Tire's movement.  RIP-Tire can be reactivated to detonate immediately, knocking nearby enemies back and dealing 775 (+4% per level) damage to enemies near the center gradually reduced to 475 (+4% per level) to enemies on the edge.",
         "hotkey": "R",
@@ -55,6 +59,7 @@
         "type": "heroic"
       },
       {
+        "uid": "82ec8fc",
         "name": "Rocket Ride",
         "description": "After 1.25 seconds, Junkrat launches into the air. While in the air, he can steer the landing location by moving.  After 3.75 seconds, Junkrat lands, dealing 750 (+4% per level) damage to nearby enemies and activating Total Mayhem. 5 seconds after landing, Junkrat reappears at the Hall of Storms and gains 150% additional Movement Speed until dismounted.",
         "hotkey": "R",
@@ -64,6 +69,7 @@
         "type": "heroic"
       },
       {
+        "uid": "9ffd8c2",
         "name": "Total Mayhem",
         "description": "Upon dying, drop 5 grenades that explode after 0.75 seconds, each dealing 250 (+4% per level) damage to nearby enemies. Deals 75% less damage to Structures.  Detonate Mine  Detonate an active Concussion Mine.",
         "trait": true,

--- a/hero/kaelthas.json
+++ b/hero/kaelthas.json
@@ -21,6 +21,7 @@
   "abilities": {
     "Kael'thas": [
       {
+        "uid": "a0a66cb",
         "name": "Flamestrike",
         "description": "After 1 second, deal 345 (+4% per level) damage in an area.  Verdant Spheres increases the radius by 50%.",
         "hotkey": "Q",
@@ -31,6 +32,7 @@
         "type": "basic"
       },
       {
+        "uid": "55fda32",
         "name": "Living Bomb",
         "description": "Deal 126 (+4% per level) damage over 3 seconds to an enemy, then they explode dealing 215 (+4% per level) damage to all nearby enemies.  Other Heroes damaged by this explosion are also affected by Living Bomb, though the secondary explosions cannot spread.  Verdant Spheres makes this Ability cost no Mana and have no cooldown.",
         "hotkey": "W",
@@ -41,6 +43,7 @@
         "type": "basic"
       },
       {
+        "uid": "2e60a7b",
         "name": "Gravity Lapse",
         "description": "Stun the first enemy hit for 1 second.  Verdant Spheres causes Gravity Lapse to stun the first 3 enemies hit and increases the stun duration by 50%.",
         "hotkey": "E",
@@ -51,6 +54,7 @@
         "type": "basic"
       },
       {
+        "uid": "1ce0f7f",
         "name": "Pyroblast",
         "description": "After 1.5 seconds, cast a slow-moving fireball that deals 810 (+5% per level) damage to an enemy Hero and 405 (+5% per level) damage to enemies nearby.",
         "hotkey": "R",
@@ -61,6 +65,7 @@
         "type": "heroic"
       },
       {
+        "uid": "258a1b9",
         "name": "Phoenix",
         "description": "Launch a Phoenix to an area, dealing 78 (+4% per level) damage to enemies along the way. The Phoenix persists for 7 seconds, attacking enemies for 78 (+4% per level) damage and splashing for 39 (+4% per level) damage.",
         "hotkey": "R",
@@ -71,6 +76,7 @@
         "type": "heroic"
       },
       {
+        "uid": "1d363c1",
         "name": "Verdant Spheres",
         "description": "Activate to make Kael'thas's next Basic Ability more powerful.",
         "hotkey": "D",

--- a/hero/kelthuzad.json
+++ b/hero/kelthuzad.json
@@ -20,6 +20,7 @@
   "abilities": {
     "Kel'Thuzad": [
       {
+        "uid": "27ad874",
         "name": "Death and Decay",
         "description": "After 0.5 seconds, launch an orb that explodes upon hitting an enemy, dealing 150 (+2.5% per level) damage to enemies in the area. The explosion leaves behind a pool of decay that lasts 2 seconds, dealing 82 (+2.5% per level) damage every 0.5 seconds to enemies.",
         "hotkey": "Q",
@@ -30,6 +31,7 @@
         "type": "basic"
       },
       {
+        "uid": "e4774fe",
         "name": "Frost Nova",
         "description": "Create a nova that explodes after 1 second, dealing 180 (+2.5% per level) damage to enemies inside and Slowing them by 35% for 2.5 seconds. Enemies in the center are Rooted for 1 second.",
         "hotkey": "W",
@@ -40,6 +42,7 @@
         "type": "basic"
       },
       {
+        "uid": "08bd2e9",
         "name": "Chains of Kel'Thuzad",
         "description": "Launch a chain, dealing 97 (+2.5% per level) damage to the first enemy Hero hit. For 3 seconds after hitting an enemy, Chains can be reactivated to launch to an additional enemy, pulling both enemies together and Stunning them for 0.5 seconds.",
         "hotkey": "E",
@@ -50,6 +53,7 @@
         "type": "basic"
       },
       {
+        "uid": "423a912",
         "name": "Frost Blast",
         "description": "Launch a meteor of ice at an enemy Hero. Upon impact, the meteor deals 115 (+2.5% per level) damage to its target and 275 (+2.5% per level) damage to enemies in the area. All enemies hit by Frost Blast are Rooted for 1.75 seconds.",
         "hotkey": "R",
@@ -60,6 +64,7 @@
         "type": "heroic"
       },
       {
+        "uid": "7848710",
         "name": "Shadow Fissure",
         "description": "Create a fissure anywhere on the Battleground that explodes after 1.5 seconds, dealing 360 (+2.5% per level) damage to enemy Heroes in its area.",
         "hotkey": "R",
@@ -70,6 +75,7 @@
         "type": "heroic"
       },
       {
+        "uid": "1b72614",
         "name": "Master of the Cold Dark",
         "description": "Quest: Gain 1 Blight every time a Hero is Rooted by Frost Nova or hit by Chains of Kel'Thuzad.  Reward: After gaining 15 Blight, gain the Glacial Spike Ability.  Reward: After gaining 30 Blight, gain 75% Spell Power.  Blight: 0/30",
         "trait": true,
@@ -78,6 +84,7 @@
         "type": "trait"
       },
       {
+        "uid": "5725ae6",
         "name": "Glacial Spike",
         "description": "Activate to create a spike that detonates after 4 seconds, dealing 60 (+2.5% per level) damage to nearby enemies. The spike can be affected by Chains of Kel'Thuzad.",
         "hotkey": "1",

--- a/hero/kerrigan.json
+++ b/hero/kerrigan.json
@@ -20,6 +20,7 @@
   "abilities": {
     "Kerrigan": [
       {
+        "uid": "b87c92d",
         "name": "Ravage",
         "description": "Leap to a target, dealing 130 (+4% per level) damage. If the enemy dies within 1.5 seconds, restore 1 charge and refund 20 Mana.",
         "hotkey": "Q",
@@ -30,6 +31,7 @@
         "type": "basic"
       },
       {
+        "uid": "b4ab2c8",
         "name": "Impaling Blades",
         "description": "After 1.25 seconds, deal 165 (+4% per level) damage to enemies within the target area, Stunning them for 1 second.",
         "hotkey": "W",
@@ -40,6 +42,7 @@
         "type": "basic"
       },
       {
+        "uid": "a49bb42",
         "name": "Primal Grasp",
         "description": "Pulls enemies within the target area towards Kerrigan, dealing 25 (+4% per level) damage. After 2.5 seconds, an explosion occurs around Kerrigan, dealing 195 (+4% per level) damage to nearby enemies.",
         "hotkey": "E",
@@ -50,6 +53,7 @@
         "type": "basic"
       },
       {
+        "uid": "c2af57c",
         "name": "Summon Ultralisk",
         "description": "After 0.5 seconds, summon an Ultralisk that rushes forward upon spawning, dealing 250 (+4% per level) damage to the first enemy Hero hit and Stunning them for 0.5 seconds.  The Ultralisk's Basic Attacks deal 50% of their damage in an area around their target. Reactivate to retarget the Ultralisk.",
         "hotkey": "R",
@@ -60,6 +64,7 @@
         "type": "heroic"
       },
       {
+        "uid": "b791533",
         "name": "Maelstrom",
         "description": "Deals 74 (+4% per level) damage per second to nearby enemies. Lasts for 7 seconds.",
         "hotkey": "R",
@@ -70,6 +75,7 @@
         "type": "heroic"
       },
       {
+        "uid": "b85742f",
         "name": "Assimilation",
         "description": "Gain 10% of damage dealt from Basic Attacks and Abilities as Shields for 6 seconds. Shield amount gained doubled against Heroes.  Current maximum: 1004 (+4% per level)",
         "trait": true,

--- a/hero/kharazim.json
+++ b/hero/kharazim.json
@@ -23,6 +23,7 @@
   "abilities": {
     "Kharazim": [
       {
+        "uid": "fdd06c9",
         "name": "Radiant Dash",
         "description": "Jump to an allied or enemy unit. Enemies are immediately hit with a Basic Attack.  Stores up to 2 charges.",
         "hotkey": "Q",
@@ -33,6 +34,7 @@
         "type": "basic"
       },
       {
+        "uid": "07eb472",
         "name": "Breath of Heaven",
         "description": "Heal nearby Heroes for 276 (+4% per level) and give them 15% Movement Speed for 3 seconds.",
         "hotkey": "W",
@@ -43,6 +45,7 @@
         "type": "basic"
       },
       {
+        "uid": "4a00da2",
         "name": "Deadly Reach",
         "description": "Kharazim's next Basic Attack increases his Attack Speed and Attack Range by 100% for 2 seconds.",
         "hotkey": "E",
@@ -53,6 +56,7 @@
         "type": "basic"
       },
       {
+        "uid": "40efe4f",
         "name": "Seven-Sided Strike",
         "description": "Become Invulnerable and strike 7 times over 2 seconds. Each strike hits the highest Health nearby Hero for 7% of their maximum Health.",
         "hotkey": "R",
@@ -63,6 +67,7 @@
         "type": "heroic"
       },
       {
+        "uid": "d2b3a8f",
         "name": "Divine Palm",
         "description": "Protect an allied Hero from death, causing them to be healed for 1200 (+4% per level) if they take fatal damage in the next 3 seconds.",
         "hotkey": "R",
@@ -73,6 +78,7 @@
         "type": "heroic"
       },
       {
+        "uid": "9ac34a4",
         "name": "Pick Your Trait",
         "description": "Choose between Transcendence, Iron Fists, and Insight from the Talents panel.",
         "trait": true,

--- a/hero/leoric.json
+++ b/hero/leoric.json
@@ -20,6 +20,7 @@
   "abilities": {
     "Leoric": [
       {
+        "uid": "b6bef4b",
         "name": "Skeletal Swing",
         "description": "Leoric swings his mace, dealing 150 (+4% per level) damage and Slowing enemies by 40% for 2.5 seconds. If an enemy Hero is hit, refund 50% of the cooldown and Mana cost. Peasants!",
         "hotkey": "Q",
@@ -30,6 +31,7 @@
         "type": "basic"
       },
       {
+        "uid": "ea460f4",
         "name": "Drain Hope",
         "description": "Grab an enemy Hero's soul, dealing up to 20% of their maximum Health as damage and healing Leoric for up to 20% of his maximum Health while he is nearby, over 4 seconds. Leoric's Movement Speed is reduced by 20% while this is active.",
         "hotkey": "W",
@@ -40,6 +42,7 @@
         "type": "basic"
       },
       {
+        "uid": "5f918e8",
         "name": "Wraith Walk",
         "description": "Leoric separates from his body, becoming Unstoppable and gaining Movement Speed accelerating up to 50% over 2.5 seconds. When Wraith Walk ends or is canceled, his body jumps to his wraith.",
         "hotkey": "E",
@@ -50,6 +53,7 @@
         "type": "basic"
       },
       {
+        "uid": "70fc23b",
         "name": "Entomb",
         "description": "Create an unpassable tomb for 4 seconds.",
         "hotkey": "R",
@@ -60,6 +64,7 @@
         "type": "heroic"
       },
       {
+        "uid": "628f1d9",
         "name": "March of the Black King",
         "description": "Leoric becomes Unstoppable and walks forward, swinging his mace 3 times. Enemies hit take 250 (+4% per level) damage, and Heroes hit heal Leoric for 12% of his maximum Health.",
         "hotkey": "R",
@@ -70,6 +75,7 @@
         "type": "heroic"
       },
       {
+        "uid": "43d6f54",
         "name": "Undying",
         "description": "Leoric becomes a ghost when he dies, and resurrects upon reaching full Health. Leoric deals no damage while dead.  Wrath Of The Bone King  Leoric's first two Basic Attacks cleave for 100% damage, and his third Basic Attack deals 200% damage to a single target.",
         "trait": true,
@@ -80,6 +86,7 @@
     ],
     "LeoricUndyingTrait": [
       {
+        "uid": "8badff8",
         "name": "Ghastly Swing",
         "description": "Slow enemies by 40% for 2.5 seconds.",
         "hotkey": "Q",
@@ -89,6 +96,7 @@
         "type": "subunit"
       },
       {
+        "uid": "6c60dec",
         "name": "Drain Essence",
         "description": "Throw out a chain, attaching to the first enemy Hero hit, healing Leoric for up to 10% of his maximum Health over 4 seconds as long as the enemy remains close.",
         "hotkey": "W",

--- a/hero/lili.json
+++ b/hero/lili.json
@@ -21,6 +21,7 @@
   "abilities": {
     "Li Li": [
       {
+        "uid": "89be463",
         "name": "Healing Brew",
         "description": "Heal lowest Health ally (prioritizing Heroes) within 6 range for 175 (+4% per level) Health.",
         "hotkey": "Q",
@@ -31,6 +32,7 @@
         "type": "basic"
       },
       {
+        "uid": "f990f70",
         "name": "Cloud Serpent",
         "description": "Summon a Cloud Serpent on an allied Hero that attacks nearby enemies every second. Each attack deals 26 (+4% per level) damage and heals the ally for 20 (+4% per level). Lasts for 8 seconds.",
         "hotkey": "W",
@@ -41,6 +43,7 @@
         "type": "basic"
       },
       {
+        "uid": "60ae31d",
         "name": "Blinding Wind",
         "description": "Throw a cloud of wind at the 2 nearest enemies (prioritizing Heroes), dealing 133 (+4% per level) damage. Affected targets are Blinded for 1.5 seconds, causing their Basic Attacks to miss and deal no damage.",
         "hotkey": "E",
@@ -51,6 +54,7 @@
         "type": "basic"
       },
       {
+        "uid": "034d107",
         "name": "Jug of 1,000 Cups",
         "description": "Channel for up to 6 seconds. Every 0.25 seconds, heal the lowest Health nearby allied Hero for 66 (+4% per level) Health and increase the cooldown of Jug of 1,000 Cups by 2 seconds, up to 50.",
         "hotkey": "R",
@@ -61,6 +65,7 @@
         "type": "heroic"
       },
       {
+        "uid": "497e5a1",
         "name": "Water Dragon",
         "description": "Li Li channels for 2 seconds, summoning a Water Dragon that hits the nearest enemy Hero within 12 range and all enemies near them, dealing 300 (+4% per level) damage and slowing their Movement Speed by 70% for 4 seconds.",
         "hotkey": "R",
@@ -71,6 +76,7 @@
         "type": "heroic"
       },
       {
+        "uid": "a61e0b3",
         "name": "Fast Feet",
         "description": "Upon taking damage, your Basic Ability cooldowns refresh 50% faster and you gain 10% Movement Speed for 1 second.",
         "trait": true,

--- a/hero/liming.json
+++ b/hero/liming.json
@@ -20,6 +20,7 @@
   "abilities": {
     "Li-Ming": [
       {
+        "uid": "7efb099",
         "name": "Magic Missiles",
         "description": "Fire three missiles toward an area, each dealing 147 (+3% per level) damage to the first enemy hit. These missiles do 50% damage to Structures.",
         "hotkey": "Q",
@@ -30,6 +31,7 @@
         "type": "basic"
       },
       {
+        "uid": "10b62b5",
         "name": "Arcane Orb",
         "description": "Fire an Orb that powers up as it travels, dealing 135 (+3% per level) damage to the first enemy hit. Damage is increased the further it travels, up to 270 (+3% per level) more damage.",
         "hotkey": "W",
@@ -40,6 +42,7 @@
         "type": "basic"
       },
       {
+        "uid": "5ec61d9",
         "name": "Teleport",
         "description": "Teleport a short distance instantly.",
         "hotkey": "E",
@@ -50,6 +53,7 @@
         "type": "basic"
       },
       {
+        "uid": "5769b45",
         "name": "Disintegrate",
         "description": "Channel a powerful beam, dealing 440 (+5% per level) damage over 2.6 seconds to enemies while they are in it. The direction of the beam changes with your mouse cursor position.",
         "hotkey": "R",
@@ -60,6 +64,7 @@
         "type": "heroic"
       },
       {
+        "uid": "4bdc74f",
         "name": "Wave of Force",
         "description": "Knock away all enemies from an area and deal 160 (+5% per level) damage.",
         "hotkey": "R",
@@ -70,6 +75,7 @@
         "type": "heroic"
       },
       {
+        "uid": "75eaa4c",
         "name": "Critical Mass",
         "description": "Getting a Takedown will refresh the cooldown on all of Li-Ming's Abilities.",
         "trait": true,

--- a/hero/lostvikings.json
+++ b/hero/lostvikings.json
@@ -22,6 +22,7 @@
   "abilities": {
     "The Lost Vikings": [
       {
+        "uid": "1d72f5a",
         "name": "Spin To Win!",
         "description": "Activate to have each Viking deal 101 (+4% per level) damage to nearby enemies.",
         "hotkey": "Q",
@@ -31,6 +32,7 @@
         "type": "basic"
       },
       {
+        "uid": "c3cd717",
         "name": "Nordic Attack Squad",
         "description": "Activate to have all Viking Basic Attacks deal bonus damage equal to 1.25% of a Hero's maximum Health for 5 seconds.",
         "hotkey": "W",
@@ -40,6 +42,7 @@
         "type": "basic"
       },
       {
+        "uid": "616f88a",
         "name": "Viking Bribery",
         "description": "Enemy Minions or captured Mercenaries killed near The Lost Vikings grant stacks of Bribe. Use 40 stacks to bribe target Mercenary, instantly defeating them. Does not work on Elite Mercenaries. Maximum stacks available: 200. If a camp is defeated entirely with Bribe, the camp respawns 50% faster.  Current number of Bribe stacks: 0",
         "hotkey": "E",
@@ -48,6 +51,7 @@
         "type": "basic"
       },
       {
+        "uid": "85d6161",
         "name": "Play Again!",
         "description": "Summon, fully heal, and revive all Lost Vikings at target location after a Viking channels for 2 seconds.  Only one Viking may attempt to summon at a time.",
         "hotkey": "R",
@@ -57,6 +61,7 @@
         "type": "heroic"
       },
       {
+        "uid": "32e8c00",
         "name": "Longboat Raid!",
         "description": "Hop into an Unstoppable Longboat that fires at nearby enemies for 112 (+4% per level) damage per second and can fire a mortar that deals 205 (+4% per level) damage in an area.  The boat has increased Health for each Viking inside. If the boat is destroyed by enemies, all Vikings are stunned for 1.5 seconds. Lasts 15 seconds.  Requires all surviving Vikings to be nearby.",
         "hotkey": "R",
@@ -66,6 +71,7 @@
         "type": "heroic"
       },
       {
+        "uid": "6c5bf95",
         "name": "Go Go Go!",
         "description": "The Vikings gain 30% increased Movement Speed for 4 seconds.",
         "hotkey": "Z",
@@ -75,6 +81,7 @@
         "type": "mount"
       },
       {
+        "uid": "a07cc19",
         "name": "Select Olaf",
         "description": "Olaf can charge enemies and slow their Movement Speed by 30% for 3 seconds by right-clicking on them. 8 second cooldown.  Olaf gains increased Health Regeneration when out of combat for 4 seconds.",
         "hotkey": "3",
@@ -83,6 +90,7 @@
         "type": "activable"
       },
       {
+        "uid": "9005cd5",
         "name": "Select Baleog",
         "description": "Baleog's Basic Attacks deal 50% splash damage to enemies behind his attack target.",
         "hotkey": "1",
@@ -91,6 +99,7 @@
         "type": "activable"
       },
       {
+        "uid": "cf27aa9",
         "name": "Select Erik",
         "description": "Erik moves faster than the other Vikings and has increased Basic Attack range.",
         "hotkey": "2",
@@ -99,6 +108,7 @@
         "type": "activable"
       },
       {
+        "uid": "29fbe91",
         "name": "Jump!",
         "description": "Makes all Vikings Invulnerable and able to pass over enemies for 1.5 seconds.",
         "hotkey": "W",
@@ -108,6 +118,7 @@
         "type": "basic"
       },
       {
+        "uid": "6bb9a50",
         "name": "Norse Force!",
         "description": "All Vikings gain a 130 (+4% per level) to 260 (+4% per level) point Shield, increasing in strength for each Viking alive. Lasts 4 seconds.",
         "hotkey": "Q",
@@ -117,6 +128,7 @@
         "type": "basic"
       },
       {
+        "uid": "f73377d",
         "name": "Mortar",
         "description": "Fires a mortar at the targeted location, dealing 205 (+4% per level) damage in a large area.",
         "hotkey": "Q",
@@ -126,6 +138,7 @@
         "type": "basic"
       },
       {
+        "uid": "4313b63",
         "name": "Viking Hoard",
         "description": "Gathering a Regeneration Globe with a Viking permanently increases all their Health Regeneration by 0.5 per second.  Current Bonus: 0 Regen per second",
         "trait": true,
@@ -136,6 +149,7 @@
     ],
     "LostVikingsLongboatRaidNewer": [
       {
+        "uid": "8044936",
         "name": "Select All Vikings",
         "description": "The Lost Vikings can be controlled individually or as a group. Each Viking has particular strengths.",
         "hotkey": "1",

--- a/hero/ltmorales.json
+++ b/hero/ltmorales.json
@@ -19,6 +19,7 @@
   "abilities": {
     "Lt. Morales": [
       {
+        "uid": "b8ecaa3",
         "name": "Healing Beam",
         "description": "Heal target allied Hero or Minion for 172 (+4% per level) Health per second as long as they are in range. After not channeling Healing Beam for 2 seconds, regenerate 6 Energy per second.  Reactivate to switch targets, or self-cast to cancel channeling.",
         "hotkey": "Q",
@@ -30,6 +31,7 @@
         "type": "basic"
       },
       {
+        "uid": "b4c083c",
         "name": "Safeguard",
         "description": "Grant target ally Hero 30 Armor for 3 seconds.",
         "hotkey": "W",
@@ -39,6 +41,7 @@
         "type": "basic"
       },
       {
+        "uid": "4969c58",
         "name": "Displacement Grenade",
         "description": "Fire a grenade that can be manually detonated, dealing 208 (+4% per level) to nearby enemies and knocking them away.",
         "hotkey": "E",
@@ -48,6 +51,7 @@
         "type": "basic"
       },
       {
+        "uid": "0506b6d",
         "name": "Stim Drone",
         "description": "Grant an allied Hero 75% Attack Speed and 25% Movement Speed for 10 seconds.",
         "hotkey": "R",
@@ -57,6 +61,7 @@
         "type": "heroic"
       },
       {
+        "uid": "5afa053",
         "name": "Medivac Dropship",
         "description": "Target a location for a Medivac transport. For up to 10 seconds before takeoff, allies can right-click to enter the Medivac.",
         "hotkey": "R",
@@ -66,6 +71,7 @@
         "type": "heroic"
       },
       {
+        "uid": "3274517",
         "name": "Caduceus Reactor",
         "description": "While channeling Healing Beam, Lt. Morales regenerates 2% of her maximum Health per second.",
         "trait": true,

--- a/hero/lucio.json
+++ b/hero/lucio.json
@@ -22,6 +22,7 @@
   "abilities": {
     "Lúcio": [
       {
+        "uid": "44ed254",
         "name": "Soundwave",
         "description": "Deal 105 (+4% per level) damage to enemies in an area and knock them back.",
         "hotkey": "Q",
@@ -32,6 +33,7 @@
         "type": "basic"
       },
       {
+        "uid": "3a4b93e",
         "name": "Amp It Up",
         "description": "Raise Lúcio's Crossfade track volume for 3 seconds, amping Healing Boost to 112 (+4% per level) Health per second and Speed Boost to 30% increased Movement Speed.",
         "hotkey": "E",
@@ -42,6 +44,7 @@
         "type": "basic"
       },
       {
+        "uid": "11a3cf4",
         "name": "Sound Barrier",
         "description": "After 1 second, Lúcio and nearby allied Heroes gain a 1296 (+4% per level) point Shield that rapidly decays over 6 seconds.",
         "hotkey": "R",
@@ -52,6 +55,7 @@
         "type": "heroic"
       },
       {
+        "uid": "4584f34",
         "name": "Wall Ride",
         "description": "When moving alongside terrain, Lúcio begins to Wall Ride for 2 seconds. While Wall Ride is active, Lúcio can walk through units and gains 20% Movement Speed that stacks with other bonuses.",
         "abilityId": "Lúcio|Z1",
@@ -59,6 +63,7 @@
         "type": "mount"
       },
       {
+        "uid": "0b5cf08",
         "name": "High Five",
         "description": "Quickly skate to an allied Hero. Upon arrival, the ally is granted Unstoppable for 1 second and is healed for 250 (+4% per level).",
         "hotkey": "R",
@@ -69,6 +74,7 @@
         "type": "heroic"
       },
       {
+        "uid": "4a6faa2",
         "name": "Push Off",
         "description": "While moving alongside terrain, activate to slide towards a targeted location. Enemies hit take 100 (+4% per level) damage and are Slowed by 75% for 1 second.",
         "trait": true,
@@ -78,6 +84,7 @@
         "type": "trait"
       },
       {
+        "uid": "c891e16",
         "name": "Crossfade",
         "description": "Currently playing Speed Boost, increasing the Movement Speed of Lúcio and nearby allied Heroes by 10%.  Toggle to play Healing Boost instead.",
         "hotkey": "W",
@@ -88,6 +95,7 @@
     ],
     "LucioCrossfade": [
       {
+        "uid": "bede789",
         "name": "Crossfade",
         "description": "Currently playing Healing Boost, passively healing Lúcio and nearby allied Heroes for 15 (+4% per level) Health per second.  Toggle to play Speed Boost instead.",
         "hotkey": "W",

--- a/hero/lunara.json
+++ b/hero/lunara.json
@@ -21,6 +21,7 @@
   "abilities": {
     "Lunara": [
       {
+        "uid": "e709daa",
         "name": "Noxious Blossom",
         "description": "After 0.5 seconds, cause an area to explode with pollen dealing 160 (+4% per level) damage.",
         "hotkey": "Q",
@@ -31,6 +32,7 @@
         "type": "basic"
       },
       {
+        "uid": "9eebbfb",
         "name": "Crippling Spores",
         "description": "Enemies currently afflicted by Nature's Toxin have its duration increased by 3 seconds and are Slowed by 40% decaying over 3 seconds.",
         "hotkey": "W",
@@ -41,6 +43,7 @@
         "type": "basic"
       },
       {
+        "uid": "4c69179",
         "name": "Wisp",
         "description": "Spawn a Wisp to scout an area. Can be redirected once active. When the Wisp is in a bush for more 2 seconds, its vision radius is increased by 75%.  Lasts 45 seconds.",
         "hotkey": "E",
@@ -50,6 +53,7 @@
         "type": "basic"
       },
       {
+        "uid": "75a8b15",
         "name": "Thornwood Vine",
         "description": "Send forth vines that deal 176 (+4% per level) damage to all enemies in a line.  Stores up to 3 charges.",
         "hotkey": "R",
@@ -60,6 +64,7 @@
         "type": "heroic"
       },
       {
+        "uid": "7d220f7",
         "name": "Leaping Strike",
         "description": "Leap over an enemy, Slowing them by 80% for 0.35 seconds and dealing 271 (+4% per level) damage.  Stores up to 2 charges.",
         "hotkey": "R",
@@ -70,6 +75,7 @@
         "type": "heroic"
       },
       {
+        "uid": "45d35fe",
         "name": "Nature's Toxin",
         "description": "Lunara's Basic Attacks and damaging Abilities poison their target, dealing 30 (+5% per level) damage a second for 3 seconds. Every additional application increases the duration by 3 seconds, up to a maximum of 9 seconds.",
         "trait": true,
@@ -78,6 +84,7 @@
         "type": "trait"
       },
       {
+        "uid": "56ea45f",
         "name": "Dryad's Swiftness",
         "description": "Lunara moves 20% faster by leaping short distances.",
         "abilityId": "Lunara|Z1",

--- a/hero/maiev.json
+++ b/hero/maiev.json
@@ -15,6 +15,7 @@
   "abilities": {
     "Maiev": [
       {
+        "uid": "feb394a",
         "name": "Fan of Knives",
         "description": "Deal 152 (+4% per level) damage to enemies in a crescent area.  Hitting at least 2 enemy Heroes with Fan of Knives reduces its cooldown to 0.5 seconds, and refunds its Mana cost.",
         "hotkey": "Q",
@@ -25,6 +26,7 @@
         "type": "basic"
       },
       {
+        "uid": "bc98674",
         "name": "Umbral Bind",
         "description": "Maiev's next Basic Attack cleaves and applies a tether to enemy Heroes hit for 2.5 seconds. If a tethered Hero moves too far from Maiev, they are pulled toward her, dealing 110 (+4% per level) damage and breaking the tether.",
         "hotkey": "W",
@@ -35,6 +37,7 @@
         "type": "basic"
       },
       {
+        "uid": "88093b9",
         "name": "Spirit of Vengeance",
         "description": "Send a shadow of Maiev outward that will return to its cast location, dealing 150 (+4% per level) damage to enemies along both paths. If an enemy Hero is hit, reduce the cooldown by 4 seconds.",
         "hotkey": "E",
@@ -45,6 +48,7 @@
         "type": "basic"
       },
       {
+        "uid": "1ecc6bb",
         "name": "Containment Disc",
         "description": "Throw a glaive in the target direction. If an enemy Hero is hit, Containment Disc can be reactivated to remove their vision and Time Stop them for 4 seconds.  Containment Disc automatically activates 6 seconds after hitting a Hero.",
         "hotkey": "R",
@@ -55,6 +59,7 @@
         "type": "heroic"
       },
       {
+        "uid": "3e124e6",
         "name": "Warden's Cage",
         "description": "Summon 8 Warden Avatars as a cage around Maiev. After 1.5 seconds, enemy Heroes that come in contact with an Avatar consume it and are knocked to the center of the cage. Warden Avatars last 5 seconds.",
         "hotkey": "R",
@@ -65,6 +70,7 @@
         "type": "heroic"
       },
       {
+        "uid": "74d33e4",
         "name": "Vault of the Wardens",
         "description": "Leap into the air, becoming immune to all hostile effects for 0.75 seconds.",
         "hotkey": "D",

--- a/hero/malfurion.json
+++ b/hero/malfurion.json
@@ -21,6 +21,7 @@
   "abilities": {
     "Malfurion": [
       {
+        "uid": "5a3ef22",
         "name": "Regrowth",
         "description": "Heal an allied Hero for 380 (+4% per level) Health over 20 seconds.",
         "hotkey": "Q",
@@ -31,6 +32,7 @@
         "type": "basic"
       },
       {
+        "uid": "56a5964",
         "name": "Moonfire",
         "description": "Deal 90 (+4% per level) damage to enemies in an area and reveal them for 2 seconds.  Allies with an active Regrowth are healed for 130 (+4% per level) Health for each enemy Hero hit by Moonfire.",
         "hotkey": "W",
@@ -41,6 +43,7 @@
         "type": "basic"
       },
       {
+        "uid": "6e2caa2",
         "name": "Entangling Roots",
         "description": "Root enemy Heroes in an area for 1.25 seconds, and deal 117 (+4% per level) damage over the duration. Affected area grows over 3 seconds.",
         "hotkey": "E",
@@ -51,6 +54,7 @@
         "type": "basic"
       },
       {
+        "uid": "7ab654c",
         "name": "Tranquility",
         "description": "Heal nearby allied Heroes for 80 (+4% per level) Health per second for 8 seconds. Allies affected by Regrowth within Tranquility's area gain 10 Armor.",
         "hotkey": "R",
@@ -61,6 +65,7 @@
         "type": "heroic"
       },
       {
+        "uid": "39f1e67",
         "name": "Twilight Dream",
         "description": "After 0.5 seconds, deal 310 (+4% per level) damage in a large area around Malfurion, Silencing enemies making them unable to use Abilities for 3 seconds.",
         "hotkey": "R",
@@ -71,6 +76,7 @@
         "type": "heroic"
       },
       {
+        "uid": "2f181bf",
         "name": "Innervate",
         "description": "Grant an allied Hero 20% of their maximum Mana over 5 seconds. While affected by Innervate, their Basic Ability cooldowns recharge 50% faster.  Cannot be used on Heroes that do not use Mana.",
         "hotkey": "D",

--- a/hero/malganis.json
+++ b/hero/malganis.json
@@ -21,6 +21,7 @@
   "abilities": {
     "Mal'Ganis": [
       {
+        "uid": "7599439",
         "name": "Fel Claws",
         "description": "Violently slash in the chosen direction, dealing 69 (+4% per level) damage to enemies.  Reactivate to slash up to 2 more times. The third slash Stuns enemies for 0.75 seconds.",
         "hotkey": "Q",
@@ -31,6 +32,7 @@
         "type": "basic"
       },
       {
+        "uid": "de3ae62",
         "name": "Necrotic Embrace",
         "description": "Desecrate the air, dealing 110 (+4% per level) damage to nearby enemies and gaining 25 Armor for 3 seconds.",
         "hotkey": "W",
@@ -41,6 +43,7 @@
         "type": "basic"
       },
       {
+        "uid": "6203e91",
         "name": "Night Rush",
         "description": "After 0.75 seconds, gain 50% Movement Speed for 2 seconds. While active, Mal'Ganis can move through enemy Heroes and put them to Sleep for 2.5 seconds.",
         "hotkey": "E",
@@ -51,6 +54,7 @@
         "type": "basic"
       },
       {
+        "uid": "69d57a2",
         "name": "Carrion Swarm",
         "description": "After 1 second, disperse into an Invulnerable swarm of bats for 3 seconds, dealing 126 (+4% per level) damage per second to enemies.  Vampiric Touch heals for 75% of Carrion Swarm's damage to Heroes.",
         "hotkey": "R",
@@ -61,6 +65,7 @@
         "type": "heroic"
       },
       {
+        "uid": "a2cbffd",
         "name": "Dark Conversion",
         "description": "Channel on an enemy Hero for 0.75 seconds, then swap Health percentages with the target over 3 seconds.",
         "hotkey": "R",
@@ -71,6 +76,7 @@
         "type": "heroic"
       },
       {
+        "uid": "3504360",
         "name": "Vampiric Touch",
         "description": "Mal'Ganis heals for 45% of damage dealt to enemy Heroes and 10% of damage dealt to non-Heroes.",
         "trait": true,

--- a/hero/malthael.json
+++ b/hero/malthael.json
@@ -23,6 +23,7 @@
   "abilities": {
     "Malthael": [
       {
+        "uid": "b2fd2a8",
         "name": "Soul Rip",
         "description": "Extract the souls of nearby enemies afflicted by Reaper's Mark, dealing 100 (+4% per level) damage and healing Malthael for 25 (+4% per level) per target hit. Heroic targets heal Malthael for an additional 4% of the Hero's maximum Health.",
         "hotkey": "Q",
@@ -33,6 +34,7 @@
         "type": "basic"
       },
       {
+        "uid": "625e9e1",
         "name": "Wraith Strike",
         "description": "Instantly teleport through an enemy afflicted by Reaper's Mark, dealing 59 (+4% per level) damage and refreshing Reaper's Mark.",
         "hotkey": "W",
@@ -43,6 +45,7 @@
         "type": "basic"
       },
       {
+        "uid": "bdec408",
         "name": "Death Shroud",
         "description": "After 0.25 seconds, unleash a wave of dark mist that applies Reaper's Mark to enemies it hits.",
         "hotkey": "E",
@@ -53,6 +56,7 @@
         "type": "basic"
       },
       {
+        "uid": "3f08ef9",
         "name": "Tormented Souls",
         "description": "Unleash a torrent of souls, continually applying Reaper's Mark to nearby enemies for 4 seconds.  When Tormented Souls is cast and when it expires, reset the cooldown of Wraith Strike.",
         "hotkey": "R",
@@ -63,6 +67,7 @@
         "type": "heroic"
       },
       {
+        "uid": "78d285c",
         "name": "Last Rites",
         "description": "Apply a death sentence to an enemy Hero that, after 2 seconds, deals damage equal to 50% of their missing Health.  Quest: Enemies killed between the application of Last Rites and within 1.5 seconds of it dealing damage permanently reduce its cooldown by 5 seconds, to a minimum of 15 seconds.",
         "hotkey": "R",
@@ -73,6 +78,7 @@
         "type": "heroic"
       },
       {
+        "uid": "dfc12ce",
         "name": "Reaper's Mark",
         "description": "Basic Attacks cleave in an area in front of Malthael and afflict non-Structure targets with Reaper's Mark for 4 seconds.  Marked enemies are revealed and take damage equal to 1.75% of their maximum Health every 1 second.",
         "trait": true,

--- a/hero/medivh.json
+++ b/hero/medivh.json
@@ -21,6 +21,7 @@
   "abilities": {
     "Medivh": [
       {
+        "uid": "0650274",
         "name": "Arcane Rift",
         "description": "Launch a rift that deals 170 (+4% per level) damage to enemies in its path. If an enemy Hero is hit, reduce its cooldown by 5 seconds and refund 50 Mana.  Quest: Hit 40 enemy Heroes with Arcane Rift without dying.  Reward: Permanently increase the damage dealt by 75 and cooldown reduction for hitting a Hero by 1 second.",
         "hotkey": "Q",
@@ -31,6 +32,7 @@
         "type": "basic"
       },
       {
+        "uid": "0511489",
         "name": "Force of Will",
         "description": "Protect an allied Hero from all damage for 1.5 seconds.  Upon expiration, Force of Will heals the target for 20% of the damage it absorbed.",
         "hotkey": "W",
@@ -41,6 +43,7 @@
         "type": "basic"
       },
       {
+        "uid": "3cc3d97",
         "name": "Portal",
         "description": "Create a set of portals between Medivh and the target location, allowing allies to teleport between both. The portals last 6 seconds.",
         "hotkey": "E",
@@ -51,6 +54,7 @@
         "type": "basic"
       },
       {
+        "uid": "be3e2ba",
         "name": "Poly Bomb",
         "description": "Polymorph an enemy Hero for 2 seconds, Silencing them and making them unable to attack. On expiration, Poly Bomb spreads to other nearby enemy Heroes.",
         "hotkey": "R",
@@ -61,6 +65,7 @@
         "type": "heroic"
       },
       {
+        "uid": "6abc78a",
         "name": "Ley Line Seal",
         "description": "After 0.5 seconds, unleash a wave of energy that places enemy Heroes in Time Stop for 3 seconds.",
         "hotkey": "R",
@@ -71,6 +76,7 @@
         "type": "heroic"
       },
       {
+        "uid": "e7871e3",
         "name": "Raven Form",
         "description": "Transform into a raven, increasing Movement Speed by 20%. While transformed, Medivh can see and fly over terrain and is immune to all effects.",
         "hotkey": "Z",
@@ -80,6 +86,7 @@
         "type": "mount"
       },
       {
+        "uid": "6a0dd6b",
         "name": "Raven Form",
         "description": "Instead of mounting, Medivh can transform into a raven, increasing Movement Speed by 20%. While transformed, Medivh can see and fly over all terrain and is immune to all effects.",
         "trait": true,

--- a/hero/mephisto.json
+++ b/hero/mephisto.json
@@ -20,6 +20,7 @@
   "abilities": {
     "Mephisto": [
       {
+        "uid": "92822f3",
         "name": "Skull Missile",
         "description": "Conjure a skull that travels in the target direction after 0.75 seconds, dealing 127 (+4% per level) damage to enemies hit and Slowing Heroes hit by 25% for 2 seconds.",
         "hotkey": "Q",
@@ -30,6 +31,7 @@
         "type": "basic"
       },
       {
+        "uid": "10efb19",
         "name": "Lightning Nova",
         "description": "A ring of lightning appears around Mephisto for 2.5 seconds. Enemies within the ring take 45 (+4% per level) damage every 0.25 seconds.  Each time a cast of Lightning Nova hits a Hero, its damage is increased by 3%, up to 30%.",
         "hotkey": "W",
@@ -40,6 +42,7 @@
         "type": "basic"
       },
       {
+        "uid": "4442d5a",
         "name": "Shade of Mephisto",
         "description": "Teleport to a location, dealing 78 (+4% per level) damage to nearby enemies and leaving behind a Shade of Mephisto at Mephisto's original location.  After 2.5 seconds, Mephisto is teleported back to the Shade's location.",
         "hotkey": "E",
@@ -50,6 +53,7 @@
         "type": "basic"
       },
       {
+        "uid": "812dcd5",
         "name": "Consume Souls",
         "description": "Channel for 2.5 seconds, revealing all enemy Heroes. After the Channel completes, all enemy Heroes take 357 (+4% per level) damage and are Slowed by 25% for 2.5 seconds.",
         "hotkey": "R",
@@ -60,6 +64,7 @@
         "type": "heroic"
       },
       {
+        "uid": "9334fe2",
         "name": "Durance of Hate",
         "description": "After 1 second, unleash a wave of evil spirits that Root the first enemy Hero hit for 2.5 seconds and deal 250 (+4% per level) damage to them over the same duration.  Durance of Hate spreads outwards from its initial target, Rooting and damaging additional nearby enemy Heroes.",
         "hotkey": "R",
@@ -70,6 +75,7 @@
         "type": "heroic"
       },
       {
+        "uid": "dcbb866",
         "name": "Lord Of Hatred",
         "description": "Hitting enemy Heroes with Basic Abilities reduces Mephisto's Basic Ability cooldowns.  Skull Missile and Shade of Mephisto grant 1.5 seconds of cooldown reduction per Hero hit, and Lightning Nova grants 0.3 seconds per Hero hit.",
         "trait": true,

--- a/hero/muradin.json
+++ b/hero/muradin.json
@@ -22,6 +22,7 @@
   "abilities": {
     "Muradin": [
       {
+        "uid": "e76a512",
         "name": "Storm Bolt",
         "description": "Throw a hammer, dealing 110 (+4% per level) damage to the first enemy hit and Stunning them for 1.25 seconds.  Quest: Hit 25 Heroes with Storm Bolt. Heroes who die within 2.5 seconds of being hit by Storm Bolt count as hitting 3 additional Heroes.  Reward: Storm Bolt pierces to hit an additional target, and Muradin's Basic Attacks reduce the cooldown of Storm Bolt by 1 second.",
         "hotkey": "Q",
@@ -32,6 +33,7 @@
         "type": "basic"
       },
       {
+        "uid": "abf1ff1",
         "name": "Thunder Clap",
         "description": "Blast nearby enemies for 96 (+4% per level) damage and Slow them by 25% for 2.5 seconds. Heroes hit also have their Attack Speed reduced by 25% for the duration.",
         "hotkey": "W",
@@ -42,6 +44,7 @@
         "type": "basic"
       },
       {
+        "uid": "ba49cdf",
         "name": "Dwarf Toss",
         "description": "Leap to target location, dealing 59 (+4% per level) damage to enemies on landing. Upon leaping, gain 25 Armor for 2 seconds, reducing damage taken by 25%.",
         "hotkey": "E",
@@ -52,6 +55,7 @@
         "type": "basic"
       },
       {
+        "uid": "b465bcf",
         "name": "Avatar",
         "description": "Transform for 20 seconds, gaining 1053 (+4% per level) Health.",
         "hotkey": "R",
@@ -62,6 +66,7 @@
         "type": "heroic"
       },
       {
+        "uid": "5251783",
         "name": "Haymaker",
         "description": "Stun target enemy Hero, and wind up a punch dealing 319 (+4% per level) damage and knocking the target back, hitting enemies in the way for 319 (+4% per level) damage and knocking them aside.",
         "hotkey": "R",
@@ -72,6 +77,7 @@
         "type": "heroic"
       },
       {
+        "uid": "7fad63a",
         "name": "Second Wind",
         "description": "Muradin restores 55 (+4% per level) Health per second when he has not taken damage for 4 seconds. When below 40% Health, increased to 111 (+4% per level) Health per second.",
         "trait": true,

--- a/hero/murky.json
+++ b/hero/murky.json
@@ -25,6 +25,7 @@
   "abilities": {
     "Murky": [
       {
+        "uid": "5dc2e3f",
         "name": "Slime",
         "description": "Deal 86 (+4% per level) damage and apply Slime on nearby enemies for 6 seconds, slowing them by 20%.  Deal 210 (+4% per level) damage to enemies who are already Slimed.",
         "hotkey": "Q",
@@ -34,6 +35,7 @@
         "type": "basic"
       },
       {
+        "uid": "d011dac",
         "name": "Pufferfish",
         "description": "Spit out a Pufferfish with 225 (+5.5% per level) health at the target point. After 3 seconds, the fish will blow up for 410 (+4% per level) damage. Deals 50% less damage to Structures.",
         "hotkey": "W",
@@ -43,6 +45,7 @@
         "type": "basic"
       },
       {
+        "uid": "17ceb60",
         "name": "Safety Bubble",
         "description": "Becomes Invulnerable for 2 seconds. While active, Murky cannot attack or use abilities.",
         "hotkey": "E",
@@ -52,6 +55,7 @@
         "type": "basic"
       },
       {
+        "uid": "1f121b8",
         "name": "March of the Murlocs",
         "description": "After 0.75 seconds, Murky commands a legion of Murlocs to march in a target direction, each one leaping onto the first enemy Hero or Structure they find. Each Murloc deals 125 (+4% per level) damage and slows its target by 15% for 5 seconds. Murlocs deal 50% damage to Structures.",
         "hotkey": "R",
@@ -61,6 +65,7 @@
         "type": "heroic"
       },
       {
+        "uid": "65800fe",
         "name": "Octo-Grab",
         "description": "Murky becomes Unstoppable and Stuns target enemy Hero for 3 seconds while he hits them for 1 damage a second.",
         "hotkey": "R",
@@ -70,6 +75,7 @@
         "type": "heroic"
       },
       {
+        "uid": "c2d8cd4",
         "name": "Spawn Egg",
         "description": "Place an Egg at target location, revealing the nearby area. Upon dying, Murky respawns at the Egg after 8 seconds. Murky only grants 25% of a real Hero's experience upon dying.  If Murky's Egg is killed, he is revealed to enemies for 15 seconds, and Spawn Egg is placed on cooldown.",
         "hotkey": "D",

--- a/hero/nazeebo.json
+++ b/hero/nazeebo.json
@@ -21,6 +21,7 @@
   "abilities": {
     "Nazeebo": [
       {
+        "uid": "4d96a1a",
         "name": "Corpse Spiders",
         "description": "Hurl a jar of spiders that deals 50 (+4% per level) damage. If it hits at least one enemy, create 3 Corpse Spiders that attack for 38 (+4% per level) damage. Spiders last for 4 seconds.",
         "hotkey": "Q",
@@ -31,6 +32,7 @@
         "type": "basic"
       },
       {
+        "uid": "92e3716",
         "name": "Zombie Wall",
         "description": "After 1 second, create a ring of Zombies surrounding the target area that deal 28 (+4% per level) damage and last for 3 seconds.",
         "hotkey": "W",
@@ -41,6 +43,7 @@
         "type": "basic"
       },
       {
+        "uid": "5d86b28",
         "name": "Plague of Toads",
         "description": "Create a wave of 3 Toads that explode on contact, dealing 119 (+4% per level) damage over 6 seconds. This effect stacks.  Stores up to 2 charges.",
         "hotkey": "E",
@@ -51,6 +54,7 @@
         "type": "basic"
       },
       {
+        "uid": "26a4060",
         "name": "Gargantuan",
         "description": "Summon a Gargantuan to guard an area for 20 seconds. Deals 100 (+4% per level) damage when summoned, attacks for 140 (+4% per level) damage, and can be ordered to stomp nearby enemies.",
         "hotkey": "R",
@@ -61,6 +65,7 @@
         "type": "heroic"
       },
       {
+        "uid": "8162ee9",
         "name": "Ravenous Spirit",
         "description": "Channel a Ravenous Spirit that deals 216 (+4% per level) damage per second. Cannot move while channeling. Lasts for 8 seconds.",
         "hotkey": "R",
@@ -71,6 +76,7 @@
         "type": "heroic"
       },
       {
+        "uid": "ef9b6a8",
         "name": "Voodoo Ritual",
         "description": "Nazeebo's Basic Attacks and Abilities poison Non-Heroic enemies, causing them to take 67 (+4% per level) additional damage over 6 seconds.  Quest: If a Minion dies while poisoned by Voodoo Ritual, Nazeebo permanently gains 6 Health and 1 Mana.",
         "trait": true,
@@ -81,6 +87,7 @@
     ],
     "WitchDoctorGargantuan": [
       {
+        "uid": "8b3e463",
         "name": "Gargantuan Stomp",
         "description": "Order the Gargantuan to stomp, dealing 240 (+4% per level) damage to nearby enemies and slowing them by 30% for 2 seconds.",
         "hotkey": "R",
@@ -90,6 +97,7 @@
         "type": "subunit"
       },
       {
+        "uid": "fb7b2bc",
         "name": "Gargantuan Stomp",
         "description": "Order the Gargantuan to stomp, dealing 240 (+4% per level) damage to nearby enemies and slowing them by 30% for 2 seconds.",
         "hotkey": "R",

--- a/hero/nova.json
+++ b/hero/nova.json
@@ -20,6 +20,7 @@
   "abilities": {
     "Nova": [
       {
+        "uid": "4d1365a",
         "name": "Snipe",
         "description": "Deal 230 (+4% per level) damage to the first enemy hit.  Passive: Hitting an enemy Hero with Snipe permanently increases the damage of Snipe by 6%, stacking up to 30%. Gain an additional 25% damage bonus at maximum stacks. All stacks are lost if Snipe fails to hit an enemy.",
         "hotkey": "Q",
@@ -30,6 +31,7 @@
         "type": "basic"
       },
       {
+        "uid": "7e7e227",
         "name": "Pinning Shot",
         "description": "Deal 100 (+4% per level) damage to an enemy and Slow them by 40% for 2.25 seconds.",
         "hotkey": "W",
@@ -40,6 +42,7 @@
         "type": "basic"
       },
       {
+        "uid": "e99ae67",
         "name": "Holo Decoy",
         "description": "Create a Decoy for 5 seconds with 100% of Nova's current Health that attacks enemies, dealing 10% of Nova's base damage. Whenever a Decoy takes damage, it deals that amount of damage to itself, effectively doubling the damage it takes.  Using this Ability does not break Stealth.",
         "hotkey": "E",
@@ -50,6 +53,7 @@
         "type": "basic"
       },
       {
+        "uid": "d043b6e",
         "name": "Triple Tap",
         "description": "Locks in on the target Hero, then fires 3 shots that hit the first Hero or Structure they come in contact with for 372 (+4% per level) damage each.",
         "hotkey": "R",
@@ -60,6 +64,7 @@
         "type": "heroic"
       },
       {
+        "uid": "1b5dbc0",
         "name": "Precision Strike",
         "description": "After a 1.5 second delay, deals 435 (+4% per level) damage to enemies within an area. Unlimited range.",
         "hotkey": "R",
@@ -70,6 +75,7 @@
         "type": "heroic"
       },
       {
+        "uid": "56e3463",
         "name": "Permanent Cloak",
         "description": "Gain Stealth when out of combat for 3 seconds. Taking damage, attacking, using Abilities, or Channeling ends Stealth. Remaining stationary for at least 1.5 seconds while Stealthed grants Invisible.  Passive: Gain 15% Movement Speed while Stealthed.",
         "trait": true,
@@ -78,6 +84,7 @@
         "type": "trait"
       },
       {
+        "uid": "d36cf3d",
         "name": "Ghost Protocol",
         "description": "Activate to instantly grant Stealth to Nova and spawn a Holo Decoy at her location. Nova is Unrevealable for the first 0.5 seconds when Stealthed by Ghost Protocol.",
         "hotkey": "1",

--- a/hero/orphea.json
+++ b/hero/orphea.json
@@ -23,6 +23,7 @@
   "abilities": {
     "Orphea": [
       {
+        "uid": "67b9e5d",
         "name": "Shadow Waltz",
         "description": "After 0.5 seconds, deal 165 (+4% per level) damage to enemies in a line.  Hitting a Hero with Shadow Waltz sets its cooldown to 2 seconds, refunds 40 Mana, and causes Orphea to dash a short distance upon moving.",
         "hotkey": "Q",
@@ -33,6 +34,7 @@
         "type": "basic"
       },
       {
+        "uid": "b534c77",
         "name": "Chomp",
         "description": "After 0.625 seconds, deal 285 (+4% per level) damage to nearby enemies in front of Orphea.",
         "hotkey": "W",
@@ -43,6 +45,7 @@
         "type": "basic"
       },
       {
+        "uid": "c2e0ba6",
         "name": "Dread",
         "description": "Release a wave of dread that deals 85 (+4% per level) damage to enemies hit. Dread erupts 0.75 seconds after reaching the end of its path, dealing 175 (+4% per level) damage and Slowing enemies in the area by 25% for 2 seconds.",
         "hotkey": "E",
@@ -53,6 +56,7 @@
         "type": "basic"
       },
       {
+        "uid": "a2a6a43",
         "name": "Eternal Feast",
         "description": "After 1.5 seconds, deal 210 (+4% per level) damage in an area. Eternal Feast repeats every 1 second as long as it hits an enemy Hero.",
         "hotkey": "R",
@@ -63,6 +67,7 @@
         "type": "heroic"
       },
       {
+        "uid": "13f8182",
         "name": "Crushing Jaws",
         "description": "After 1.25 seconds, pull enemies in an area towards the center, dealing 250 (+4% per level) damage and Stunning them for 0.5 seconds.",
         "hotkey": "R",
@@ -73,6 +78,7 @@
         "type": "heroic"
       },
       {
+        "uid": "0acb8cb",
         "name": "Overflowing Chaos",
         "description": "Hitting an enemy Hero with a Basic Ability grants 1 Chaos. Chaos can stack up to 3 times.  While Orphea has Chaos, her Basic Attacks against Heroes consume all Chaos, dealing 50% increased damage per stack, and healing for 100% of the damage dealt.",
         "trait": true,

--- a/hero/probius.json
+++ b/hero/probius.json
@@ -20,6 +20,7 @@
   "abilities": {
     "Probius": [
       {
+        "uid": "0d2670d",
         "name": "Disruption Pulse",
         "description": "Fire a burst of energy forward, dealing 142 (+5% per level) damage to all enemies it passes through.  Hitting the center of a Warp Rift will cause it to explode, dealing additional damage.",
         "hotkey": "Q",
@@ -30,6 +31,7 @@
         "type": "basic"
       },
       {
+        "uid": "543ed1c",
         "name": "Warp Rift",
         "description": "Open an unstable Warp Rift at a location that takes 1.25 seconds to arm, which then slows nearby enemies by 25% lasting 9 seconds.  Armed Warp Rifts explode when hit by Disruption Pulse, dealing 261 (+5% per level) damage to nearby enemies.  Stores up to 2 charges.",
         "hotkey": "W",
@@ -40,6 +42,7 @@
         "type": "basic"
       },
       {
+        "uid": "3119fc6",
         "name": "Photon Cannon",
         "description": "Warp in a Photon Cannon that deals 105 (+4% per level) damage per second. Lasts for 13 seconds.  Must be placed within a Pylon's Power Field.  Deactivates if it doesn't have a Pylon powering it.",
         "hotkey": "E",
@@ -49,6 +52,7 @@
         "type": "basic"
       },
       {
+        "uid": "c8b8812",
         "name": "Pylon Overcharge",
         "description": "Increase the size of Pylon power fields and allow them to attack enemies within it for 96 (+4% per level) damage per second. Lasts 10 seconds.",
         "hotkey": "R",
@@ -59,6 +63,7 @@
         "type": "heroic"
       },
       {
+        "uid": "b43b831",
         "name": "Null Gate",
         "description": "Vector Targeting Project a barrier of negative energy in the target direction that lasts 4 seconds. Enemies who touch the barrier take 68 (+4% per level) damage per second and are Slowed by 80% for as long as they remain in contact with it.",
         "hotkey": "R",
@@ -69,6 +74,7 @@
         "type": "heroic"
       },
       {
+        "uid": "ac0b052",
         "name": "Warp In Pylon",
         "description": "Warp in a Pylon that generates a Power Field and grants vision of the surrounding area. Probius only regenerates mana while inside a Power Field.  Up to 2 Pylons can be active at a time.",
         "hotkey": "D",
@@ -79,6 +85,7 @@
         "type": "trait"
       },
       {
+        "uid": "e6b08e2",
         "name": "Worker Rush",
         "description": "Activate to gain an additional 60% Movement Speed for 5 seconds. Taking damage ends this effect early.  Worker Rush is always active while at the Hall of Storms.  Passive: Probius moves 10% faster by hovering over the ground.",
         "hotkey": "Z",

--- a/hero/qhira.json
+++ b/hero/qhira.json
@@ -23,6 +23,7 @@
   "abilities": {
     "Qhira": [
       {
+        "uid": "f2a96ea",
         "name": "Carnage",
         "description": "Unleash your sword in the target direction, continuously dealing 30 (+4% per level) damage to enemies caught in its path.",
         "hotkey": "Q",
@@ -33,6 +34,7 @@
         "type": "basic"
       },
       {
+        "uid": "ca2dc4e",
         "name": "Blood Rage",
         "description": "Passive: Basic Attack and Ability damage cause enemies to bleed for 44 (+4% per level) damage over 4 seconds. Stacks 5 times.  Active: Qhira deals 32 (+4% per level) damage and heals for 85 (+4% per level) Health per enemy Hero affected. Damage and healing is increased by 50% per each additional stack on that Hero.",
         "hotkey": "W",
@@ -43,6 +45,7 @@
         "type": "basic"
       },
       {
+        "uid": "2072b82",
         "name": "Revolving Sweep",
         "description": "Fly into your target dealing 108 (+4% per level) damage, knocking them away and Stunning them for 0.75 seconds.",
         "hotkey": "E",
@@ -51,6 +54,7 @@
         "type": "basic"
       },
       {
+        "uid": "8a2e369",
         "name": "Revolving Sweep",
         "description": "Attach your sword on the first enemy Hero hit, dealing 96 (+4% per level) damage and Stunning them for 0.25 seconds. Once attached, Qhira becomes immune to all effects, swinging around the target for 2.75 seconds and dealing 105 (+4% per level) damage to enemies between you and the target.  Re-activate to send you to the target's location knocking them away, dealing 108 (+4% per level) damage and Stunning them for 0.75 seconds.",
         "hotkey": "E",
@@ -61,6 +65,7 @@
         "type": "basic"
       },
       {
+        "uid": "cb30177",
         "name": "Unrelenting Strikes",
         "description": "Deal 44 (+4% per level) damage to nearby enemies every 0.5 seconds for 2.5 seconds as your sword grows outward. Upon expiring, deal 83 (+4% per level) damage to nearby enemy Heroes and Stun them for 0.75 seconds.",
         "hotkey": "R",
@@ -71,6 +76,7 @@
         "type": "heroic"
       },
       {
+        "uid": "6609292",
         "name": "Final Strike",
         "description": "After 1 second, deal 415 (+4% per level) damage to enemies in a line. This damage is increased by 25% against enemy Heroes who are below 50% Health.",
         "hotkey": "R",
@@ -81,6 +87,7 @@
         "type": "heroic"
       },
       {
+        "uid": "509bbba",
         "name": "Grappling Hook",
         "description": "Qhira fires a grappling hook that pulls her to terrain it contacts. If an enemy Hero is hit, they take 35 (+4% per level) damage and Qhira launches at them, kicking them for an additional 108 (+4% per level) damage.  Can be used while Revolving Sweep is active.",
         "trait": true,

--- a/hero/ragnaros.json
+++ b/hero/ragnaros.json
@@ -21,6 +21,7 @@
   "abilities": {
     "Ragnaros": [
       {
+        "uid": "cd59533",
         "name": "Empower Sulfuras",
         "description": "Ragnaros's next Basic Attack is instant, dealing 191 (+4% per level) Ability damage in an area, and heals for 20% of the damage dealt. Healing doubled versus Heroes.  Molten Core: Molten Swing Stun and damage nearby enemies.",
         "hotkey": "Q",
@@ -31,6 +32,7 @@
         "type": "basic"
       },
       {
+        "uid": "2f35dd0",
         "name": "Living Meteor",
         "description": "Vector Targeting Summon a meteor at the target point that deals 68 (+4% per level) damage, then rolls in the target direction dealing 272 (+4% per level) damage per second for 1.75 seconds.  Molten Core: Meteor Shower Drop a line of meteor impacts.",
         "hotkey": "W",
@@ -41,6 +43,7 @@
         "type": "basic"
       },
       {
+        "uid": "b34d04d",
         "name": "Blast Wave",
         "description": "Ignite Ragnaros or an ally, granting 25% Movement Speed for 1.5 seconds before exploding dealing 104 (+4% per level) damage to nearby enemies.  Molten Core: Explosive Rune Cause a delayed explosion in a large area.",
         "hotkey": "E",
@@ -51,6 +54,7 @@
         "type": "basic"
       },
       {
+        "uid": "9b8215f",
         "name": "Sulfuras Smash",
         "description": "Hurl Sulfuras at the target area, landing after 0.75 seconds, dealing 198 (+4% per level) damage. Enemies in the center take 594 (+4% per level) damage instead and are Stunned for 0.5 seconds.",
         "hotkey": "R",
@@ -61,6 +65,7 @@
         "type": "heroic"
       },
       {
+        "uid": "cb554cf",
         "name": "Lava Wave",
         "description": "Release a wave of lava from Ragnaros's Core that travels down the targeted lane, dealing 240 (+4% per level) damage per second to non-Structure enemies in its path and instantly killing enemy Minions. Damage increased by 100% versus Heroes.",
         "hotkey": "R",
@@ -71,6 +76,7 @@
         "type": "heroic"
       },
       {
+        "uid": "9f58180",
         "name": "Molten Core",
         "description": "Channel on an allied or destroyed Fort or Keep to replace it with Ragnaros's ultimate form, temporarily gaining new Abilities, having 3996 (+4% per level) Health that burns away over 18 seconds.  Ragnaros returns to his normal form upon losing all Health in Molten Core.",
         "hotkey": "D",
@@ -83,6 +89,7 @@
     ],
     "RagnarosBigRag": [
       {
+        "uid": "1553849",
         "name": "Molten Swing",
         "description": "Swing Sulfuras in a wide arc, dealing 161 (+4% per level) damage and Stunning enemies for 1 second.  Damage increased by 25% versus Minions, Mercenaries, and Monsters.",
         "hotkey": "Q",
@@ -92,6 +99,7 @@
         "type": "subunit"
       },
       {
+        "uid": "d5c7b3c",
         "name": "Meteor Shower",
         "description": "Vector Targeting Summon 3 meteors at the target point that fall in the target direction. Each meteor deals 151 (+4% per level) damage and slows enemies by 25% for 2 seconds.  Damage increased by 25% versus Minions, Mercenaries, and Monsters.",
         "hotkey": "W",
@@ -101,6 +109,7 @@
         "type": "subunit"
       },
       {
+        "uid": "974f66b",
         "name": "Explosive Rune",
         "description": "Create a rune that deals 285 (+4% per level) damage to non-Structure enemies after 1.5 seconds.  Damage increased by 25% versus Minions, Mercenaries, and Monsters.",
         "hotkey": "E",
@@ -110,6 +119,7 @@
         "type": "subunit"
       },
       {
+        "uid": "93601b9",
         "name": "Sulfuras Smash",
         "description": "Hurl Sulfuras at the target area, landing after 0.75 seconds, dealing 198 (+4% per level) damage. Enemies in the center take 594 (+4% per level) damage instead and are Stunned for 0.5 seconds.",
         "hotkey": "R",

--- a/hero/raynor.json
+++ b/hero/raynor.json
@@ -19,6 +19,7 @@
   "abilities": {
     "Raynor": [
       {
+        "uid": "d135872",
         "name": "Penetrating Round",
         "description": "Deal 220 (+4% per level) damage, knock back, and Slow enemies in a line by 20% for 2 seconds. Enemies close to Raynor are knocked back further.",
         "hotkey": "Q",
@@ -29,6 +30,7 @@
         "type": "basic"
       },
       {
+        "uid": "7f67c07",
         "name": "Inspire",
         "description": "Raynor and all nearby allied Minions and Mercenaries gain 30% Attack Speed and 10% Movement Speed for 4 seconds.  Casting Inspire resets Raynor's Basic Attack cooldown.",
         "hotkey": "W",
@@ -39,6 +41,7 @@
         "type": "basic"
       },
       {
+        "uid": "c6fbec0",
         "name": "Adrenaline Rush",
         "description": "Heal Raynor for 25% of his maximum Health over 1 second. Raynor's Basic Attacks lower the cooldown of this by 0.5 seconds, doubled against Heroes.",
         "hotkey": "E",
@@ -49,6 +52,7 @@
         "type": "basic"
       },
       {
+        "uid": "7847316",
         "name": "Hyperion",
         "description": "Order the Hyperion to make a strafing run for 12 seconds, hitting up to 4 enemies for 66 (+4% per level) damage every second. Every 4 seconds, it can fire its Yamato Cannon at a Structure, dealing 794 (+4% per level) damage.",
         "hotkey": "R",
@@ -59,6 +63,7 @@
         "type": "heroic"
       },
       {
+        "uid": "f17494f",
         "name": "Give 'Em Some Pepper",
         "description": "Every 4th Basic Attack splashes in a small area and deals 125% more damage to the main target.",
         "trait": true,
@@ -67,6 +72,7 @@
         "type": "trait"
       },
       {
+        "uid": "e89dd8b",
         "name": "Command Raynor's Raider",
         "description": "Order the Banshee to attack an enemy.",
         "hotkey": "R",

--- a/hero/rehgar.json
+++ b/hero/rehgar.json
@@ -23,6 +23,7 @@
   "abilities": {
     "Rehgar": [
       {
+        "uid": "eba8e87",
         "name": "Chain Heal",
         "description": "Heal an ally with a wave of healing for 260 (+4% per level) Health. The wave then bounces 2 times to nearby allies within 7 range, restoring 260 (+4% per level) Health to them.",
         "hotkey": "Q",
@@ -33,6 +34,7 @@
         "type": "basic"
       },
       {
+        "uid": "718299c",
         "name": "Lightning Shield",
         "description": "Imbue an ally with lightning dealing 64 (+4% per level) damage a second to nearby enemies. Lasts 5 seconds.",
         "hotkey": "W",
@@ -43,6 +45,7 @@
         "type": "basic"
       },
       {
+        "uid": "5aa4eaf",
         "name": "Earthbind Totem",
         "description": "Create a totem that slows nearby enemies by 35%. The totem has 217 (+4% per level) Health and lasts for 8 seconds.",
         "hotkey": "E",
@@ -53,6 +56,7 @@
         "type": "basic"
       },
       {
+        "uid": "9216183",
         "name": "Bloodlust",
         "description": "Grant nearby allied Heroes 40% Attack Speed and 25% Movement Speed and causes them to heal for 30% of the Basic Attack damage to their primary target. Lasts for 8 seconds.",
         "hotkey": "R",
@@ -63,6 +67,7 @@
         "type": "heroic"
       },
       {
+        "uid": "14acc53",
         "name": "Ancestral Healing",
         "description": "After 1 second, heal an allied Hero for 1180 (+4% per level) Health.",
         "hotkey": "R",
@@ -73,6 +78,7 @@
         "type": "heroic"
       },
       {
+        "uid": "8734a0b",
         "name": "Ghost Wolf",
         "description": "Increases Movement Speed by 20%.",
         "hotkey": "Z",
@@ -82,6 +88,7 @@
         "type": "mount"
       },
       {
+        "uid": "2bf11d7",
         "name": "Ghost Wolf",
         "description": "Instead of using a mount, Rehgar transforms into a Ghost Wolf with 20% increased Movement Speed. Basic Attacks in Ghost Wolf form cause him to lunge at his target and deal 75% bonus damage. Dealing damage, using Abilities, and channeling cancels Ghost Wolf form.",
         "trait": true,

--- a/hero/rexxar.json
+++ b/hero/rexxar.json
@@ -21,6 +21,7 @@
   "abilities": {
     "Rexxar": [
       {
+        "uid": "75987bf",
         "name": "Spirit Swoop",
         "description": "Deal 141 (+4% per level) damage to enemies in a line, slowing them by 30% for 2 seconds.",
         "hotkey": "Q",
@@ -31,6 +32,7 @@
         "type": "basic"
       },
       {
+        "uid": "5f656bf",
         "name": "Misha, Charge!",
         "description": "Misha charges in a line, dealing 150 (+4% per level) damage and stunning enemies for 1.25 seconds.",
         "hotkey": "W",
@@ -41,6 +43,7 @@
         "type": "basic"
       },
       {
+        "uid": "01525a6",
         "name": "Mend Pet",
         "description": "Heal Misha for 714 (+4% per level) Health over 5 seconds.",
         "hotkey": "E",
@@ -51,6 +54,7 @@
         "type": "basic"
       },
       {
+        "uid": "58265ee",
         "name": "Unleash the Boars",
         "description": "Release a herd of boars that track down all enemy Heroes in a direction, dealing 110 (+4% per level) damage, revealing, and slowing enemies by 40% for 5 seconds.",
         "hotkey": "R",
@@ -61,6 +65,7 @@
         "type": "heroic"
       },
       {
+        "uid": "1bbda6e",
         "name": "Bestial Wrath",
         "description": "Increases Misha's Basic Attack damage by 200% for 12 seconds.",
         "hotkey": "R",
@@ -71,6 +76,7 @@
         "type": "heroic"
       },
       {
+        "uid": "9273f1a",
         "name": "Misha, Focus!",
         "description": "Passive: Misha gains 15% move speed.  Command Misha to attack a specific enemy or move to a point and wait.  Targeting Rexxar commands Misha to retreat to his position, gaining 30% move speed until she reaches Rexxar.  Targeting Misha commands her to hold her current position.",
         "hotkey": "D",

--- a/hero/samuro.json
+++ b/hero/samuro.json
@@ -21,6 +21,7 @@
   "abilities": {
     "Samuro": [
       {
+        "uid": "e8420b6",
         "name": "Mirror Image",
         "description": "Teleport a short distance in the direction of the mouse cursor, creating 2 Mirror Images for 18 seconds with 100% of Samuro's current Health that Basic Attack enemies for 9 (+4% per level) damage. Whenever an Image takes damage, it deals that amount of damage to itself, effectively doubling the damage it takes.  Maximum 2 Mirror Images can be active at at time. Using Mirror Image removes most negative effects from Samuro.",
         "hotkey": "Q",
@@ -30,6 +31,7 @@
         "type": "basic"
       },
       {
+        "uid": "e173a9c",
         "name": "Critical Strike",
         "description": "Samuro's next Basic Attack within 8 seconds will be a Critical Strike, dealing 50% increased damage. This also applies to Images, and does not break Wind Walk.  Passive: Samuro and his Images deal a Critical Strike on every 4th Basic Attack.",
         "hotkey": "W",
@@ -39,6 +41,7 @@
         "type": "basic"
       },
       {
+        "uid": "6ad1df4",
         "name": "Wind Walk",
         "description": "Grant Samuro Stealth for up to 10 seconds or until he attacks, uses an Ability, or takes damage.  While Stealthed, Samuro's Movement Speed is increased by 25% and he can pass through other units. Remaining stationary for at least 1.5 seconds while Stealthed grants Invisible.  Samuro is Unrevealable for the first 1 second of Wind Walk.",
         "hotkey": "E",
@@ -48,6 +51,7 @@
         "type": "basic"
       },
       {
+        "uid": "46ea882",
         "name": "Bladestorm",
         "description": "Cause a Bladestorm of destructive force around Samuro for 4 seconds, making him Unstoppable and dealing 235 (+4% per level) damage per second to nearby enemies.",
         "hotkey": "R",
@@ -57,6 +61,7 @@
         "type": "heroic"
       },
       {
+        "uid": "a07a089",
         "name": "Image Transmission",
         "description": "Activate to switch places with a target Mirror Image, removing most negative effects from Samuro and the Mirror Image.  Advancing Strikes  Basic Attacks against enemy Heroes increase Samuro's Movement Speed by 25% for 2 seconds.",
         "hotkey": "R",
@@ -67,6 +72,7 @@
         "type": "trait"
       },
       {
+        "uid": "89972c2",
         "name": "Illusion Master",
         "description": "Mirror Images can be controlled individually or as a group and their damage is increased by 100%.  Passive: Image Transmission's cooldown is reduced to 10 seconds.",
         "hotkey": "R",
@@ -76,6 +82,7 @@
         "type": "heroic"
       },
       {
+        "uid": "e305f55",
         "name": "Select Samuro",
         "description": "Select Samuro  Issue orders to Samuro only.",
         "hotkey": "1",
@@ -84,6 +91,7 @@
         "type": "activable"
       },
       {
+        "uid": "89be25e",
         "name": "Select All",
         "description": "Select All  Issue orders to Samuro and all Mirror Images.",
         "hotkey": "2",

--- a/hero/sgthammer.json
+++ b/hero/sgthammer.json
@@ -20,6 +20,7 @@
   "abilities": {
     "Sgt. Hammer": [
       {
+        "uid": "2d5145f",
         "name": "Spider Mines",
         "description": "Create 3 mines that arm after 1.25 seconds. Mines detonate when an enemy comes in range, dealing 96 (+4% per level) damage to nearby enemies and Slowing them by 25% for 1.5 seconds.  Siege Mode: Cast range increased by 100%.",
         "hotkey": "Q",
@@ -30,6 +31,7 @@
         "type": "basic"
       },
       {
+        "uid": "ff8e49f",
         "name": "Concussive Blast",
         "description": "Deal 141 (+4% per level) damage to enemies in front of Sgt. Hammer and knock them back.  Siege Mode: Radius increased by 50%.",
         "hotkey": "W",
@@ -40,6 +42,7 @@
         "type": "basic"
       },
       {
+        "uid": "7c9e801",
         "name": "Neosteel Plating",
         "description": "Gain 25 Armor for 2 seconds.  Siege Mode: Grants 100% more Armor.",
         "hotkey": "E",
@@ -50,6 +53,7 @@
         "type": "basic"
       },
       {
+        "uid": "7c907f5",
         "name": "Napalm Strike",
         "description": "Deals 164 (+4% per level) damage on impact, and leaves a napalm area that deals 50 (+4% per level) damage per second. Lasts for 4 seconds.",
         "hotkey": "R",
@@ -60,6 +64,7 @@
         "type": "heroic"
       },
       {
+        "uid": "3cddb88",
         "name": "Blunt Force Gun",
         "description": "Fire a missile across the battlefield, dealing 500 (+3% per level) damage to non-Structure enemies in its path.",
         "hotkey": "R",
@@ -70,6 +75,7 @@
         "type": "heroic"
       },
       {
+        "uid": "fc18aeb",
         "name": "Siege Mode",
         "description": "Activate to enter Siege Mode. While in Siege Mode, Basic Attacks deal 20% more damage, have 100% increased range, and deal 25% of their damage as splash damage around the target.",
         "hotkey": "D",
@@ -80,6 +86,7 @@
         "type": "trait"
       },
       {
+        "uid": "f1a3526",
         "name": "Thrusters",
         "description": "Increase Movement Speed by 60% for 4 seconds. Thrusters are always active while at the Hall of Storms. Activating Thrusters cancels Siege Mode.",
         "hotkey": "Z",

--- a/hero/sonya.json
+++ b/hero/sonya.json
@@ -23,6 +23,7 @@
   "abilities": {
     "Sonya": [
       {
+        "uid": "dc4c43c",
         "name": "Ancient Spear",
         "description": "Throw out a spear that pulls Sonya to the first enemy hit, dealing 173 (+4% per level) damage and briefly stunning them. If this hits an enemy, generate 40 Fury.",
         "hotkey": "Q",
@@ -32,6 +33,7 @@
         "type": "basic"
       },
       {
+        "uid": "ae73b5d",
         "name": "Seismic Slam",
         "description": "Deals 176 (+4% per level) damage to the target enemy, and 44 (+4% per level) to enemies behind the target.",
         "hotkey": "W",
@@ -42,6 +44,7 @@
         "type": "basic"
       },
       {
+        "uid": "73c7823",
         "name": "Whirlwind",
         "description": "Deals 126 (+4% per level) damage a second to nearby enemies for 3 seconds, healing for 25% of damage dealt. Healing tripled versus Heroes.",
         "hotkey": "E",
@@ -52,6 +55,7 @@
         "type": "basic"
       },
       {
+        "uid": "241be03",
         "name": "Leap",
         "description": "Leap into the air, dealing 135 (+4% per level) damage to nearby enemies, and stunning them for 1.25 seconds.",
         "hotkey": "R",
@@ -61,6 +65,7 @@
         "type": "heroic"
       },
       {
+        "uid": "0944b4a",
         "name": "Wrath of the Berserker",
         "description": "Increase damage dealt by 40%. Reduce the duration of Stuns, Roots, and Slows against Sonya by 50%. Lasts 15 seconds, and extends by 1 second for every 10 Fury gained.",
         "hotkey": "R",
@@ -70,6 +75,7 @@
         "type": "heroic"
       },
       {
+        "uid": "df02f0a",
         "name": "Fury",
         "description": "Use Fury instead of Mana, which is gained by taking damage or dealing Basic Attack damage. Using a Basic or Heroic Ability grants 10% Movement Speed for 4 seconds.",
         "trait": true,

--- a/hero/stitches.json
+++ b/hero/stitches.json
@@ -21,6 +21,7 @@
   "abilities": {
     "Stitches": [
       {
+        "uid": "43f3078",
         "name": "Hook",
         "description": "Pull the first enemy hit towards Stitches and deal 91 (+4% per level) damage.",
         "hotkey": "Q",
@@ -31,6 +32,7 @@
         "type": "basic"
       },
       {
+        "uid": "7fb2054",
         "name": "Slam",
         "description": "Deal 104 (+4% per level) damage to enemies within the target area. Enemies in the inner impact area take 40% more damage and are Slowed by 40% for 1.5 seconds.",
         "hotkey": "W",
@@ -41,6 +43,7 @@
         "type": "basic"
       },
       {
+        "uid": "8da45d9",
         "name": "Devour",
         "description": "Deal 319 (+4% per level) damage to non-Heroic units, or 114 (+4% per level) damage to Heroes. Restores 20% of Stitches's maximum Health.",
         "hotkey": "E",
@@ -51,6 +54,7 @@
         "type": "basic"
       },
       {
+        "uid": "6c67c81",
         "name": "Putrid Bile",
         "description": "Emit bile that deals 37 (+4% per level) damage per second to enemies within, Slowing them by 35% for 1.5 seconds. Gain 20% Movement Speed while emitting bile. Lasts 8 seconds.",
         "hotkey": "R",
@@ -61,6 +65,7 @@
         "type": "heroic"
       },
       {
+        "uid": "613b9bd",
         "name": "Gorge",
         "description": "Consume an enemy Hero, trapping them for 4 seconds. When Gorge ends, the enemy Hero takes 274 (+4% per level) damage. The trapped Hero cannot move or act and doesn't take damage from other sources.",
         "hotkey": "R",
@@ -71,6 +76,7 @@
         "type": "heroic"
       },
       {
+        "uid": "462a5e4",
         "name": "Helping Hand",
         "description": "Activate to use Hook that can hit allied Heroes. When used to pull allies, the cooldown of Hook is reduced by 50%.",
         "hotkey": "1",
@@ -81,6 +87,7 @@
         "type": "activable"
       },
       {
+        "uid": "f12fad4",
         "name": "Vile Cleaver",
         "description": "Basic Attacks splash Vile Gas, poisoning nearby enemies for 45 (+4% per level) damage over 3 seconds. Re-applying Vile Gas increases its current duration to a maximum of 10 seconds.",
         "trait": true,

--- a/hero/stukov.json
+++ b/hero/stukov.json
@@ -21,6 +21,7 @@
   "abilities": {
     "Stukov": [
       {
+        "uid": "e4aaf6b",
         "name": "Healing Pathogen",
         "description": "Infest an allied Hero with a Healing Pathogen that heals the target for 222 (+4% per level) Health over 4.5 seconds. Healing Pathogens can spread to a nearby allied Hero every 0.75 seconds.  Each cast of Healing Pathogen can only spread to each allied Hero 1 time.",
         "hotkey": "Q",
@@ -31,6 +32,7 @@
         "type": "basic"
       },
       {
+        "uid": "f42e57f",
         "name": "Weighted Pustule",
         "description": "Hurl a pustule that impacts all enemy Heroes in its path, dealing 20 (+4% per level) damage and Slowing by 5%, increasing to 50% over 3 seconds. Deals an additional 80 (+4% per level) damage upon expiring or being removed.",
         "hotkey": "W",
@@ -41,6 +43,7 @@
         "type": "basic"
       },
       {
+        "uid": "d6ef0a1",
         "name": "Lurking Arm",
         "description": "Channel at a target location, creating an area that deals 136 (+4% per level) damage per second to non-Structure enemies and Silences them. Deals 50% reduced damage to non-Heroes.  Does not cost Mana while Channeling, and lasts until canceled or interrupted.",
         "hotkey": "E",
@@ -51,6 +54,7 @@
         "type": "basic"
       },
       {
+        "uid": "16e2f04",
         "name": "Flailing Swipe",
         "description": "Swipe 3 times in front of Stukov over 1.75 seconds, dealing 48 (+4% per level) damage to enemies hit and knocking them away. Each swipe is larger than the previous.",
         "hotkey": "R",
@@ -61,6 +65,7 @@
         "type": "heroic"
       },
       {
+        "uid": "922f72e",
         "name": "Massive Shove",
         "description": "Extend Stukov's arm. If it hits an enemy Hero, they are rapidly shoved until they collide with terrain, dealing 190 (+4% per level) damage and Stunning them for 0.5 seconds. Stukov gains 50 Armor while shoving an enemy.",
         "hotkey": "R",
@@ -71,6 +76,7 @@
         "type": "heroic"
       },
       {
+        "uid": "5ab03e7",
         "name": "Bio-Kill Switch",
         "description": "Activate to detonate all of Stukov's Viruses. Each Healing Pathogen heals its target for 450 (+4% per level) Health, and each Weighted Pustule does 100 (+4% per level) damage and Slows its target by 70% for 2 seconds.  Can be cast while Channeling Lurking Arm.",
         "hotkey": "D",

--- a/hero/sylvanas.json
+++ b/hero/sylvanas.json
@@ -23,6 +23,7 @@
   "abilities": {
     "Sylvanas": [
       {
+        "uid": "b0179a0",
         "name": "Withering Fire",
         "description": "Shoot the closest enemy up to 5 times over 1.5 seconds for 39 (+4% per level) damage, prioritizing Heroes. Cooldown is reset on getting a Takedown.",
         "hotkey": "Q",
@@ -33,6 +34,7 @@
         "type": "basic"
       },
       {
+        "uid": "a6babc6",
         "name": "Shadow Dagger",
         "description": "Throw a dagger at a target enemy that deals 30 (+4% per level) damage and an additional 150 (+4% per level) damage over 2.5 seconds. Damage dealt by Sylvanas to the initial target spreads Shadow Dagger to all nearby enemies.",
         "hotkey": "W",
@@ -43,6 +45,7 @@
         "type": "basic"
       },
       {
+        "uid": "ad3d91d",
         "name": "Haunting Wave",
         "description": "Send forth a wave of banshees dealing 114 (+4% per level) damage to all targets. Reactivate to teleport to the banshees' location.",
         "hotkey": "E",
@@ -53,6 +56,7 @@
         "type": "basic"
       },
       {
+        "uid": "5ddce37",
         "name": "Wailing Arrow",
         "description": "Shoot an arrow that can be reactivated to deal 228 (+4% per level) damage and Silence enemies in an area for 2.5 seconds. The arrow detonates automatically if it reaches maximum range.",
         "hotkey": "R",
@@ -63,6 +67,7 @@
         "type": "heroic"
       },
       {
+        "uid": "2beb0f7",
         "name": "Mind Control",
         "description": "After 0.25 seconds, fire a missile that Mind Controls the first enemy Hero hit. Heroes hit are Silenced, Slowed by 30%, and forced to walk towards Sylvanas for 1.75 seconds.",
         "hotkey": "R",
@@ -73,6 +78,7 @@
         "type": "heroic"
       },
       {
+        "uid": "c419fd8",
         "name": "Black Arrows",
         "description": "Activate to cause all Basic Attacks and Abilities to Stun Minions, non-Elite Mercenaries, and Structures for 3 seconds. Lasts for 10 seconds.   Banshee's Curse  Basic Attacks infect enemies with Banshee's Curse for 3 seconds, stacking up to 3 times. Deal 25% more damage to enemies with 3 stacks.",
         "trait": true,

--- a/hero/tassadar.json
+++ b/hero/tassadar.json
@@ -21,6 +21,7 @@
   "abilities": {
     "Tassadar": [
       {
+        "uid": "3301850",
         "name": "Plasma Shield",
         "description": "Grant an allied Hero, Minion, or Structure a Shield that absorbs 455 (+4% per level) damage over 4 seconds. If the target is a Hero, they heal for 40% of their Basic Attack damage done while Shielded.",
         "hotkey": "Q",
@@ -31,6 +32,7 @@
         "type": "basic"
       },
       {
+        "uid": "80154d4",
         "name": "Psionic Storm",
         "description": "Deal 82 (+4% per level) damage per second to enemies in target area for 3 seconds. Damage increases by 12% for each consecutive instance of damage, up to 60%.",
         "hotkey": "W",
@@ -41,6 +43,7 @@
         "type": "basic"
       },
       {
+        "uid": "11e1c4c",
         "name": "Dimensional Shift",
         "description": "Tassadar becomes Invulnerable and Unrevealable for 2 seconds. While shifted, he has 25% increased Movement Speed.",
         "hotkey": "E",
@@ -51,6 +54,7 @@
         "type": "basic"
       },
       {
+        "uid": "a6fb6f9",
         "name": "Archon",
         "description": "Tassadar transforms into an Archon and gains a Plasma Shield. His Basic Attacks deal 158 (+4% per level) damage, slow the target by 30% for 1 second and splash for 79 (+4% per level) damage to enemies within 2.5 range. Lasts for 10 seconds.  Passive: Archon refreshes the cooldown of Dimensional Shift.",
         "hotkey": "R",
@@ -60,6 +64,7 @@
         "type": "heroic"
       },
       {
+        "uid": "7d97e21",
         "name": "Force Wall",
         "description": "Create a wall that blocks all units from moving through it for 2 seconds.  Passive: Increases the slow amount of Distortion Beam to 30%.",
         "hotkey": "R",
@@ -70,6 +75,7 @@
         "type": "heroic"
       },
       {
+        "uid": "fbc8f7a",
         "name": "Oracle",
         "description": "Activate to greatly increase Tassadar's vision radius, allow him to see over obstacles, and detect stealthed units. Lasts for 5 seconds.  Distortion Beam  Tassadar's Basic Attack is a beam that slows enemy units by 20%.",
         "hotkey": "D",

--- a/hero/thebutcher.json
+++ b/hero/thebutcher.json
@@ -22,6 +22,7 @@
   "abilities": {
     "The Butcher": [
       {
+        "uid": "31ba134",
         "name": "Hamstring",
         "description": "Deal 110 (+4% per level) damage and slow enemies by 50% fading over 2 seconds.  The Butcher's next Basic Attack will strike immediately.",
         "hotkey": "Q",
@@ -32,6 +33,7 @@
         "type": "basic"
       },
       {
+        "uid": "fc04363",
         "name": "Butcher's Brand",
         "description": "Deal 37 (+4% per level) damage to an enemy and Brand them for 4 seconds. The Butcher's Basic Attacks against the Branded target heal him for 75% of the damage done.  Basic Attacks against Branded Heroes heal for double and extend the duration of the Brand by 0.5 seconds.",
         "hotkey": "W",
@@ -42,6 +44,7 @@
         "type": "basic"
       },
       {
+        "uid": "db3d874",
         "name": "Ruthless Onslaught",
         "description": "Charge at an enemy, becoming Unstoppable and gaining Movement Speed. If The Butcher reaches the target, they are stunned for 1 second and take 119 (+4% per level) damage.",
         "hotkey": "E",
@@ -52,6 +55,7 @@
         "type": "basic"
       },
       {
+        "uid": "0889630",
         "name": "Lamb to the Slaughter",
         "description": "Throw a hitching post that attaches to the nearest enemy Hero after a 1 second delay. This deals 171 (+4% per level) damage and causes the enemy to be chained to the post and Silenced for 3 seconds.",
         "hotkey": "R",
@@ -62,6 +66,7 @@
         "type": "heroic"
       },
       {
+        "uid": "72dde49",
         "name": "Furnace Blast",
         "description": "After a 3 second delay, fire explodes around The Butcher dealing 500 (+4% per level) damage to enemies.  Can be cast while using Ruthless Onslaught.",
         "hotkey": "R",
@@ -72,6 +77,7 @@
         "type": "heroic"
       },
       {
+        "uid": "d776a18",
         "name": "Fresh Meat",
         "description": "Upon dying, nearby enemy Minions drop 1 Fresh Meat and enemy Heroes drop 20 Fresh Meat. Fresh Meat can be picked up to gain 0.5 Attack Damage per Meat. The Butcher loses 15 Fresh Meat upon dying.  Quest: Collect 200 Fresh Meat.  Reward: Gain an additional 125 Attack Damage and 25% increased Attack Speed. Heroes continue to drop 10 Fresh Meat, Minions no longer drop Fresh Meat, and Fresh Meat is no longer lost on death.",
         "trait": true,

--- a/hero/thrall.json
+++ b/hero/thrall.json
@@ -21,6 +21,7 @@
   "abilities": {
     "Thrall": [
       {
+        "uid": "8f41d1b",
         "name": "Chain Lightning",
         "description": "Shock an enemy with lightning, dealing 162 (+4% per level) damage. The lightning then bounces 3 times to nearby enemies, dealing 81 (+4% per level) damage to each enemy hit.",
         "hotkey": "Q",
@@ -31,6 +32,7 @@
         "type": "basic"
       },
       {
+        "uid": "90c754b",
         "name": "Feral Spirit",
         "description": "Unleash a Feral Spirit that deals 153 (+4% per level) damage to enemies in its path and Roots Heroes hit for 1 second. Each Hero hit increases the distance traveled by 25%.",
         "hotkey": "W",
@@ -41,6 +43,7 @@
         "type": "basic"
       },
       {
+        "uid": "85fd413",
         "name": "Windfury",
         "description": "Increase Thrall's Movement Speed by 30% for 4 seconds. His next 3 Basic Attacks occur 100% faster and generate stacks of Frostwolf Resilience.",
         "hotkey": "E",
@@ -51,6 +54,7 @@
         "type": "basic"
       },
       {
+        "uid": "3ff166c",
         "name": "Sundering",
         "description": "After 0.5 seconds, sunder the earth in a long line, dealing 290 (+4% per level) damage and shoving enemies to the side, Stunning them for 1 second.",
         "hotkey": "R",
@@ -61,6 +65,7 @@
         "type": "heroic"
       },
       {
+        "uid": "c5d47e6",
         "name": "Earthquake",
         "description": "After 0.5 seconds, summon a massive Earthquake that pulses every 4 seconds. Each pulse lasts 2 seconds, Slowing all enemies in the area by 50%, and deals 50 (+4% per level) damage to enemy Heroes. Does 3 pulses.",
         "hotkey": "R",
@@ -71,6 +76,7 @@
         "type": "heroic"
       },
       {
+        "uid": "2d8980d",
         "name": "Frostwolf Resilience",
         "description": "Dealing damage with Abilities grants 1 stack of Frostwolf Resilience. At 5 stacks, Thrall is instantly healed for 223 (+4% per level) Health.",
         "trait": true,

--- a/hero/tracer.json
+++ b/hero/tracer.json
@@ -19,6 +19,7 @@
   "abilities": {
     "Tracer": [
       {
+        "uid": "5169464",
         "name": "Blink",
         "description": "Dash towards an area.  Stores up to 3 charges.",
         "hotkey": "Q",
@@ -28,6 +29,7 @@
         "type": "basic"
       },
       {
+        "uid": "cf20ed4",
         "name": "Melee",
         "description": "Deal 220 (+4% per level) damage to a nearby enemy, prioritizing Heroes. Gain 5% Pulse Bomb charge when using Melee against an enemy, and 10% against Heroes.",
         "hotkey": "W",
@@ -37,6 +39,7 @@
         "type": "basic"
       },
       {
+        "uid": "042f2c7",
         "name": "Recall",
         "description": "Tracer returns to the position she was at 3 seconds ago, refilling her ammo, and removing all negative status effects from herself.",
         "hotkey": "E",
@@ -46,6 +49,7 @@
         "type": "basic"
       },
       {
+        "uid": "0afd191",
         "name": "Pulse Bomb",
         "description": "Fire a short range bomb that can attach to an enemy if it hits them. The bomb explodes after 2 seconds dealing 360 (+6% per level) damage to them and 180 (+6% per level) damage to other nearby enemies.  This Ability is slowly charged over time by dealing damage to enemies with Basic Attacks and Melee.",
         "hotkey": "R",
@@ -54,6 +58,7 @@
         "type": "heroic"
       },
       {
+        "uid": "8320ce8",
         "name": "Reload",
         "description": "Tracer can Basic Attack while moving, and after attacking 10 times she needs to reload over 0.75 seconds. Tracer can manually reload early by activating Reload.",
         "hotkey": "D",

--- a/hero/tychus.json
+++ b/hero/tychus.json
@@ -20,6 +20,7 @@
   "abilities": {
     "Tychus": [
       {
+        "uid": "90ddab5",
         "name": "Overkill",
         "description": "Deal 552 (+4% per level) damage to the target and 276 (+4% per level) damage to nearby targets over 4 seconds. Reactivate to select a new target.  Can move and use Abilities while Channeling.",
         "hotkey": "Q",
@@ -30,6 +31,7 @@
         "type": "basic"
       },
       {
+        "uid": "db2eb48",
         "name": "Frag Grenade",
         "description": "Lob a grenade that deals 256 (+4% per level) damage, knocking enemies away.",
         "hotkey": "W",
@@ -40,6 +42,7 @@
         "type": "basic"
       },
       {
+        "uid": "5013769",
         "name": "Run and Gun",
         "description": "Dash a short distance.",
         "hotkey": "E",
@@ -50,6 +53,7 @@
         "type": "basic"
       },
       {
+        "uid": "5043afa",
         "name": "Drakken Laser Drill",
         "description": "Call down a Laser Drill to attack nearby enemies, dealing 142 (+4% per level) damage every second. Reactivate to assign a new target. Lasts 22 seconds.",
         "hotkey": "R",
@@ -60,6 +64,7 @@
         "type": "heroic"
       },
       {
+        "uid": "dfe33bf",
         "name": "Commandeer Odin",
         "description": "Call down an Odin to pilot. The Odin deals increased Damage, has 100% increased Basic Attack range, and uses different Abilities. The Odin has 25 Armor and lasts 23 seconds.",
         "hotkey": "R",
@@ -70,6 +75,7 @@
         "type": "heroic"
       },
       {
+        "uid": "a378d63",
         "name": "Minigun",
         "description": "Activate to have Basic Attacks against Heroes deal bonus damage equal to 2.5% of their maximum Health. Lasts 3 seconds.",
         "trait": true,
@@ -81,6 +87,7 @@
     ],
     "TychusOdinNoHealth": [
       {
+        "uid": "dbf0732",
         "name": "Annihilate",
         "description": "Fire the Odin's cannons in a straight line, dealing 196 (+4% per level) damage to everything in the path.",
         "hotkey": "Q",
@@ -90,6 +97,7 @@
         "type": "subunit"
       },
       {
+        "uid": "31f2f21",
         "name": "Ragnarok Missiles",
         "description": "Launches a volley of missiles at target area, dealing 132 (+4% per level) damage and slowing enemy Movement Speed by 30% for 2 seconds.",
         "hotkey": "W",
@@ -99,6 +107,7 @@
         "type": "subunit"
       },
       {
+        "uid": "944d7b3",
         "name": "Thrusters",
         "description": "Dash in target direction.",
         "hotkey": "E",

--- a/hero/tyrael.json
+++ b/hero/tyrael.json
@@ -23,6 +23,7 @@
   "abilities": {
     "Tyrael": [
       {
+        "uid": "747a20a",
         "name": "El'druin's Might",
         "description": "Throw El'druin to the target area, dealing 110 (+4% per level) damage to nearby enemies and Slowing them by 25% for 2.5 seconds. It can be reactivated within 5 seconds to teleport Tyrael to El'druin and Slow nearby enemies again.",
         "hotkey": "Q",
@@ -33,6 +34,7 @@
         "type": "basic"
       },
       {
+        "uid": "3cd93e1",
         "name": "Righteousness",
         "description": "Shields Tyrael for 336 (+4% per level) damage and nearby allied Heroes and Minions for 40% as much for 4 seconds.",
         "hotkey": "W",
@@ -43,6 +45,7 @@
         "type": "basic"
       },
       {
+        "uid": "112007d",
         "name": "Smite",
         "description": "Rake target area for 150 (+4% per level) damage. Allies moving through the targeted area gain 25% increased Movement Speed for 2 seconds.",
         "hotkey": "E",
@@ -53,6 +56,7 @@
         "type": "basic"
       },
       {
+        "uid": "cc69be6",
         "name": "Judgment",
         "description": "After 0.75 seconds, charge an enemy Hero, dealing 150 (+4% per level) damage and Stunning them for 1.5 seconds. Nearby enemies are knocked away and take 75 (+4% per level) damage.",
         "hotkey": "R",
@@ -63,6 +67,7 @@
         "type": "heroic"
       },
       {
+        "uid": "ce5c0e9",
         "name": "Sanctification",
         "description": "After 0.5 seconds create a field of holy energy that makes allied Heroes Invulnerable. Lasts 3 seconds.",
         "hotkey": "R",
@@ -73,6 +78,7 @@
         "type": "heroic"
       },
       {
+        "uid": "39e24c8",
         "name": "Archangel's Wrath",
         "description": "Upon dying, become Invulnerable and explode for 550 (+4% per level) damage after 3.5 seconds.",
         "trait": true,

--- a/hero/tyrande.json
+++ b/hero/tyrande.json
@@ -23,6 +23,7 @@
   "abilities": {
     "Tyrande": [
       {
+        "uid": "e122256",
         "name": "Light of Elune",
         "description": "Heal an ally Hero for 255 (+4% per level). Light of Elune's cooldown is reduced by 1.5 seconds every time Tyrande damages an enemy.  Stores up to 2 charges. Cooldown replenishes all charges at the same time.",
         "hotkey": "Q",
@@ -33,6 +34,7 @@
         "type": "basic"
       },
       {
+        "uid": "ceea873",
         "name": "Sentinel",
         "description": "Send an Owl across the battleground revealing its path, dealing 120 (+4% per level) damage to the first Hero hit, and revealing them for 5 seconds.",
         "hotkey": "W",
@@ -43,6 +45,7 @@
         "type": "basic"
       },
       {
+        "uid": "c80b95e",
         "name": "Lunar Flare",
         "description": "After 0.75 seconds, deal 150 (+4% per level) damage and Stun enemies in the target area for 0.75 seconds.",
         "hotkey": "E",
@@ -53,6 +56,7 @@
         "type": "basic"
       },
       {
+        "uid": "a76596b",
         "name": "Shadowstalk",
         "description": "Grant all allied Heroes Stealth for 10 seconds and heal them for 380 (+4% per level) Health over 10 seconds. Remaining stationary for at least 1.5 seconds while Stealthed grants Invisible.",
         "hotkey": "R",
@@ -63,6 +67,7 @@
         "type": "heroic"
       },
       {
+        "uid": "608a430",
         "name": "Starfall",
         "description": "Deal 88 (+4% per level) damage per second and Slow enemies by 20% in an area. Lasts 6 seconds.",
         "hotkey": "R",
@@ -73,6 +78,7 @@
         "type": "heroic"
       },
       {
+        "uid": "9b6716d",
         "name": "Hunter's Mark",
         "description": "Reveal a non-Structure enemy and reduce their Armor by 15 for 4 seconds.",
         "hotkey": "D",

--- a/hero/uther.json
+++ b/hero/uther.json
@@ -22,6 +22,7 @@
   "abilities": {
     "Uther": [
       {
+        "uid": "5a0a50a",
         "name": "Holy Light",
         "description": "Heal target allied Hero for 362 (+4% per level) Health. When used on a target other than Uther, also heal Uther for 181 (+4% per level) Health.",
         "hotkey": "Q",
@@ -32,6 +33,7 @@
         "type": "basic"
       },
       {
+        "uid": "3467f2b",
         "name": "Holy Radiance",
         "description": "Heal all allied Heroes and Minions in a line for 177 (+4% per level) Health, dealing 177 (+4% per level) damage to enemies.",
         "hotkey": "W",
@@ -42,6 +44,7 @@
         "type": "basic"
       },
       {
+        "uid": "1760769",
         "name": "Hammer of Justice",
         "description": "Deal 109 (+4% per level) damage and Stun the target for 1 second.",
         "hotkey": "E",
@@ -52,6 +55,7 @@
         "type": "basic"
       },
       {
+        "uid": "c4e2106",
         "name": "Divine Shield",
         "description": "Make an allied Hero Invulnerable and increase their Movement Speed by 20% for 3 seconds.",
         "hotkey": "R",
@@ -62,6 +66,7 @@
         "type": "heroic"
       },
       {
+        "uid": "f536b3b",
         "name": "Divine Storm",
         "description": "Deal 170 (+4% per level) damage and Stun nearby enemies for 1.75 seconds.",
         "hotkey": "R",
@@ -72,6 +77,7 @@
         "type": "heroic"
       },
       {
+        "uid": "d98eea7",
         "name": "Devotion",
         "description": "Allied Heroes affected by Uther's Basic Abilities gain 25 Armor for 2 seconds.  This effect does not stack with itself.  Eternal Vanguard  Upon dying, Uther becomes an Invulnerable spirit for up to 8 seconds. While in spirit form, Uther can heal allies with Flash of Light.",
         "trait": true,
@@ -83,6 +89,7 @@
     ],
     "UtherEternalDevotion": [
       {
+        "uid": "eb21192",
         "name": "Flash of Light",
         "description": "Heal an ally for 230 (+4% per level) Health.",
         "hotkey": "Q",

--- a/hero/valeera.json
+++ b/hero/valeera.json
@@ -21,6 +21,7 @@
   "abilities": {
     "Valeera": [
       {
+        "uid": "3737e22",
         "name": "Sinister Strike",
         "description": "Dash forward, hitting all enemies in a line for 110 (+4% per level) damage. If Sinister Strike hits a Hero, Valeera stops dashing immediately and the cooldown is reduced to 1 second.  Awards 1 Combo Point.  Stealth: Ambush Heavily damage an enemy and reduce their Armor.",
         "hotkey": "Q",
@@ -31,6 +32,7 @@
         "type": "basic"
       },
       {
+        "uid": "3cb16e4",
         "name": "Blade Flurry",
         "description": "Deal 130 (+4% per level) damage in an area around Valeera.  Awards 1 Combo Point per enemy Hero hit.  Stealth: Cheap Shot Stun, Blind, and damage an enemy.",
         "hotkey": "W",
@@ -41,6 +43,7 @@
         "type": "basic"
       },
       {
+        "uid": "c37452b",
         "name": "Eviscerate",
         "description": "Eviscerate an enemy, dealing damage per Combo Point.  1 Point: 85 (+4% per level) 2 Points: 170 (+4% per level) 3 Points: 255 (+4% per level)  Stealth: Garrote Silence and damage an enemy over time.",
         "hotkey": "E",
@@ -51,6 +54,7 @@
         "type": "basic"
       },
       {
+        "uid": "0adf79f",
         "name": "Smoke Bomb",
         "description": "Create a cloud of smoke. While in the smoke, Valeera is Unrevealable, can pass through other units, and gains 30 Armor, reducing damage taken by 30%. Valeera can continue to attack and use abilities without being revealed. Lasts 5 seconds.  Using this Ability does not break Stealth.",
         "hotkey": "R",
@@ -60,6 +64,7 @@
         "type": "heroic"
       },
       {
+        "uid": "b21b32d",
         "name": "Cloak of Shadows",
         "description": "Valeera is enveloped in a Cloak of Shadows, which immediately removes all damage over time effects from her. For 1.5 seconds, she becomes Unstoppable and gains 75 Spell Armor, reducing Ability Damage taken by 75%.  Using this Ability does not break Stealth.",
         "hotkey": "R",
@@ -69,6 +74,7 @@
         "type": "heroic"
       },
       {
+        "uid": "b2836c3",
         "name": "Vanish",
         "description": "Vanish from sight, becoming Stealthed, gaining 20% Movement Speed and access to new Abilities. For the first second, Valeera is Unrevealable and can pass through other units. Remaining stationary for at least 1.5 seconds while Stealthed grants Invisible.  After being Stealthed for 3 seconds, Ambush, Cheap Shot, and Garrote have 100% increased range, and cause Valeera to teleport to the target when used.",
         "hotkey": "D",
@@ -81,6 +87,7 @@
     ],
     "ValeeraStealth": [
       {
+        "uid": "55af9b1",
         "name": "Ambush",
         "description": "Ambush an enemy, dealing 130 (+4% per level) damage and reducing their Armor by 10 for 5 seconds.  Awards 1 Combo Point.  Unstealth: Sinister Strike Dash forward, damaging enemies.",
         "hotkey": "Q",
@@ -91,6 +98,7 @@
         "type": "subunit"
       },
       {
+        "uid": "dc7704a",
         "name": "Cheap Shot",
         "description": "Deal 30 (+4% per level) damage to an enemy, Stun them for 0.75 seconds, and Blind them for 2 seconds once Cheap Shot's Stun expires.  Awards 1 Combo Point.  Unstealth: Blade Flurry Deal damage in an area around Valeera.",
         "hotkey": "W",
@@ -101,6 +109,7 @@
         "type": "subunit"
       },
       {
+        "uid": "07ca592",
         "name": "Garrote",
         "description": "Deal 20 (+4% per level) damage to an enemy and an additional 140 (+4% per level) damage over 7 seconds, and Silence them for 2.5 seconds.  Awards 1 Combo Point.  Unstealth: Eviscerate High damage finishing move.",
         "hotkey": "E",

--- a/hero/valla.json
+++ b/hero/valla.json
@@ -21,6 +21,7 @@
   "abilities": {
     "Valla": [
       {
+        "uid": "9d16f5f",
         "name": "Hungering Arrow",
         "description": "Fire an arrow that deals 140 (+4% per level) damage to the first target hit, then seeks up to 2 additional enemies, prioritizing Heroes, dealing 80 (+4% per level) damage. Can hit an enemy multiple times.",
         "hotkey": "Q",
@@ -31,6 +32,7 @@
         "type": "basic"
       },
       {
+        "uid": "0a51d89",
         "name": "Multishot",
         "description": "Deal 172 (+4% per level) damage to enemies within the target area.",
         "hotkey": "W",
@@ -41,6 +43,7 @@
         "type": "basic"
       },
       {
+        "uid": "6a34abe",
         "name": "Vault",
         "description": "Dash to the target area. Valla's next Basic Attack within 2 seconds deals 6% increased damage per stack of Hatred.",
         "hotkey": "E",
@@ -51,6 +54,7 @@
         "type": "basic"
       },
       {
+        "uid": "2968a43",
         "name": "Rain of Vengeance",
         "description": "Launch a wave of Shadow Beasts that deals 250 (+4% per level) damage and stuns enemies in the target area for 0.5 seconds.  Stores up to 2 charges.",
         "hotkey": "R",
@@ -61,6 +65,7 @@
         "type": "heroic"
       },
       {
+        "uid": "93804e8",
         "name": "Strafe",
         "description": "Rapidly attack enemies within 10 range for 60 (+4% per level) damage per hit, prioritizing Heroes over Minions. Valla is able to move and use Vault while strafing. Lasts for 4 seconds.",
         "hotkey": "R",
@@ -71,6 +76,7 @@
         "type": "heroic"
       },
       {
+        "uid": "cc16e46",
         "name": "Hatred",
         "description": "Basic Attacks grant a stack of Hatred, up to 10. Each Hatred stack increases Basic Attack damage by 8% and Movement Speed by 1%. Lasts 6 seconds.",
         "trait": true,

--- a/hero/varian.json
+++ b/hero/varian.json
@@ -21,6 +21,7 @@
   "abilities": {
     "Varian": [
       {
+        "uid": "e15f695",
         "name": "Lion's Fang",
         "description": "Create a shockwave that travels in a straight line, dealing 150 (+4% per level) damage and Slowing enemies by 35% for 1.5 seconds. Each enemy hit heals Varian for 35 (+4% per level), increased to 140 (+4% per level) against Heroes.",
         "hotkey": "Q",
@@ -31,6 +32,7 @@
         "type": "basic"
       },
       {
+        "uid": "7a8378b",
         "name": "Parry",
         "description": "Parry all incoming Basic Attacks for 1.25 seconds, reducing their damage by 100%.  Stores up to 2 charges.",
         "hotkey": "W",
@@ -41,6 +43,7 @@
         "type": "basic"
       },
       {
+        "uid": "2ba5b0d",
         "name": "Charge",
         "description": "Charge to the target enemy, dealing 50 (+4% per level) damage and Slowing them by 75% for 1 second.",
         "hotkey": "E",
@@ -51,6 +54,7 @@
         "type": "basic"
       },
       {
+        "uid": "f620e35",
         "name": "Taunt",
         "description": "Silence a target Hero and force them to attack Varian for 1.25 seconds.  Passive: Maximum Health and Health Regeneration increased by 30%.",
         "hotkey": "R",
@@ -61,6 +65,7 @@
         "type": "heroic"
       },
       {
+        "uid": "5ac8d0f",
         "name": "Colossus Smash",
         "description": "Smash a target enemy, dealing 160 (+4% per level) damage and lowering their Armor by 20 for 3 seconds, causing them to take 20% increased damage.  Passive: Base Attack Damage increased by 100%. Passive: Maximum Health and Health Regeneration reduced by 10%.",
         "hotkey": "R",
@@ -71,6 +76,7 @@
         "type": "heroic"
       },
       {
+        "uid": "b8832d1",
         "name": "Twin Blades of Fury",
         "description": "Basic Attacks reduce Heroic Strike's cooldown by 9 seconds, and increase Varian's Movement Speed by 30% for 2 seconds.  Passive: Attack Speed increased by 100%. Passive: Base Attack Damage reduced by 20%.",
         "hotkey": "R",
@@ -79,6 +85,7 @@
         "type": "heroic"
       },
       {
+        "uid": "4d4cc92",
         "name": "Heroic Strike",
         "description": "Every 18 seconds, Varian's next Basic Attack deals 125 (+4% per level) bonus Spell Damage. Basic Attacks reduce this cooldown by 2 seconds.",
         "trait": true,

--- a/hero/whitemane.json
+++ b/hero/whitemane.json
@@ -20,6 +20,7 @@
   "abilities": {
     "Whitemane": [
       {
+        "uid": "05c4e67",
         "name": "Desperate Plea",
         "description": "Heal an allied Hero for 140 (+4% per level) and gain Desperation for 4 seconds.  Desperation increases Desperate Plea's Mana cost by 60, and stacks up to 3 times.  Current Mana Cost: 30",
         "hotkey": "Q",
@@ -29,6 +30,7 @@
         "type": "basic"
       },
       {
+        "uid": "9abab82",
         "name": "Inquisition",
         "description": "Channel on an enemy Hero for up to 3 seconds, dealing 50 (+4% per level) damage every 0.5 seconds and Slowing them by 30%.",
         "hotkey": "W",
@@ -38,6 +40,7 @@
         "type": "basic"
       },
       {
+        "uid": "83d34aa",
         "name": "Searing Lash",
         "description": "After 0.5 seconds, smite enemies in a straight line for 82 (+4% per level) damage.  If the first strike hits an enemy Hero, a second strike will occur after a short delay.",
         "hotkey": "E",
@@ -47,6 +50,7 @@
         "type": "basic"
       },
       {
+        "uid": "e6b8d35",
         "name": "Scarlet Aegis",
         "description": "Bolster the spirits of nearby allied Heroes, healing them for 250 (+4% per level) and granting them 40 Armor for 4 seconds.",
         "hotkey": "R",
@@ -56,6 +60,7 @@
         "type": "heroic"
       },
       {
+        "uid": "3c0468a",
         "name": "Divine Reckoning",
         "description": "After 1 second, consecrate an area for 4 seconds, dealing 50 (+4% per level) damage every 0.5 seconds to enemies inside.",
         "hotkey": "R",
@@ -65,6 +70,7 @@
         "type": "heroic"
       },
       {
+        "uid": "e003ec1",
         "name": "Zeal",
         "description": "Whitemane's healing Abilities apply Zeal for 8 seconds.  Allies with Zeal are healed for 100% of the damage Whitemane deals to Heroes.",
         "trait": true,

--- a/hero/xul.json
+++ b/hero/xul.json
@@ -23,6 +23,7 @@
   "abilities": {
     "Xul": [
       {
+        "uid": "7fd87e6",
         "name": "Spectral Scythe",
         "description": "Summon a scythe that travels to Xul after 1 second, dealing 240 (+4% per level) damage to enemies.",
         "hotkey": "Q",
@@ -33,6 +34,7 @@
         "type": "basic"
       },
       {
+        "uid": "08bf2ab",
         "name": "Cursed Strikes",
         "description": "Xul's Basic Attacks deal damage in a wide area and reduce the Attack Speed of Heroes and Summons by 40% for 2 seconds. Lasts 4 seconds once triggered.",
         "hotkey": "W",
@@ -43,6 +45,7 @@
         "type": "basic"
       },
       {
+        "uid": "a26161f",
         "name": "Bone Prison",
         "description": "After a 2 second delay, deal 80 (+4% per level) damage and Root the target enemy Hero for 1.75 seconds.  All nearby Skeletal Warriors will fixate on the target for their duration.",
         "hotkey": "E",
@@ -53,6 +56,7 @@
         "type": "basic"
       },
       {
+        "uid": "69a0bd3",
         "name": "Skeletal Mages",
         "description": "Vector Targeting Summon 4 Frost Mages in a line that attack nearby enemies for 47 (+4% per level) damage a second and Slow them by 30% for 2 seconds. Last up to 15 seconds.",
         "hotkey": "R",
@@ -63,6 +67,7 @@
         "type": "heroic"
       },
       {
+        "uid": "a8b7e99",
         "name": "Poison Nova",
         "description": "After 0.5 seconds, release poisonous missiles that deal 570 (+4% per level) damage to all enemies hit over 10 seconds.",
         "hotkey": "R",
@@ -73,6 +78,7 @@
         "type": "heroic"
       },
       {
+        "uid": "9410c65",
         "name": "Bone Armor",
         "description": "Activate to gain a Shield equal to 25% of Xul's maximum Health for 3 seconds.",
         "hotkey": "1",
@@ -82,6 +88,7 @@
         "type": "activable"
       },
       {
+        "uid": "3dec1ba",
         "name": "Raise Skeleton",
         "description": "When a nearby enemy Minion dies, it becomes a Skeletal Warrior with 225 (+4% per level) Health that attacks for 21 (+4% per level) damage and last up to 15 seconds. Up to 4 Skeletal Warriors can be active at once.",
         "trait": true,

--- a/hero/yrel.json
+++ b/hero/yrel.json
@@ -23,6 +23,7 @@
   "abilities": {
     "Yrel": [
       {
+        "uid": "5507d18",
         "name": "Vindication",
         "description": "Unleash holy energy around Yrel, dealing 42 (+4% per level) damage to nearby enemies and healing her for 96 (+4% per level).  Charging up this Ability increases its damage up to 140 (+4% per level), and healing up to 320 (+4% per level).",
         "hotkey": "Q",
@@ -33,6 +34,7 @@
         "type": "basic"
       },
       {
+        "uid": "1bf6888",
         "name": "Avenging Wrath",
         "description": "Leap to a location, dealing 225 (+4% per level) damage to enemies in an area and Slowing them by 50% for 1 second.  Charging up this Ability increases its range.",
         "hotkey": "E",
@@ -43,6 +45,7 @@
         "type": "basic"
       },
       {
+        "uid": "2fd9342",
         "name": "Ardent Defender",
         "description": "Surround Yrel in a barrier for 3 seconds, absorbing all damage taken and healing her for 50% of the damage received.",
         "hotkey": "R",
@@ -53,6 +56,7 @@
         "type": "heroic"
       },
       {
+        "uid": "7390a4d",
         "name": "Sacred Ground",
         "description": "Yrel sanctifies the ground around her, gaining 50 Armor until she leaves the area.",
         "hotkey": "R",
@@ -63,6 +67,7 @@
         "type": "heroic"
       },
       {
+        "uid": "ec75c9a",
         "name": "Divine Purpose",
         "description": "Activate to instantly charge Yrel's next Basic Ability at no mana cost.  Passive: Yrel's Basic Abilities charge up over 1.5 seconds, increasing in effectiveness, but reducing Yrel's Movement Speed by 25%.",
         "hotkey": "D",
@@ -73,6 +78,7 @@
         "type": "trait"
       },
       {
+        "uid": "ede1881",
         "name": "Righteous Hammer",
         "description": "Swing Yrel's hammer, dealing 38 (+4% per level) damage to enemies in front of her and knocking them away.  Charging up this Ability increases its knockback distance, and damage up to 125 (+4% per level). Enemies hit at maximum charge are Stunned for 0.75 seconds.",
         "hotkey": "W",

--- a/hero/zagara.json
+++ b/hero/zagara.json
@@ -21,6 +21,7 @@
   "abilities": {
     "Zagara": [
       {
+        "uid": "13bfb31",
         "name": "Baneling Barrage",
         "description": "Launch 1 Baneling that deals 86 (+4% per level) damage to enemies it hits.  Stores up to 4 charges.",
         "hotkey": "Q",
@@ -31,6 +32,7 @@
         "type": "basic"
       },
       {
+        "uid": "ad0d2bd",
         "name": "Hunter Killer",
         "description": "Summon a Hydralisk to attack a single target, dealing 71 (+5% per level) damage per second. Lasts 8 seconds.",
         "hotkey": "W",
@@ -41,6 +43,7 @@
         "type": "basic"
       },
       {
+        "uid": "5e5990a",
         "name": "Infested Drop",
         "description": "Bombard target area with a Zerg Drop Pod for 140 (+4% per level) damage.  The pod spawns 2 Roachlings that deal 27 (+4% per level) damage per second and last for 8 seconds.",
         "hotkey": "E",
@@ -51,6 +54,7 @@
         "type": "basic"
       },
       {
+        "uid": "6097873",
         "name": "Nydus Network",
         "description": "Summon a Nydus Worm on Creep anywhere that Zagara has vision. Zagara can enter a Nydus Worm and travel to any other Nydus Worm by right-clicking near it. While inside a Nydus Worm, Zagara regenerates 10% Health and Mana per second.  Stores up to 2 charges. Maximum of 4 Nydus Worms at a time.  Passive: Creep spreads 15% farther.  Passive: While on Creep, each Basic Attack reduces all of Zagara's cooldowns by 0.4 seconds.",
         "hotkey": "R",
@@ -61,6 +65,7 @@
         "type": "heroic"
       },
       {
+        "uid": "b67da9b",
         "name": "Devouring Maw",
         "description": "Summon a Devouring Maw that devours enemies for 4 seconds. Devoured enemies cannot fight and take 88 (+4% per level) damage per second.  Usable on Unstoppable enemies.",
         "hotkey": "R",
@@ -71,6 +76,7 @@
         "type": "heroic"
       },
       {
+        "uid": "db8b00f",
         "name": "Creep Tumor",
         "description": "Lay a Creep Tumor that generates Creep. While on Creep, Zagara gains 20% additional attack range and both Zagara and her summons move 20% faster. Tumors last 240 seconds and reveal the surrounding area while active.  Stores up to 3 charges.",
         "hotkey": "D",

--- a/hero/zarya.json
+++ b/hero/zarya.json
@@ -20,6 +20,7 @@
   "abilities": {
     "Zarya": [
       {
+        "uid": "bbf6e60",
         "name": "Particle Grenade",
         "description": "Launch a particle grenade that deals 75 (+4% per level) damage to enemies within the area. Deals 50% damage to Structures.  Stores up to 4 charges.",
         "hotkey": "Q",
@@ -29,6 +30,7 @@
         "type": "basic"
       },
       {
+        "uid": "3d2b3fd",
         "name": "Personal Barrier",
         "description": "Gain a Shield that absorbs 560 (+4% per level) damage for 3 seconds.",
         "hotkey": "W",
@@ -38,6 +40,7 @@
         "type": "basic"
       },
       {
+        "uid": "54bc2db",
         "name": "Shield Ally",
         "description": "Grants an allied Hero a Shield that absorbs 420 (+4% per level) damage for 3 seconds.",
         "hotkey": "E",
@@ -47,6 +50,7 @@
         "type": "basic"
       },
       {
+        "uid": "0c2ce1e",
         "name": "Expulsion Zone",
         "description": "Launch a gravity bomb that deals 124 (+4% per level) damage and creates an expulsion zone for 3.5 seconds. Enemies who enter the affected area are knocked back and have their Movement Speed reduced by 50% for 1 second.",
         "hotkey": "R",
@@ -56,6 +60,7 @@
         "type": "heroic"
       },
       {
+        "uid": "7847566",
         "name": "Graviton Surge",
         "description": "Launch a gravity bomb that detonates after 1 second and draws enemy Heroes toward the center for 2.5 seconds.",
         "hotkey": "R",
@@ -65,6 +70,7 @@
         "type": "heroic"
       },
       {
+        "uid": "25511a4",
         "name": "Energy",
         "description": "Each time Zarya's Personal Barrier or Shield Ally absorbs 9 (+4% per level) damage, her Energy is increased by 1. Each point of Energy increases Zarya's damage by 2%. After 0.5 seconds, Energy decays by 3 per second.",
         "trait": true,

--- a/hero/zeratul.json
+++ b/hero/zeratul.json
@@ -23,6 +23,7 @@
   "abilities": {
     "Zeratul": [
       {
+        "uid": "84b5f86",
         "name": "Cleave",
         "description": "Deal 200 (+4% per level) damage to nearby enemies.",
         "hotkey": "Q",
@@ -33,6 +34,7 @@
         "type": "basic"
       },
       {
+        "uid": "85e6886",
         "name": "Singularity Spike",
         "description": "Flings a Singularity Spike that sticks to the first enemy hit. Deals 240 (+4% per level) damage after 1 second and Slows the enemy by 40% for 3 seconds.",
         "hotkey": "W",
@@ -43,6 +45,7 @@
         "type": "basic"
       },
       {
+        "uid": "feba377",
         "name": "Blink",
         "description": "Teleport to the target location.  Using this Ability does not break Stealth.",
         "hotkey": "E",
@@ -53,6 +56,7 @@
         "type": "basic"
       },
       {
+        "uid": "85e2282",
         "name": "Might Of The Nerazim",
         "description": "Activate to cast an untalented version of Zeratul's most recently used Basic Ability, dealing 50% less damage.  Passive: After using an Ability, Zeratul's next Basic Attack within 6 seconds deals 30% more damage.",
         "hotkey": "R",
@@ -63,6 +67,7 @@
         "type": "heroic"
       },
       {
+        "uid": "e51880f",
         "name": "Void Prison",
         "description": "Slows time in an area to a near standstill, placing allies and enemies in Time Stop for 5 seconds. Zeratul is not affected.",
         "hotkey": "R",
@@ -73,6 +78,7 @@
         "type": "heroic"
       },
       {
+        "uid": "b018c6d",
         "name": "Permanent Cloak",
         "description": "Gain Stealth when out of combat for 3 seconds. Taking damage, attacking, using Abilities, or Channeling ends Stealth. Remaining stationary for at least 1.5 seconds while Stealthed grants Invisible.",
         "trait": true,
@@ -81,6 +87,7 @@
         "type": "trait"
       },
       {
+        "uid": "9af1420",
         "name": "Vorpal Blade",
         "description": "Activate to teleport to Zeratul's last non-structure Basic Attack target within 3 seconds. The target is revealed during these 3 seconds.",
         "hotkey": "1",

--- a/hero/zuljin.json
+++ b/hero/zuljin.json
@@ -20,6 +20,7 @@
   "abilities": {
     "Zul'jin": [
       {
+        "uid": "8f82b28",
         "name": "Grievous Throw",
         "description": "Zul'jin throws an axe forward, dealing 125 (+4% per level) damage to the first 2 enemies hit and marking them for 6 seconds. Marked enemies take 50% bonus damage from Zul'jin's next 3 Basic Attacks against them.",
         "hotkey": "Q",
@@ -30,6 +31,7 @@
         "type": "basic"
       },
       {
+        "uid": "a79ad17",
         "name": "Twin Cleave",
         "description": "Throw 2 axes in a large, circular arc, dealing 112 (+4% per level) damage and Slowing affected enemies by 15% per axe for 2 seconds.",
         "hotkey": "W",
@@ -40,6 +42,7 @@
         "type": "basic"
       },
       {
+        "uid": "99ea734",
         "name": "Regeneration",
         "description": "Zul'jin channels to regenerate 30% of his maximum Health over 4 seconds. Moving while channeling or taking damage will interrupt this effect.",
         "hotkey": "E",
@@ -50,6 +53,7 @@
         "type": "basic"
       },
       {
+        "uid": "ed061bd",
         "name": "Taz'dingo!",
         "description": "For the next 4 seconds, Zul'jin is Unkillable, and cannot be reduced to less than 1 Health. Taz'dingo!",
         "hotkey": "R",
@@ -60,6 +64,7 @@
         "type": "heroic"
       },
       {
+        "uid": "41c1dda",
         "name": "Guillotine",
         "description": "Zul'jin launches a massive axe into the air that drops on the targeted area, dealing 330 (+4% per level) damage plus bonus damage the lower his Health is.",
         "hotkey": "R",
@@ -70,6 +75,7 @@
         "type": "heroic"
       },
       {
+        "uid": "dd74a5f",
         "name": "Berserker",
         "description": "Activate to increase Basic Attack damage by 25% but consume 2% maximum Health per attack.  Passive: Zul'jin attacks 1% faster for every 1% of maximum Health missing.  You Want Axe?  Quest: Every 5 Basic Attacks against Heroes permanently increases Basic Attack damage by 1.  Reward: After attacking Heroes 75 times, Basic Attack range is increased by 1.1.  Reward: After attacking Heroes 150 times, Twin Cleave now revolves twice.",
         "trait": true,
@@ -78,6 +84,7 @@
         "type": "trait"
       },
       {
+        "uid": "8607d21",
         "name": "Amani Rage",
         "description": "Activate to cause Zul'jin to instantly lose 50% of his current Health and heal for that amount over 10 seconds.",
         "hotkey": "1",


### PR DESCRIPTION
A separate PR just so the diff for the new patch will display nicely.

Abilities now carry a UID - greatly helpful internally for tracking duplicates across their raw data equivalents. UIDs are calculated as follows:
```
str = ''
for key in 'abilityType', 'nameId', 'buttonId', 'isPassive'
	if raw[key] then str .= $raw[$key]
return md5(str);
```