### PR TITLE
[WIP] First attempt with heroes-convert (2.48.2.76781)

### DIFF
--- a/hero/abathur.json
+++ b/hero/abathur.json
@@ -1,5 +1,5 @@
 {
-  "id": "1",
+  "id": 1,
   "shortName": "abathur",
   "attributeId": "Abat",
   "cHeroId": "Abathur",
@@ -22,7 +22,7 @@
   "abilities": {
     "Abathur": [
       {
-        "uid": "9c810ae",
+        "uid": "62ce22",
         "name": "Symbiote",
         "description": "Spawn and attach a Symbiote to a target ally or Structure. While active, Abathur controls the Symbiote, gaining access to new Abilities. The Symbiote is able to gain XP from nearby enemy deaths.",
         "hotkey": "Q",
@@ -32,7 +32,7 @@
         "type": "basic"
       },
       {
-        "uid": "82a0b5c",
+        "uid": "42614e",
         "name": "Toxic Nest",
         "description": "Spawn a mine that becomes active after a short time. Deals 153 (+4% per level) damage and reveals the enemy for 4 seconds. Lasts 90 seconds.  Stores up to 3 charges.",
         "hotkey": "W",
@@ -42,7 +42,7 @@
         "type": "basic"
       },
       {
-        "uid": "a6eb53a",
+        "uid": "36124c",
         "name": "Evolve Monstrosity",
         "description": "Turn an allied Minion or Locust into a Monstrosity. When enemy Minions near the Monstrosity die, it gains 2% Health and 2% Basic Attack damage, stacking up to 40 times.  The Monstrosity can be healed by Carapace and has the ability to Burrow to a visible location every 80 seconds.  Using Symbiote on the Monstrosity allows Abathur to control it, in addition to Symbiote's normal benefits.  This Ability can be reactivated to automatically cast Symbiote on his Monstrosity.",
         "hotkey": "R",
@@ -52,7 +52,7 @@
         "type": "heroic"
       },
       {
-        "uid": "a4dc837",
+        "uid": "e5fd94",
         "name": "Ultimate Evolution",
         "description": "Clone target allied Hero and control it for 20 seconds. Abathur has perfected the clone, granting it 20% Spell Power, 20% bonus Attack Damage, and 10% bonus Movement Speed. Cannot use their Heroic Ability.",
         "hotkey": "R",
@@ -62,7 +62,7 @@
         "type": "heroic"
       },
       {
-        "uid": "75fc9a2",
+        "uid": "c6b01f",
         "name": "Locust Strain",
         "description": "Spawns a Locust to attack down the nearest lane every 15 seconds. Locusts last for 16 seconds, have 316 (+4% per level) health and deal 46 (+4% per level) damage with each Basic Attack.",
         "trait": true,
@@ -72,7 +72,7 @@
         "type": "trait"
       },
       {
-        "uid": "f3ed2ec",
+        "uid": "8562c7",
         "name": "Deep Tunnel",
         "description": "Quickly tunnel to a visible location",
         "hotkey": "Z",
@@ -84,44 +84,54 @@
     ],
     "AbathurSymbiote": [
       {
-        "uid": "ad3fb1f",
-        "name": "Stab",
-        "description": "Shoots a spike towards target area that deals 119 (+4% per level) damage to the first enemy it contacts.",
-        "hotkey": "Q",
-        "abilityId": "Abathur|Q2",
-        "cooldown": 3,
-        "icon": "storm_ui_icon_abathur_stab.png",
-        "type": "subunit"
-      },
-      {
-        "uid": "82650ee",
-        "name": "Spike Burst",
-        "description": "Deals 120 (+4% per level) damage to nearby enemies.",
-        "hotkey": "W",
-        "abilityId": "Abathur|W2",
-        "cooldown": 6,
-        "icon": "storm_ui_icon_abathur_spikeburst.png",
-        "type": "subunit"
-      },
-      {
-        "uid": "a8f01c1",
+        "uid": "00e154",
         "name": "Carapace",
         "description": "Shields the assisted ally for 150 (+4% per level). Allied Heroes are healed for 22 (+4% per level) Health per second while the Shield is active. Lasts for 6 seconds.",
         "hotkey": "E",
         "abilityId": "Abathur|E1",
         "cooldown": 6,
         "icon": "storm_ui_icon_abathur_carapace.png",
-        "type": "subunit"
+        "type": "basic"
       },
       {
-        "uid": "7c6b61b",
+        "uid": "bc64f9",
+        "name": "Evolve Monstrosity Active",
+        "description": "Activate to cast Symbiote on Abathur's Monstrosity.",
+        "hotkey": "R",
+        "abilityId": "Abathur|R3",
+        "cooldown": 4,
+        "icon": "storm_ui_icon_abathur_evolvemonstrosity.png",
+        "type": "heroic"
+      },
+      {
+        "uid": "f10324",
+        "name": "Stab",
+        "description": "Shoots a spike towards target area that deals 119 (+4% per level) damage to the first enemy it contacts.",
+        "hotkey": "Q",
+        "abilityId": "Abathur|Q2",
+        "cooldown": 3,
+        "icon": "storm_ui_icon_abathur_stab.png",
+        "type": "basic"
+      },
+      {
+        "uid": "74e3e6",
+        "name": "Spike Burst",
+        "description": "Deals 120 (+4% per level) damage to nearby enemies.",
+        "hotkey": "W",
+        "abilityId": "Abathur|W2",
+        "cooldown": 6,
+        "icon": "storm_ui_icon_abathur_spikeburst.png",
+        "type": "basic"
+      },
+      {
+        "uid": "1cdf05",
         "name": "Deep Tunnel",
         "description": "Order your Evolved Monstrosity to quickly tunnel to a visible location",
         "hotkey": "Z",
         "abilityId": "Abathur|Z2",
         "cooldown": 80,
         "icon": "storm_ui_icon_abathur_mount.png",
-        "type": "subunit"
+        "type": "mount"
       }
     ]
   },

--- a/hero/alarak.json
+++ b/hero/alarak.json
@@ -1,5 +1,5 @@
 {
-  "id": "56",
+  "id": 56,
   "shortName": "alarak",
   "attributeId": "Alar",
   "cHeroId": "Alarak",
@@ -21,7 +21,7 @@
   "abilities": {
     "Alarak": [
       {
-        "uid": "1b96dbd",
+        "uid": "6e893b",
         "name": "Discord Strike",
         "description": "After a 0.5 second delay, enemies in front of Alarak take 175 (+4% per level) damage and are silenced for 1.5 seconds.",
         "hotkey": "Q",
@@ -32,7 +32,7 @@
         "type": "basic"
       },
       {
-        "uid": "e9f3fa3",
+        "uid": "ec4419",
         "name": "Telekinesis",
         "description": "Vector Targeting Create a force, pushing Alarak and all enemies hit from the targeted point towards the targeted direction. Deals 48 (+4% per level) damage to enemies.",
         "hotkey": "W",
@@ -43,7 +43,7 @@
         "type": "basic"
       },
       {
-        "uid": "aeb7b52",
+        "uid": "45c0f0",
         "name": "Lightning Surge",
         "description": "Deal 62 (+4% per level) damage to an enemy and an additional 100% damage to enemies between Alarak and the target. Restore 70 (+4% per level) health for each Hero hit.",
         "hotkey": "E",
@@ -54,18 +54,7 @@
         "type": "basic"
       },
       {
-        "uid": "3b76d00",
-        "name": "Counter-Strike",
-        "description": "Alarak targets an area and channels for 1 second, becoming Protected and Unstoppable. After, if he took damage from an enemy Hero, he sends a shockwave that deals 275 (+4% per level) damage.",
-        "hotkey": "R",
-        "abilityId": "Alarak|R2",
-        "cooldown": 30,
-        "manaCost": 50,
-        "icon": "storm_ui_icon_alarak_counterstrike.png",
-        "type": "heroic"
-      },
-      {
-        "uid": "c6f73c4",
+        "uid": "59fa15",
         "name": "Deadly Charge",
         "description": "After channeling, Alarak charges forward dealing 200 (+4% per level) damage to all enemies in his path. Distance is increased based on the amount of time channeled, up to 1.5 seconds.  Issuing a Move order while this is channeling will cancel it at no cost. Taking damage will interrupt the channeling.",
         "hotkey": "R",
@@ -76,7 +65,18 @@
         "type": "heroic"
       },
       {
-        "uid": "74c559f",
+        "uid": "b63665",
+        "name": "Counter-Strike",
+        "description": "Alarak targets an area and channels for 1 second, becoming Protected and Unstoppable. After, if he took damage from an enemy Hero, he sends a shockwave that deals 275 (+4% per level) damage.",
+        "hotkey": "R",
+        "abilityId": "Alarak|R2",
+        "cooldown": 30,
+        "manaCost": 50,
+        "icon": "storm_ui_icon_alarak_counterstrike.png",
+        "type": "heroic"
+      },
+      {
+        "uid": "f300e2",
         "name": "Sadism",
         "description": "Alarak's Ability damage and self-healing are increased by 100% against enemy Heroes.  Repeatable Quest: Takedowns increase Sadism by 3%, up to 30%. Sadism gained from Takedowns is lost on death.",
         "trait": true,
@@ -98,7 +98,9 @@
         "sort": 1,
         "abilityId": "Alarak|W1",
         "abilityLinks": [
-          "Alarak|W1"
+          "Alarak|W1",
+          "Alarak|D3",
+          "Alarak|D4"
         ]
       },
       {
@@ -109,8 +111,9 @@
         "icon": "storm_ui_icon_alarak_lightningsurge_a.png",
         "type": "E",
         "sort": 2,
-        "abilityId": "Alarak|E1",
+        "abilityId": "Alarak|E2",
         "abilityLinks": [
+          "Alarak|E2",
           "Alarak|E1"
         ]
       },
@@ -123,8 +126,9 @@
         "type": "E",
         "sort": 3,
         "isQuest": true,
-        "abilityId": "Alarak|E1",
+        "abilityId": "Alarak|E2",
         "abilityLinks": [
+          "Alarak|E2",
           "Alarak|E1"
         ]
       }
@@ -153,8 +157,9 @@
         "type": "E",
         "sort": 2,
         "isQuest": true,
-        "abilityId": "Alarak|E1",
+        "abilityId": "Alarak|E2",
         "abilityLinks": [
+          "Alarak|E2",
           "Alarak|E1"
         ]
       },
@@ -166,8 +171,10 @@
         "icon": "storm_ui_icon_alarak_sadism.png",
         "type": "Trait",
         "sort": 3,
-        "abilityId": "Alarak|D1",
+        "abilityId": "Alarak|D3",
         "abilityLinks": [
+          "Alarak|D3",
+          "Alarak|D4",
           "Alarak|D1"
         ]
       }
@@ -252,8 +259,10 @@
         "icon": "storm_ui_icon_alarak_sadism.png",
         "type": "Trait",
         "sort": 1,
-        "abilityId": "Alarak|D1",
+        "abilityId": "Alarak|D3",
         "abilityLinks": [
+          "Alarak|D3",
+          "Alarak|D4",
           "Alarak|D1"
         ]
       },
@@ -265,8 +274,10 @@
         "icon": "storm_ui_icon_alarak_sadism_a.png",
         "type": "Trait",
         "sort": 2,
-        "abilityId": "Alarak|D1",
+        "abilityId": "Alarak|D3",
         "abilityLinks": [
+          "Alarak|D3",
+          "Alarak|D4",
           "Alarak|D1"
         ]
       },
@@ -278,8 +289,7 @@
         "icon": "storm_ui_icon_alarak_sadism_b.png",
         "type": "Trait",
         "sort": 3,
-        "cooldown": 300,
-        "abilityId": "Alarak|Trait"
+        "cooldown": 300
       }
     ],
     "16": [
@@ -304,8 +314,9 @@
         "icon": "storm_ui_icon_alarak_lightningsurge.png",
         "type": "E",
         "sort": 2,
-        "abilityId": "Alarak|E1",
+        "abilityId": "Alarak|E2",
         "abilityLinks": [
+          "Alarak|E2",
           "Alarak|E1"
         ]
       },
@@ -319,6 +330,8 @@
         "sort": 3,
         "abilityId": "Alarak|Passive",
         "abilityLinks": [
+          "Alarak|D3",
+          "Alarak|D4",
           "Alarak|D1"
         ]
       }
@@ -332,8 +345,7 @@
         "icon": "storm_ui_icon_alarak_counterstrike.png",
         "type": "Heroic",
         "sort": 1,
-        "cooldown": 30,
-        "abilityId": "Alarak|Heroic"
+        "cooldown": 30
       },
       {
         "tooltipId": "AlarakDeadlyCharge",

--- a/hero/alarak.json
+++ b/hero/alarak.json
@@ -98,9 +98,7 @@
         "sort": 1,
         "abilityId": "Alarak|W1",
         "abilityLinks": [
-          "Alarak|W1",
-          "Alarak|D3",
-          "Alarak|D4"
+          "Alarak|W1"
         ]
       },
       {
@@ -111,9 +109,8 @@
         "icon": "storm_ui_icon_alarak_lightningsurge_a.png",
         "type": "E",
         "sort": 2,
-        "abilityId": "Alarak|E2",
+        "abilityId": "Alarak|E1",
         "abilityLinks": [
-          "Alarak|E2",
           "Alarak|E1"
         ]
       },
@@ -126,9 +123,8 @@
         "type": "E",
         "sort": 3,
         "isQuest": true,
-        "abilityId": "Alarak|E2",
+        "abilityId": "Alarak|E1",
         "abilityLinks": [
-          "Alarak|E2",
           "Alarak|E1"
         ]
       }
@@ -157,9 +153,8 @@
         "type": "E",
         "sort": 2,
         "isQuest": true,
-        "abilityId": "Alarak|E2",
+        "abilityId": "Alarak|E1",
         "abilityLinks": [
-          "Alarak|E2",
           "Alarak|E1"
         ]
       },
@@ -171,10 +166,8 @@
         "icon": "storm_ui_icon_alarak_sadism.png",
         "type": "Trait",
         "sort": 3,
-        "abilityId": "Alarak|D3",
+        "abilityId": "Alarak|D1",
         "abilityLinks": [
-          "Alarak|D3",
-          "Alarak|D4",
           "Alarak|D1"
         ]
       }
@@ -259,10 +252,8 @@
         "icon": "storm_ui_icon_alarak_sadism.png",
         "type": "Trait",
         "sort": 1,
-        "abilityId": "Alarak|D3",
+        "abilityId": "Alarak|D1",
         "abilityLinks": [
-          "Alarak|D3",
-          "Alarak|D4",
           "Alarak|D1"
         ]
       },
@@ -274,10 +265,8 @@
         "icon": "storm_ui_icon_alarak_sadism_a.png",
         "type": "Trait",
         "sort": 2,
-        "abilityId": "Alarak|D3",
+        "abilityId": "Alarak|D1",
         "abilityLinks": [
-          "Alarak|D3",
-          "Alarak|D4",
           "Alarak|D1"
         ]
       },
@@ -314,9 +303,8 @@
         "icon": "storm_ui_icon_alarak_lightningsurge.png",
         "type": "E",
         "sort": 2,
-        "abilityId": "Alarak|E2",
+        "abilityId": "Alarak|E1",
         "abilityLinks": [
-          "Alarak|E2",
           "Alarak|E1"
         ]
       },
@@ -330,8 +318,6 @@
         "sort": 3,
         "abilityId": "Alarak|Passive",
         "abilityLinks": [
-          "Alarak|D3",
-          "Alarak|D4",
           "Alarak|D1"
         ]
       }

--- a/hero/alexstrasza.json
+++ b/hero/alexstrasza.json
@@ -1,5 +1,5 @@
 {
-  "id": "74",
+  "id": 74,
   "shortName": "alexstrasza",
   "attributeId": "Alex",
   "cHeroId": "Alexstrasza",
@@ -20,7 +20,7 @@
   "abilities": {
     "Alexstrasza": [
       {
-        "uid": "b7c5d9e",
+        "uid": "71e1bd",
         "name": "Gift of Life",
         "description": "Sacrifice 15% of Alexstrasza's current Health, healing an allied Hero for 150% of that amount.  Dragonqueen: Breath of Life Cooldown greatly reduced and does not cost Health.",
         "hotkey": "Q",
@@ -30,7 +30,7 @@
         "type": "basic"
       },
       {
-        "uid": "cf4e573",
+        "uid": "2b7cd6",
         "name": "Abundance",
         "description": "Plant a seed of healing that blooms after 3 seconds, healing nearby allied Heroes for 20% of their maximum Health.  Dragonqueen: Preservation Heal area and amount greatly increased.",
         "hotkey": "W",
@@ -41,7 +41,7 @@
         "type": "basic"
       },
       {
-        "uid": "9a18508",
+        "uid": "6c099c",
         "name": "Flame Buffet",
         "description": "Launch a fireball, Burning enemies hit for 75 (+4% per level) damage over 5.5 seconds.  Hitting enemies that are already Burning deals 125 (+4% per level) bonus damage upon impact, Slows them by 40% decaying over 2 seconds, and refunds the Mana cost.  Dragonqueen: Wing Buffet Damage and Knockback enemies in an arc.",
         "hotkey": "E",
@@ -52,7 +52,7 @@
         "type": "basic"
       },
       {
-        "uid": "5c6e17b",
+        "uid": "58759f",
         "name": "Life-Binder",
         "description": "Bind Alexstrasza's life force with an allied Hero. Both her and her target are healed for 480 (+4% per level) Health over 2 seconds. Afterwards, the Hero with a lower percentage of Health is healed to the same Health percentage as the other Hero.",
         "hotkey": "R",
@@ -63,7 +63,7 @@
         "type": "heroic"
       },
       {
-        "uid": "d250be7",
+        "uid": "e1d349",
         "name": "Cleansing Flame",
         "description": "After 1.25 seconds, take to the sky and drop 5 fireballs over 6 seconds at the position of the mouse cursor. Fireballs deal 135 (+4% per level) damage to enemies and heal allied Heroes for 300 (+4% per level) Health.  2 seconds after dropping all fireballs, Alexstrasza lands at the position of the mouse cursor.",
         "hotkey": "R",
@@ -74,10 +74,9 @@
         "type": "heroic"
       },
       {
-        "uid": "e9f0c50",
+        "uid": "f898b0",
         "name": "Dragonqueen",
         "description": "After 1.25 seconds, transform into a dragon and gain 500 (+4% per level) Health.  While Dragonqueen is active, Alexstrasza's Abilities are empowered, and her Basic Attacks deal 143 (+4% per level) damage and heal allied Heroes for 43 (+4% per level) in an arc in front of her. Additionally, the duration of incoming Stuns, Roots, and Slows, is reduced by 50%.  Lasts 15 seconds.",
-        "hotkey": "D",
         "trait": true,
         "abilityId": "Alexstrasza|D1",
         "cooldown": 150,
@@ -87,45 +86,65 @@
     ],
     "AlexstraszaDragon": [
       {
-        "uid": "5ed3eb0",
+        "uid": "58759f",
+        "name": "Life-Binder",
+        "description": "Bind Alexstrasza's life force with an allied Hero. Both her and her target are healed for 480 (+4% per level) Health over 2 seconds. Afterwards, the Hero with a lower percentage of Health is healed to the same Health percentage as the other Hero.",
+        "hotkey": "R",
+        "abilityId": "Alexstrasza|R3",
+        "cooldown": 60,
+        "manaCost": 60,
+        "icon": "storm_ui_icon_alexstrasza_life_binder.png",
+        "type": "heroic"
+      },
+      {
+        "uid": "8a1ec5",
         "name": "Breath of Life",
         "description": "Heal an allied Hero for 20% of Alexstrasza's current Health.",
         "hotkey": "Q",
         "abilityId": "Alexstrasza|Q2",
         "cooldown": 3,
         "icon": "storm_ui_icon_alexstrasza_breath_of_life.png",
-        "type": "subunit"
+        "type": "basic"
       },
       {
-        "uid": "ea7d594",
+        "uid": "25a137",
         "name": "Preservation",
         "description": "Plant a seed of healing that blooms after 3 seconds, healing nearby allied Heroes for 30% of their maximum Health.",
         "hotkey": "W",
         "abilityId": "Alexstrasza|W2",
         "cooldown": 16,
         "icon": "storm_ui_icon_alexstrasza_preservation.png",
-        "type": "subunit"
+        "type": "basic"
       },
       {
-        "uid": "5e392ea",
+        "uid": "585e96",
         "name": "Wing Buffet",
         "description": "Deal 150 (+4% per level) damage to enemies in an area, knocking them back and Slowing them by 50% for 3 seconds.",
         "hotkey": "E",
         "abilityId": "Alexstrasza|E2",
         "cooldown": 4,
         "icon": "storm_ui_icon_alexstrasza_wing_buffet.png",
-        "type": "subunit"
+        "type": "basic"
       },
       {
-        "uid": "4125e5b",
+        "uid": "21ea10",
+        "name": "Dragonqueen",
+        "description": "Alexstrasza has transformed into a powerful dragon aspect, gaining 500 (+4% per level) Health, resistance to disabling effects, and empowered Basic Attacks and Abilities.",
+        "trait": true,
+        "abilityId": "Alexstrasza|D2",
+        "icon": "storm_ui_icon_alexstrasza_dragon_queen.png",
+        "type": "trait"
+      },
+      {
+        "uid": "60a035",
         "name": "Cleansing Flame",
         "description": "Take to the sky and drop 5 fireballs over 6 seconds at the position of the mouse cursor. Fireballs deal 135 (+4% per level) damage to enemies and heal allied Heroes for 300 (+4% per level) Health.  2 seconds after dropping all fireballs, Alexstrasza lands at the position of the mouse cursor.",
         "hotkey": "R",
-        "abilityId": "Alexstrasza|R3",
+        "abilityId": "Alexstrasza|R4",
         "cooldown": 90,
         "manaCost": 100,
         "icon": "storm_ui_icon_alexstrasza_cleansing_flame.png",
-        "type": "subunit"
+        "type": "heroic"
       }
     ]
   },
@@ -262,9 +281,9 @@
         "type": "Heroic",
         "sort": 1,
         "cooldown": 60,
-        "abilityId": "Alexstrasza|R1",
+        "abilityId": "Alexstrasza|R3",
         "abilityLinks": [
-          "Alexstrasza|R1"
+          "Alexstrasza|R3"
         ]
       },
       {
@@ -367,9 +386,9 @@
         "icon": "storm_ui_icon_alexstrasza_life_binder.png",
         "type": "Heroic",
         "sort": 1,
-        "abilityId": "Alexstrasza|R1",
+        "abilityId": "Alexstrasza|R3",
         "abilityLinks": [
-          "Alexstrasza|R1"
+          "Alexstrasza|R3"
         ]
       },
       {
@@ -383,7 +402,7 @@
         "abilityId": "Alexstrasza|R2",
         "abilityLinks": [
           "Alexstrasza|R2",
-          "Alexstrasza|R3"
+          "Alexstrasza|R4"
         ]
       },
       {

--- a/hero/ana.json
+++ b/hero/ana.json
@@ -1,5 +1,5 @@
 {
-  "id": "72",
+  "id": 72,
   "shortName": "ana",
   "attributeId": "HANA",
   "cHeroId": "Ana",
@@ -22,7 +22,7 @@
   "abilities": {
     "Ana": [
       {
-        "uid": "1544659",
+        "uid": "b08c06",
         "name": "Healing Dart",
         "description": "Fire a dart which heals the first allied Hero hit for 195 (+4% per level) Health. Does not affect full Health Heroes.",
         "hotkey": "Q",
@@ -33,7 +33,7 @@
         "type": "basic"
       },
       {
-        "uid": "1590783",
+        "uid": "33bdc2",
         "name": "Biotic Grenade",
         "description": "Toss a grenade at the target area. Allied Heroes hit are healed for 152 (+4% per level) Health and receive 25% increased healing from Ana for 4 seconds. Enemies hit take 60 (+4% per level) damage and receive 100% less healing for 2 seconds.",
         "hotkey": "W",
@@ -44,7 +44,7 @@
         "type": "basic"
       },
       {
-        "uid": "61433a4",
+        "uid": "0d497c",
         "name": "Sleep Dart",
         "description": "Fire a dart that puts the first enemy Hero hit to Sleep, Stunning them for 3 seconds. Sleep's effects end instantly if the target takes damage after the first 0.5 seconds.  Cannot be used on Vehicles.",
         "hotkey": "E",
@@ -55,18 +55,7 @@
         "type": "basic"
       },
       {
-        "uid": "08549fe",
-        "name": "Eye of Horus",
-        "description": "Assume a sniping position, gaining the ability to fire up to 6 specialized rounds with unlimited range. Rounds pierce allied and enemy Heroes but collide with enemy Structures in their path. Allies are healed for 225 (+4% per level) and enemies are damaged for 135 (+4% per level). Deals 50% less damage to Structures.  Ana is unable to move while Eye of Horus is active.",
-        "hotkey": "R",
-        "abilityId": "Ana|R2",
-        "cooldown": 60,
-        "manaCost": 45,
-        "icon": "storm_ui_icon_ana_overwatch.png",
-        "type": "heroic"
-      },
-      {
-        "uid": "a9a7caf",
+        "uid": "d32efd",
         "name": "Nano Boost",
         "description": "Instantly boost an allied Hero, restoring 200 Mana. For the next 8 seconds, they gain 30% Spell Power and their Basic Ability cooldowns recharge 150% faster.  Cannot be used on Ana.",
         "hotkey": "R",
@@ -77,9 +66,20 @@
         "type": "heroic"
       },
       {
-        "uid": "ff47987",
+        "uid": "cdc336",
+        "name": "Eye of Horus",
+        "description": "Assume a sniping position, gaining the ability to fire up to 6 specialized rounds with unlimited range. Rounds pierce allied and enemy Heroes but collide with enemy Structures in their path. Allies are healed for 225 (+4% per level) and enemies are damaged for 135 (+4% per level). Deals 50% less damage to Structures.  Ana is unable to move while Eye of Horus is active.",
+        "hotkey": "R",
+        "abilityId": "Ana|R2",
+        "cooldown": 60,
+        "manaCost": 45,
+        "icon": "storm_ui_icon_ana_overwatch.png",
+        "type": "heroic"
+      },
+      {
+        "uid": "314233",
         "name": "Shrike",
-        "description": "Basic Attacks apply a Dose to enemies, dealing an additional 40 (+4% per level) damage over 5 seconds, and stacking up to 5 times. Every 0.5 seconds, Ana is healed for 50% of the damage dealt by Shrike.  Aim Down Sights  Activating Shrike reduces your Movement Speed by 25%, but increases the Range of Healing Dart and Sleep Dart by 25% while also allowing them to pierce one Hero. Lasts until canceled.",
+        "description": "Basic Attacks apply a Dose to enemies, dealing an additional 40 (+4% per level) damage over 5 seconds, and stacking up to 5 times. Every 0.5 seconds, Ana is healed for 60% of the damage dealt by Shrike.  Aim Down Sights  Activating Shrike reduces your Movement Speed by 25%, but increases the Range of Healing Dart and Sleep Dart by 25% while also allowing them to pierce one Hero. Lasts until canceled.",
         "trait": true,
         "abilityId": "Ana|D1",
         "cooldown": 4,
@@ -107,7 +107,7 @@
         "tooltipId": "AnaSleepingDartSlumberShells",
         "talentTreeId": "AnaSleepingDartSlumberShells",
         "name": "Slumber Shells",
-        "description": "Upon waking, enemy Heroes are Slowed by 25% for 3 seconds.",
+        "description": "Reduce the cooldown of Sleep Dart by 4 seconds. Upon waking, enemy Heroes are Slowed by 25% for 3 seconds.",
         "icon": "storm_ui_icon_ana_sleep_dart.png",
         "type": "E",
         "sort": 2,
@@ -120,13 +120,14 @@
         "tooltipId": "AnaShrikeVampiricRounds",
         "talentTreeId": "AnaShrikeVampiricRounds",
         "name": "Vampiric Rounds",
-        "description": "Quest: Stack 5 Doses on an enemy Hero.  Reward: Increase Shrike's healing by an additional 1.5%.",
+        "description": "Quest: Stack 5 Doses on an enemy Hero or Basic Attack a Hero with 5 Doses.  Reward: Stack 5 Doses to increase Shrike's healing by 0.75%.  Reward: Basic Attack a Hero with 5 Doses to increase Shrike's healing by 0.25%.",
         "icon": "storm_ui_icon_ana_shrike.png",
         "type": "Trait",
         "sort": 3,
         "isQuest": true,
-        "abilityId": "Ana|D1",
+        "abilityId": "Ana|D2",
         "abilityLinks": [
+          "Ana|D2",
           "Ana|D1"
         ]
       }
@@ -188,7 +189,7 @@
         "tooltipId": "AnaSleepDartNightTerrors",
         "talentTreeId": "AnaSleepDartNightTerrors",
         "name": "Night Terrors",
-        "description": "Upon waking, enemy Heroes take 10% of their Maximum Health in damage. If a Hero is not woken up early, set the cooldown of Sleep Dart to 5 seconds.",
+        "description": "Gain 20% Movement Speed for 2 seconds for every Hero hit by Sleeping Dart. Upon waking, enemy Heroes take 10% of their Maximum Health in damage.",
         "icon": "storm_ui_icon_ana_sleep_dart.png",
         "type": "E",
         "sort": 2,
@@ -205,8 +206,9 @@
         "icon": "storm_ui_icon_ana_shrike.png",
         "type": "Trait",
         "sort": 3,
-        "abilityId": "Ana|D1",
+        "abilityId": "Ana|D2",
         "abilityLinks": [
+          "Ana|D2",
           "Ana|D1"
         ]
       }
@@ -318,8 +320,7 @@
         "type": "Active",
         "sort": 3,
         "cooldown": 60,
-        "isQuest": true,
-        "abilityId": "Ana|Q1",
+        "abilityId": "Ana|Active",
         "abilityLinks": [
           "Ana|Q1"
         ]
@@ -360,8 +361,9 @@
         "icon": "storm_ui_icon_ana_aim_down_sights.png",
         "type": "Trait",
         "sort": 3,
-        "abilityId": "Ana|D1",
+        "abilityId": "Ana|D2",
         "abilityLinks": [
+          "Ana|D2",
           "Ana|D1"
         ]
       },
@@ -373,8 +375,9 @@
         "icon": "storm_ui_icon_ana_aim_down_sights_a.png",
         "type": "Trait",
         "sort": 4,
-        "abilityId": "Ana|D1",
+        "abilityId": "Ana|D2",
         "abilityLinks": [
+          "Ana|D2",
           "Ana|D1"
         ]
       }

--- a/hero/ana.json
+++ b/hero/ana.json
@@ -125,9 +125,8 @@
         "type": "Trait",
         "sort": 3,
         "isQuest": true,
-        "abilityId": "Ana|D2",
+        "abilityId": "Ana|D1",
         "abilityLinks": [
-          "Ana|D2",
           "Ana|D1"
         ]
       }
@@ -206,9 +205,8 @@
         "icon": "storm_ui_icon_ana_shrike.png",
         "type": "Trait",
         "sort": 3,
-        "abilityId": "Ana|D2",
+        "abilityId": "Ana|D1",
         "abilityLinks": [
-          "Ana|D2",
           "Ana|D1"
         ]
       }
@@ -361,9 +359,8 @@
         "icon": "storm_ui_icon_ana_aim_down_sights.png",
         "type": "Trait",
         "sort": 3,
-        "abilityId": "Ana|D2",
+        "abilityId": "Ana|D1",
         "abilityLinks": [
-          "Ana|D2",
           "Ana|D1"
         ]
       },
@@ -375,9 +372,8 @@
         "icon": "storm_ui_icon_ana_aim_down_sights_a.png",
         "type": "Trait",
         "sort": 4,
-        "abilityId": "Ana|D2",
+        "abilityId": "Ana|D1",
         "abilityLinks": [
-          "Ana|D2",
           "Ana|D1"
         ]
       }

--- a/hero/anduin.json
+++ b/hero/anduin.json
@@ -1,5 +1,5 @@
 {
-  "id": "86",
+  "id": 86,
   "shortName": "anduin",
   "attributeId": "Andu",
   "cHeroId": "Anduin",
@@ -21,7 +21,7 @@
   "abilities": {
     "Anduin": [
       {
-        "uid": "802a33e",
+        "uid": "751a85",
         "name": "Flash Heal",
         "description": "Cast for 0.75 seconds to heal an allied Hero for 260 (+4% per level).",
         "hotkey": "Q",
@@ -32,7 +32,7 @@
         "type": "basic"
       },
       {
-        "uid": "d989498",
+        "uid": "1beab5",
         "name": "Divine Star",
         "description": "Send light that deals 140 (+4% per level) damage to enemies and then returns to Anduin, healing allied Heroes for 130 (+4% per level) in a wider path. Healing increases by 25% per enemy Hero hit.",
         "hotkey": "W",
@@ -43,7 +43,7 @@
         "type": "basic"
       },
       {
-        "uid": "c40938f",
+        "uid": "daab16",
         "name": "Chastise",
         "description": "Shove a swell of light forward, dealing 145 (+4% per level) damage to the first enemy Hero hit and Rooting them for 1.25 seconds.",
         "hotkey": "E",
@@ -54,7 +54,7 @@
         "type": "basic"
       },
       {
-        "uid": "7e2826e",
+        "uid": "045573",
         "name": "Holy Word: Salvation",
         "description": "After 0.5 seconds, Channel to invoke the Light for 3 seconds. While nearby, allied Heroes heal for up to 25% of their max Health and are Protected.",
         "hotkey": "R",
@@ -65,7 +65,7 @@
         "type": "heroic"
       },
       {
-        "uid": "ffadaf9",
+        "uid": "268fc4",
         "name": "Lightbomb",
         "description": "Imbue an allied Hero with the Light. After 1.5 seconds, it explodes, dealing 150 (+4% per level) damage to enemies and Stunning them for 1.25 seconds.  The target gains a Shield that absorbs 165 (+4% per level) damage per enemy Hero hit. Lasts for 5 seconds.",
         "hotkey": "R",
@@ -76,7 +76,7 @@
         "type": "heroic"
       },
       {
-        "uid": "70dbcbd",
+        "uid": "82b883",
         "name": "Leap of Faith",
         "description": "Faith instantly pulls an allied Hero to Anduin's location, granting them Unstoppable while they travel.",
         "trait": true,

--- a/hero/anubarak.json
+++ b/hero/anubarak.json
@@ -1,5 +1,5 @@
 {
-  "id": "31",
+  "id": 31,
   "shortName": "anubarak",
   "attributeId": "Anub",
   "cHeroId": "Anubarak",
@@ -10,7 +10,7 @@
   "expandedRole": "Tank",
   "type": "Melee",
   "releaseDate": "2014-10-07",
-  "releasePatch": "0.6.5.32455",
+  "releasePatch": "0.6.5.32455 ",
   "tags": [
     "BodyBlocker",
     "EnergyImportant",
@@ -20,68 +20,68 @@
     "RoleTank"
   ],
   "abilities": {
-    "Anub'arak": [
+    "Anubarak": [
       {
-        "uid": "b2732b2",
+        "uid": "a326d7",
         "name": "Impale",
         "description": "Deals 90 (+4% per level) damage. Stuns for 1 second.",
         "hotkey": "Q",
-        "abilityId": "Anub'arak|Q1",
+        "abilityId": "Anubarak|Q1",
         "cooldown": 12,
         "manaCost": 65,
         "icon": "storm_ui_icon_anubarak_impale.png",
         "type": "basic"
       },
       {
-        "uid": "7ba9477",
+        "uid": "7338e3",
         "name": "Harden Carapace",
         "description": "Gain a Shield that grants 40 Spell Armor and absorbs 315 (+4% per level) damage over 3 seconds.",
         "hotkey": "W",
-        "abilityId": "Anub'arak|W1",
+        "abilityId": "Anubarak|W1",
         "cooldown": 7,
         "manaCost": 25,
         "icon": "storm_ui_icon_anubarak_hardencarapace_var1.png",
         "type": "basic"
       },
       {
-        "uid": "fe6aaf9",
+        "uid": "231bd0",
         "name": "Burrow Charge",
         "description": "Burrow to the target location, dealing 91 (+4% per level) damage and briefly stunning enemies in a small area upon surfacing, slowing them by 25% for 2.5 seconds.  Burrow Charge can be reactivated to surface early.",
         "hotkey": "E",
-        "abilityId": "Anub'arak|E1",
+        "abilityId": "Anubarak|E1",
         "cooldown": 14,
         "manaCost": 65,
         "icon": "storm_ui_icon_anubarak_burrowcharge.png",
         "type": "basic"
       },
       {
-        "uid": "70ba35f",
+        "uid": "d0c32b",
         "name": "Locust Swarm",
         "description": "Deal 62 (+4% per level) damage per second to nearby enemies. Each enemy damaged restores 21 (+4% per level) Health. Lasts 6 seconds.",
         "hotkey": "R",
-        "abilityId": "Anub'arak|R1",
+        "abilityId": "Anubarak|R1",
         "cooldown": 100,
         "manaCost": 75,
         "icon": "storm_ui_icon_anubarak_locustswarm.png",
         "type": "heroic"
       },
       {
-        "uid": "3b2098b",
+        "uid": "a193d1",
         "name": "Cocoon",
         "description": "Wraps target enemy Hero in a cocoon, rendering them unable to act or be targeted for 7 seconds. Allies of the Hero can attack the cocoon to break it and free them early.",
         "hotkey": "R",
-        "abilityId": "Anub'arak|R2",
+        "abilityId": "Anubarak|R2",
         "cooldown": 70,
         "manaCost": 70,
         "icon": "storm_ui_icon_anubarak_webblast.png",
         "type": "heroic"
       },
       {
-        "uid": "680f5d4",
+        "uid": "9f9721",
         "name": "Scarab Host",
         "description": "Using an Ability spawns a Beetle which lasts for 8 seconds, attacking nearby enemies for 20 (+4% per level) damage.",
         "trait": true,
-        "abilityId": "Anub'arak|D1",
+        "abilityId": "Anubarak|D1",
         "cooldown": 8,
         "icon": "storm_ui_icon_anubarak_scarabhost.png",
         "type": "trait"
@@ -98,9 +98,9 @@
         "icon": "storm_ui_icon_anubarak_hardencarapace_var1.png",
         "type": "W",
         "sort": 1,
-        "abilityId": "Anub'arak|W1",
+        "abilityId": "Anubarak|W1",
         "abilityLinks": [
-          "Anub'arak|W1"
+          "Anubarak|W1"
         ]
       },
       {
@@ -111,9 +111,9 @@
         "icon": "storm_ui_icon_anubarak_scarabhost.png",
         "type": "Trait",
         "sort": 2,
-        "abilityId": "Anub'arak|D1",
+        "abilityId": "Anubarak|D1",
         "abilityLinks": [
-          "Anub'arak|D1"
+          "Anubarak|D1"
         ]
       },
       {
@@ -125,7 +125,7 @@
         "type": "Passive",
         "sort": 3,
         "isQuest": true,
-        "abilityId": "Anub'arak|Passive"
+        "abilityId": "Anubarak|Passive"
       }
     ],
     "4": [
@@ -137,9 +137,9 @@
         "icon": "storm_ui_icon_anubarak_impale.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "Anub'arak|Q1",
+        "abilityId": "Anubarak|Q1",
         "abilityLinks": [
-          "Anub'arak|Q1"
+          "Anubarak|Q1"
         ]
       },
       {
@@ -150,9 +150,9 @@
         "icon": "storm_ui_icon_anubarak_hardencarapace_var1.png",
         "type": "W",
         "sort": 2,
-        "abilityId": "Anub'arak|W1",
+        "abilityId": "Anubarak|W1",
         "abilityLinks": [
-          "Anub'arak|W1"
+          "Anubarak|W1"
         ]
       },
       {
@@ -163,9 +163,9 @@
         "icon": "storm_ui_icon_anubarak_burrowcharge.png",
         "type": "E",
         "sort": 3,
-        "abilityId": "Anub'arak|E1",
+        "abilityId": "Anubarak|E1",
         "abilityLinks": [
-          "Anub'arak|E1"
+          "Anubarak|E1"
         ]
       }
     ],
@@ -178,9 +178,9 @@
         "icon": "storm_ui_icon_anubarak_hardencarapace_var2.png",
         "type": "W",
         "sort": 1,
-        "abilityId": "Anub'arak|W1",
+        "abilityId": "Anubarak|W1",
         "abilityLinks": [
-          "Anub'arak|W1"
+          "Anubarak|W1"
         ]
       },
       {
@@ -191,9 +191,9 @@
         "icon": "storm_ui_icon_anubarak_burrowcharge.png",
         "type": "E",
         "sort": 2,
-        "abilityId": "Anub'arak|E1",
+        "abilityId": "Anubarak|E1",
         "abilityLinks": [
-          "Anub'arak|E1"
+          "Anubarak|E1"
         ]
       },
       {
@@ -204,9 +204,9 @@
         "icon": "storm_ui_icon_anubarak_scarabhost.png",
         "type": "Trait",
         "sort": 3,
-        "abilityId": "Anub'arak|D1",
+        "abilityId": "Anubarak|D1",
         "abilityLinks": [
-          "Anub'arak|D1"
+          "Anubarak|D1"
         ]
       }
     ],
@@ -220,9 +220,9 @@
         "type": "Heroic",
         "sort": 1,
         "cooldown": 100,
-        "abilityId": "Anub'arak|R1",
+        "abilityId": "Anubarak|R1",
         "abilityLinks": [
-          "Anub'arak|R1"
+          "Anubarak|R1"
         ]
       },
       {
@@ -234,9 +234,9 @@
         "type": "Heroic",
         "sort": 2,
         "cooldown": 70,
-        "abilityId": "Anub'arak|R2",
+        "abilityId": "Anubarak|R2",
         "abilityLinks": [
-          "Anub'arak|R2"
+          "Anubarak|R2"
         ]
       }
     ],
@@ -249,7 +249,7 @@
         "icon": "storm_ui_icon_talent_burningrage.png",
         "type": "Passive",
         "sort": 1,
-        "abilityId": "Anub'arak|Passive"
+        "abilityId": "Anubarak|Passive"
       },
       {
         "tooltipId": "AnubarakHardenCarapaceUrtricatingSpinesTalent",
@@ -259,9 +259,9 @@
         "icon": "storm_ui_icon_anubarak_hardencarapace_var1.png",
         "type": "W",
         "sort": 2,
-        "abilityId": "Anub'arak|W1",
+        "abilityId": "Anubarak|W1",
         "abilityLinks": [
-          "Anub'arak|W1"
+          "Anubarak|W1"
         ]
       },
       {
@@ -272,7 +272,7 @@
         "icon": "storm_ui_icon_talent_autoattack_damage.png",
         "type": "Passive",
         "sort": 3,
-        "abilityId": "Anub'arak|Passive"
+        "abilityId": "Anubarak|Passive"
       }
     ],
     "16": [
@@ -284,9 +284,9 @@
         "icon": "storm_ui_icon_anubarak_burrowcharge.png",
         "type": "E",
         "sort": 1,
-        "abilityId": "Anub'arak|E1",
+        "abilityId": "Anubarak|E1",
         "abilityLinks": [
-          "Anub'arak|E1"
+          "Anubarak|E1"
         ]
       },
       {
@@ -297,9 +297,9 @@
         "icon": "storm_ui_icon_anubarak_burrowcharge_a.png",
         "type": "E",
         "sort": 2,
-        "abilityId": "Anub'arak|E1",
+        "abilityId": "Anubarak|E1",
         "abilityLinks": [
-          "Anub'arak|E1"
+          "Anubarak|E1"
         ]
       },
       {
@@ -310,9 +310,9 @@
         "icon": "storm_ui_icon_anubarak_scarabhost.png",
         "type": "Passive",
         "sort": 3,
-        "abilityId": "Anub'arak|Passive",
+        "abilityId": "Anubarak|Passive",
         "abilityLinks": [
-          "Anub'arak|D1"
+          "Anubarak|D1"
         ]
       }
     ],
@@ -325,9 +325,9 @@
         "icon": "storm_ui_icon_anubarak_locustswarm.png",
         "type": "Heroic",
         "sort": 1,
-        "abilityId": "Anub'arak|R1",
+        "abilityId": "Anubarak|R1",
         "abilityLinks": [
-          "Anub'arak|R1"
+          "Anubarak|R1"
         ]
       },
       {
@@ -338,9 +338,9 @@
         "icon": "storm_ui_icon_anubarak_webblast.png",
         "type": "Heroic",
         "sort": 2,
-        "abilityId": "Anub'arak|R2",
+        "abilityId": "Anubarak|R2",
         "abilityLinks": [
-          "Anub'arak|R2"
+          "Anubarak|R2"
         ]
       },
       {
@@ -352,7 +352,7 @@
         "type": "Active",
         "sort": 3,
         "cooldown": 60,
-        "abilityId": "Anub'arak|Active"
+        "abilityId": "Anubarak|Active"
       },
       {
         "tooltipId": "GenericRewindHotbar",
@@ -363,7 +363,7 @@
         "type": "Active",
         "sort": 4,
         "cooldown": 60,
-        "abilityId": "Anub'arak|Active"
+        "abilityId": "Anubarak|Active"
       }
     ]
   }

--- a/hero/artanis.json
+++ b/hero/artanis.json
@@ -1,5 +1,5 @@
 {
-  "id": "43",
+  "id": 43,
   "shortName": "artanis",
   "attributeId": "Arts",
   "cHeroId": "Artanis",
@@ -22,7 +22,7 @@
   "abilities": {
     "Artanis": [
       {
-        "uid": "c569089",
+        "uid": "0923a7",
         "name": "Blade Dash",
         "description": "Dash forward and deal 57 (+4% per level) damage to enemies, then return and deal 171 (+4% per level) damage. Every enemy hit reduces the cooldown on Shield Overload by 1 second, and Heroes by 2 seconds.",
         "hotkey": "Q",
@@ -33,7 +33,7 @@
         "type": "basic"
       },
       {
-        "uid": "74e9d34",
+        "uid": "5a69cf",
         "name": "Twin Blades",
         "description": "Artanis's next Basic Attack immediately causes him to charge a short distance and strike the enemy 2 times.",
         "hotkey": "W",
@@ -44,7 +44,7 @@
         "type": "basic"
       },
       {
-        "uid": "b04f75c",
+        "uid": "5c46cf",
         "name": "Phase Prism",
         "description": "Fire a Phase Prism that deals 66 (+4% per level) damage to the first Hero hit and swaps Artanis's position with theirs. Can be used during Blade Dash.",
         "hotkey": "E",
@@ -55,7 +55,7 @@
         "type": "basic"
       },
       {
-        "uid": "5c93f95",
+        "uid": "e3d8fb",
         "name": "Purifier Beam",
         "description": "Target an enemy Hero with an orbital beam from the Spear of Adun, dealing 184 (+4% per level) damage per second for 8 seconds. The beam will chase the target as they move.  Unlimited range.",
         "hotkey": "R",
@@ -66,7 +66,7 @@
         "type": "heroic"
       },
       {
-        "uid": "15c0925",
+        "uid": "c01f63",
         "name": "Suppression Pulse",
         "description": "Fire a large area pulse from the Spear of Adun, dealing 114 (+4% per level) damage and Blinding enemies for 4 seconds. Unlimited range.",
         "hotkey": "R",
@@ -77,7 +77,7 @@
         "type": "heroic"
       },
       {
-        "uid": "3691f55",
+        "uid": "0c414a",
         "name": "Shield Overload",
         "description": "After taking damage while below 75% Health, Artanis gains a 375 (+4% per level) Shield for 5 seconds. Basic Attacks lower the cooldown of Shield Overload by 4 seconds.",
         "trait": true,
@@ -363,7 +363,7 @@
         "tooltipId": "ArtanisSpearofAdunPurifierBeamTargetPurifiedTalent",
         "talentTreeId": "ArtanisSpearofAdunPurifierBeamTargetPurified",
         "name": "Target Purified",
-        "description": "Increase the speed of Purifier Beam by 15%. If the target of Purifier Beam dies, it automatically recasts on the nearest visible enemy Hero.",
+        "description": "Increase the speed of Purifier Beam by 14%. If the target of Purifier Beam dies, it automatically recasts on the nearest visible enemy Hero.",
         "icon": "storm_ui_icon_artanis_purifierbeam.png",
         "type": "Heroic",
         "sort": 2,

--- a/hero/arthas.json
+++ b/hero/arthas.json
@@ -1,5 +1,5 @@
 {
-  "id": "2",
+  "id": 2,
   "shortName": "arthas",
   "attributeId": "Arth",
   "cHeroId": "Arthas",
@@ -21,7 +21,7 @@
   "abilities": {
     "Arthas": [
       {
-        "uid": "08af6cf",
+        "uid": "7bb3a3",
         "name": "Death Coil",
         "description": "Deals 164 (+4% per level) damage to target enemy.  Can be self-cast to heal for 262 (+4% per level) Health.",
         "hotkey": "Q",
@@ -32,7 +32,7 @@
         "type": "basic"
       },
       {
-        "uid": "a4f68c5",
+        "uid": "b09701",
         "name": "Howling Blast",
         "description": "Root enemies within the target area for 1.25 seconds and deals 68 (+4% per level) damage.",
         "hotkey": "W",
@@ -43,19 +43,18 @@
         "type": "basic"
       },
       {
-        "uid": "1930221",
+        "uid": "ddbb50",
         "name": "Frozen Tempest",
         "description": "Deal 40 (+4% per level) damage per second to nearby enemies and Slow their Movement Speed by 10% per second, stacking up to 40%. Heroes hit also have their Attack Speed Slowed by 10% per second, stacking up to 40%. Frozen Tempest's effects last for 1.5 seconds.",
         "hotkey": "E",
         "abilityId": "Arthas|E1",
         "cooldown": 1,
-        "manaCost": 13,
-        "manaPerSecond": true,
+        "manaCost": "second",
         "icon": "storm_ui_icon_arthas_frosentempest.png",
         "type": "basic"
       },
       {
-        "uid": "1ad376e",
+        "uid": "2f62cd",
         "name": "Army of the Dead",
         "description": "Summons Ghouls that last 15 seconds. Sacrifice Ghouls to heal for 267 (+4% per level) Health.",
         "hotkey": "R",
@@ -66,7 +65,7 @@
         "type": "heroic"
       },
       {
-        "uid": "7ed0261",
+        "uid": "f397dc",
         "name": "Summon Sindragosa",
         "description": "Deals 230 (+4% per level) damage and Slows enemies by 60% for 4 seconds. Also disables Minions, Mercenaries, Monsters and Structures for 20 seconds.",
         "hotkey": "R",
@@ -77,10 +76,9 @@
         "type": "heroic"
       },
       {
-        "uid": "3f03735",
+        "uid": "61918e",
         "name": "Frostmourne Hungers",
         "description": "Activate to make Arthas's next Basic Attack strike immediately and deal 99 (+4% per level) increased damage. Dealing damage restores 30 Mana.",
-        "hotkey": "D",
         "trait": true,
         "abilityId": "Arthas|D1",
         "cooldown": 10,
@@ -329,8 +327,9 @@
         "icon": "storm_ui_icon_arthas_armyofthedead.png",
         "type": "Heroic",
         "sort": 1,
-        "abilityId": "Arthas|R1",
+        "abilityId": "Arthas|R3",
         "abilityLinks": [
+          "Arthas|R3",
           "Arthas|R1"
         ]
       },

--- a/hero/arthas.json
+++ b/hero/arthas.json
@@ -327,9 +327,8 @@
         "icon": "storm_ui_icon_arthas_armyofthedead.png",
         "type": "Heroic",
         "sort": 1,
-        "abilityId": "Arthas|R3",
+        "abilityId": "Arthas|R1",
         "abilityLinks": [
-          "Arthas|R3",
           "Arthas|R1"
         ]
       },

--- a/hero/auriel.json
+++ b/hero/auriel.json
@@ -1,5 +1,5 @@
 {
-  "id": "55",
+  "id": 55,
   "shortName": "auriel",
   "attributeId": "Auri",
   "cHeroId": "Auriel",
@@ -20,7 +20,7 @@
   "abilities": {
     "Auriel": [
       {
-        "uid": "4548738",
+        "uid": "a2f4fb",
         "name": "Sacred Sweep",
         "description": "Sweep the area with sacred power, dealing 45 (+4% per level) damage to enemies and an additional 180 (+4% per level) damage to enemies caught in the center.",
         "hotkey": "Q",
@@ -30,7 +30,7 @@
         "type": "basic"
       },
       {
-        "uid": "2a9f4a1",
+        "uid": "0d751e",
         "name": "Ray of Heaven",
         "description": "Consume Auriel's stored energy and heal allied Heroes in the area for the amount of energy consumed.",
         "hotkey": "W",
@@ -40,7 +40,7 @@
         "type": "basic"
       },
       {
-        "uid": "3d53c98",
+        "uid": "8df1df",
         "name": "Detainment Strike",
         "description": "Deal 55 (+4% per level) damage to the first enemy Hero hit and knock them back. If they collide with terrain, they are also stunned for 1.25 seconds and take an additional 165 (+4% per level) damage.",
         "hotkey": "E",
@@ -50,17 +50,7 @@
         "type": "basic"
       },
       {
-        "uid": "2936574",
-        "name": "Crystal Aegis",
-        "description": "Place an allied Hero into Stasis for 2 seconds. Upon expiration, Crystal Aegis deals 255 (+4% per level) damage to all nearby enemies.",
-        "hotkey": "R",
-        "abilityId": "Auriel|R2",
-        "cooldown": 60,
-        "icon": "storm_ui_icon_auriel_ribboncocoon.png",
-        "type": "heroic"
-      },
-      {
-        "uid": "7ab1c33",
+        "uid": "29fc08",
         "name": "Resurrect",
         "description": "Channel on the spirit of a dead ally for 0.5 seconds. After a 5 second delay, they are brought back to life with 50% of their maximum Health at the location where they died.",
         "hotkey": "R",
@@ -70,13 +60,22 @@
         "type": "heroic"
       },
       {
-        "uid": "ed0440b",
+        "uid": "9ffc43",
+        "name": "Crystal Aegis",
+        "description": "Place an allied Hero into Stasis for 2 seconds. Upon expiration, Crystal Aegis deals 255 (+4% per level) damage to all nearby enemies.",
+        "hotkey": "R",
+        "abilityId": "Auriel|R2",
+        "cooldown": 60,
+        "icon": "storm_ui_icon_auriel_ribboncocoon.png",
+        "type": "heroic"
+      },
+      {
+        "uid": "f6db43",
         "name": "Bestow Hope",
         "description": "Passive: 60% of the damage Auriel deals to Heroes and 20% dealt to non-Heroes is stored as energy.  Bestow an allied Hero with Hope.  While they remain near Auriel, 30% of their damage to Heroes and 10% of their damage to non-Heroes is converted to energy. Auriel can only have Bestow Hope on 1 ally at a time.  Auriel can store up to 475 (+4% per level) energy.",
-        "hotkey": "D",
         "trait": true,
         "abilityId": "Auriel|D1",
-        "cooldown": 1.5,
+        "cooldown": 15,
         "icon": "storm_ui_icon_auriel_bestowhope.png",
         "type": "trait"
       }

--- a/hero/azmodan.json
+++ b/hero/azmodan.json
@@ -1,5 +1,5 @@
 {
-  "id": "30",
+  "id": 30,
   "shortName": "azmodan",
   "attributeId": "Azmo",
   "cHeroId": "Azmodan",
@@ -21,7 +21,7 @@
   "abilities": {
     "Azmodan": [
       {
-        "uid": "0e3d7cc",
+        "uid": "3e5e40",
         "name": "Globe of Annihilation",
         "description": "Shoot a globe of destruction, dealing 184 (+2.5% per level) damage on impact.  Quest: Hitting a Hero or killing a Minion within 1.5 seconds of being hit by Globe of Annihilation grants 2 Annihilation.  Reward: Each stack of Annihilation increases the damage of Globe of Annihilation by 1, up to 400.",
         "hotkey": "Q",
@@ -32,7 +32,7 @@
         "type": "basic"
       },
       {
-        "uid": "6614286",
+        "uid": "cb5fea",
         "name": "Summon Demon Warrior",
         "description": "Spawn a Demon Warrior that marches forward. Warriors deal 30 (+4% per level) damage per Attack and 16 (+4% per level) damage to nearby enemies every second. Lasts for 10 seconds.  Usable while Channeling All Shall Burn.",
         "hotkey": "W",
@@ -43,7 +43,7 @@
         "type": "basic"
       },
       {
-        "uid": "22972a8",
+        "uid": "0c005b",
         "name": "All Shall Burn",
         "description": "Channel a beam of death on an enemy, dealing 120 (+4% per level) damage per second for 2.5 seconds. If the Channel lasts its full duration, deal an extra 320 (+4% per level) damage to the target.  Azmodan's Movement Speed is reduced by 30% while Channeling.",
         "hotkey": "E",
@@ -54,18 +54,7 @@
         "type": "basic"
       },
       {
-        "uid": "89a7253",
-        "name": "Tide of Sin",
-        "description": "Activate to make the next Globe of Annihilation cost no Mana and deal 50% more damage.  Usable while Channeling All Shall Burn.",
-        "hotkey": "R",
-        "abilityId": "Azmodan|R2",
-        "cooldown": 20,
-        "manaCost": 100,
-        "icon": "storm_ui_icon_azmodan_blackpool.png",
-        "type": "heroic"
-      },
-      {
-        "uid": "23a07b5",
+        "uid": "95683c",
         "name": "Demonic Invasion",
         "description": "Rain a small army of Demonic Grunts down on enemies, dealing 65 (+4% per level) damage per impact. Grunts deal 42 (+4% per level) damage, have 750 (+4% per level) Health and last up to 10 seconds. When Grunts die they explode, dealing 98 (+4% per level) damage to nearby enemies.  Usable while Channeling All Shall Burn.",
         "hotkey": "R",
@@ -76,10 +65,20 @@
         "type": "heroic"
       },
       {
-        "uid": "b9c69d6",
+        "uid": "bd6282",
+        "name": "Tide of Sin",
+        "description": "Activate to make the next Globe of Annihilation cost no Mana and deal 50% more damage.  Usable while Channeling All Shall Burn.",
+        "hotkey": "R",
+        "abilityId": "Azmodan|R2",
+        "cooldown": 20,
+        "manaCost": 100,
+        "icon": "storm_ui_icon_azmodan_blackpool.png",
+        "type": "heroic"
+      },
+      {
+        "uid": "638954",
         "name": "Demon Lieutenant",
         "description": "Summon a Demon Lieutenant at any allied Mercenary, Minion, or Azmodan Demon. The Lieutenant will cast Demonic Smite every 7 seconds, instantly killing an enemy Minion. Lasts 20 seconds.  Usable while Channeling All Shall Burn.",
-        "hotkey": "D",
         "trait": true,
         "abilityId": "Azmodan|D1",
         "cooldown": 60,
@@ -351,8 +350,9 @@
         "icon": "storm_ui_icon_azmodan_blackpool.png",
         "type": "Heroic",
         "sort": 2,
-        "abilityId": "Azmodan|R2",
+        "abilityId": "Azmodan|R3",
         "abilityLinks": [
+          "Azmodan|R3",
           "Azmodan|R2"
         ]
       },

--- a/hero/azmodan.json
+++ b/hero/azmodan.json
@@ -350,9 +350,8 @@
         "icon": "storm_ui_icon_azmodan_blackpool.png",
         "type": "Heroic",
         "sort": 2,
-        "abilityId": "Azmodan|R3",
+        "abilityId": "Azmodan|R2",
         "abilityLinks": [
-          "Azmodan|R3",
           "Azmodan|R2"
         ]
       },

--- a/hero/blaze.json
+++ b/hero/blaze.json
@@ -1,5 +1,5 @@
 {
-  "id": "76",
+  "id": 76,
   "shortName": "blaze",
   "attributeId": "Fire",
   "cHeroId": "Firebat",
@@ -22,7 +22,7 @@
   "abilities": {
     "Blaze": [
       {
-        "uid": "79dd19e",
+        "uid": "434b0b",
         "name": "Flame Stream",
         "description": "Fire two streams that deal 83 (+4% per level) damage to enemies hit. Flame Stream Ignites Oil Spills it comes in contact with.",
         "hotkey": "Q",
@@ -33,7 +33,7 @@
         "type": "basic"
       },
       {
-        "uid": "c1de3c2",
+        "uid": "d1a65a",
         "name": "Oil Spill",
         "description": "Vector Targeting Dispense a slick of oil that lasts for 5 seconds and Slows enemies that come in contact with it by 50%.  Oil Spills are Ignited for 2.5 seconds when hit by Flame Stream. Ignited Oil Spills no longer Slow enemies, but instead deal 16 (+4% per level) damage to them every 0.3 seconds. Additionally, Blaze is healed for 49 (+4% per level) Health every 0.3 seconds while standing in Ignited Oil Spills.  Stores up to 2 charges.",
         "hotkey": "W",
@@ -44,7 +44,7 @@
         "type": "basic"
       },
       {
-        "uid": "dc9f00e",
+        "uid": "7cac5a",
         "name": "Jet Propulsion",
         "description": "After 0.375 seconds, charge forward. Colliding with an enemy Hero deals 52 (+4% per level) damage to all nearby enemy Heroes and Stuns them for 1.25 seconds.",
         "hotkey": "E",
@@ -55,7 +55,7 @@
         "type": "basic"
       },
       {
-        "uid": "1cbba8c",
+        "uid": "21af94",
         "name": "Bunker Drop",
         "description": "After 0.5 seconds, deploy and enter a Bunker with 1435 (+4% per level) Health. Blaze and his allies can enter and exit the Bunker at will. While in the Bunker, occupants gain access to Flamethrower, dealing 170 (+4% per level) damage to enemies in a line.  Exiting the Bunker grants 25 Armor for 2 seconds. Bunkers last 10 seconds, or until destroyed.",
         "hotkey": "R",
@@ -66,7 +66,7 @@
         "type": "heroic"
       },
       {
-        "uid": "ae32a5a",
+        "uid": "54872b",
         "name": "Combustion",
         "description": "Channel for up to 2.6 seconds. Upon ending, Slow nearby enemies by 60% and deal 55 (+4% per level) damage to them every 0.5 seconds. Combustion's Slow and damage over time duration is extended the longer Blaze Channels, from 1 second up to 5 seconds.  Blaze's Movement Speed is reduced by 40% while Channeling.",
         "hotkey": "R",
@@ -77,10 +77,9 @@
         "type": "heroic"
       },
       {
-        "uid": "3655207",
+        "uid": "352c77",
         "name": "Pyromania",
         "description": "Gain 40 Armor and deal 40 (+4% per level) damage to nearby enemies every 0.5 seconds for 4 seconds.  Each Hero hit by Flame Stream reduces Pyromania's cooldown by 5 seconds.",
-        "hotkey": "D",
         "trait": true,
         "abilityId": "Blaze|D1",
         "cooldown": 90,

--- a/hero/brightwing.json
+++ b/hero/brightwing.json
@@ -1,5 +1,5 @@
 {
-  "id": "25",
+  "id": 25,
   "shortName": "brightwing",
   "attributeId": "Faer",
   "cHeroId": "FaerieDragon",
@@ -23,7 +23,7 @@
   "abilities": {
     "Brightwing": [
       {
-        "uid": "6600b75",
+        "uid": "bac60a",
         "name": "Arcane Flare",
         "description": "Shoot a flare dealing 75 (+4% per level) damage to enemies hit, and an additional 105 (+4% per level) damage to enemies in the center. If a Hero is hit by the center, Soothing Mist's passive healing instantly activates.",
         "hotkey": "Q",
@@ -34,7 +34,7 @@
         "type": "basic"
       },
       {
-        "uid": "d16c27c",
+        "uid": "1bb0a2",
         "name": "Polymorph",
         "description": "Polymorph a target for 1.5 seconds, Slowing their Movement Speed by 25% and Silencing them. Targets are not able to attack while Polymorphed.",
         "hotkey": "W",
@@ -45,7 +45,7 @@
         "type": "basic"
       },
       {
-        "uid": "a11fbbd",
+        "uid": "5c9c7a",
         "name": "Pixie Dust",
         "description": "Increase target Hero's Movement Speed by 20%, and grant them 25 Spell Armor for 3 seconds, reducing Spell damage taken by 25%.",
         "hotkey": "E",
@@ -56,7 +56,7 @@
         "type": "basic"
       },
       {
-        "uid": "a555f95",
+        "uid": "28d179",
         "name": "Blink Heal",
         "description": "Teleport to a nearby ally. When teleporting to a Hero, heal them for 200 (+4% per level).  Stores up to 2 charges.",
         "hotkey": "R",
@@ -67,7 +67,7 @@
         "type": "heroic"
       },
       {
-        "uid": "2340658",
+        "uid": "f38ffa",
         "name": "Emerald Wind",
         "description": "After 0.5 seconds, create an expanding nova of wind, dealing 225 (+4% per level) damage and pushing enemies away.",
         "hotkey": "R",
@@ -78,10 +78,9 @@
         "type": "heroic"
       },
       {
-        "uid": "74c3767",
+        "uid": "83eccc",
         "name": "Soothing Mist",
         "description": "Activate to remove all Stun, Root, Slow, and Silence effects from nearby allied Heroes.  Passive: Brightwing heals nearby allied Heroes for 105 (+4% per level) every 4 seconds",
-        "hotkey": "D",
         "trait": true,
         "abilityId": "Brightwing|D1",
         "cooldown": 100,
@@ -89,7 +88,7 @@
         "type": "trait"
       },
       {
-        "uid": "311e94c",
+        "uid": "76b872",
         "name": "Phase Shift",
         "description": "After 2 seconds, teleport to an allied Hero and heal them for 20% of their maximum Health.",
         "hotkey": "Z",
@@ -374,7 +373,7 @@
         "type": "Active",
         "sort": 4,
         "cooldown": 45,
-        "abilityId": "Brightwing|E1",
+        "abilityId": "Brightwing|Active",
         "abilityLinks": [
           "Brightwing|E1"
         ]

--- a/hero/cassia.json
+++ b/hero/cassia.json
@@ -1,5 +1,5 @@
 {
-  "id": "65",
+  "id": 65,
   "shortName": "cassia",
   "attributeId": "Amaz",
   "cHeroId": "Amazon",
@@ -20,18 +20,18 @@
   "abilities": {
     "Cassia": [
       {
-        "uid": "03938ff",
+        "uid": "af4e3f",
         "name": "Lightning Fury",
         "description": "Hurl a lightning javelin that deals 175 (+4% per level) damage to the first enemy hit and splits into two lightning bolts that deal 175 (+4% per level) damage to enemies in their path.",
         "hotkey": "Q",
         "abilityId": "Cassia|Q1",
-        "cooldown": 4,
+        "cooldown": 44,
         "manaCost": 30,
         "icon": "storm_ui_icon_cassia_lightningfury.png",
         "type": "basic"
       },
       {
-        "uid": "ec8544d",
+        "uid": "03b6ab",
         "name": "Blinding Light",
         "description": "After 0.5 seconds, deal 50 (+4% per level) damage and Blind enemies in the target area for 2 seconds.  Passive: Cassia deals 20% increased damage to Blinded targets.",
         "hotkey": "W",
@@ -42,7 +42,7 @@
         "type": "basic"
       },
       {
-        "uid": "1b1bb51",
+        "uid": "9bd841",
         "name": "Fend",
         "description": "Charge at an enemy, and upon arriving channel for up to 1.5 seconds, dealing 78 (+4% per level) damage to enemies in front of Cassia every 0.25 seconds. Deals 50% reduced damage to non-Heroes.",
         "hotkey": "E",
@@ -53,7 +53,7 @@
         "type": "basic"
       },
       {
-        "uid": "99c5b26",
+        "uid": "792bee",
         "name": "Ball Lightning",
         "description": "Throw a ball of lightning at an enemy Hero that bounces up to 6 times between nearby enemy Heroes and Cassia, dealing 180 (+4% per level) damage to enemies hit.",
         "hotkey": "R",
@@ -64,7 +64,7 @@
         "type": "heroic"
       },
       {
-        "uid": "2cac811",
+        "uid": "bf4642",
         "name": "Valkyrie",
         "description": "Summon a Valkyrie that rushes to Cassia after 0.75 seconds, pulling the first enemy Hero hit, dealing 225 (+4% per level) damage and Stunning them for 0.5 seconds at the end of her path. The Valkyrie knocks back all other enemy Heroes in her way.",
         "hotkey": "R",
@@ -75,7 +75,7 @@
         "type": "heroic"
       },
       {
-        "uid": "a4ba49f",
+        "uid": "0c204e",
         "name": "Avoidance",
         "description": "While moving unmounted, Cassia gains 40 Physical Armor against Heroic Basic Attacks, reducing the damage taken by 40%.",
         "trait": true,
@@ -159,8 +159,9 @@
         "type": "Trait",
         "sort": 3,
         "isQuest": true,
-        "abilityId": "Cassia|D1",
+        "abilityId": "Cassia|D2",
         "abilityLinks": [
+          "Cassia|D2",
           "Cassia|D1"
         ]
       }
@@ -187,8 +188,9 @@
         "icon": "storm_ui_icon_cassia_avoidance.png",
         "type": "Trait",
         "sort": 2,
-        "abilityId": "Cassia|D1",
+        "abilityId": "Cassia|D2",
         "abilityLinks": [
+          "Cassia|D2",
           "Cassia|D1"
         ]
       },

--- a/hero/cassia.json
+++ b/hero/cassia.json
@@ -159,9 +159,8 @@
         "type": "Trait",
         "sort": 3,
         "isQuest": true,
-        "abilityId": "Cassia|D2",
+        "abilityId": "Cassia|D1",
         "abilityLinks": [
-          "Cassia|D2",
           "Cassia|D1"
         ]
       }
@@ -188,9 +187,8 @@
         "icon": "storm_ui_icon_cassia_avoidance.png",
         "type": "Trait",
         "sort": 2,
-        "abilityId": "Cassia|D2",
+        "abilityId": "Cassia|D1",
         "abilityLinks": [
-          "Cassia|D2",
           "Cassia|D1"
         ]
       },

--- a/hero/chen.json
+++ b/hero/chen.json
@@ -1,5 +1,5 @@
 {
-  "id": "29",
+  "id": 29,
   "shortName": "chen",
   "attributeId": "Chen",
   "cHeroId": "Chen",
@@ -22,7 +22,7 @@
   "abilities": {
     "Chen": [
       {
-        "uid": "202372d",
+        "uid": "db26bd",
         "name": "Flying Kick",
         "description": "Kick through target enemy, dealing 120 (+4% per level) damage.",
         "hotkey": "Q",
@@ -33,7 +33,7 @@
         "type": "basic"
       },
       {
-        "uid": "8661e12",
+        "uid": "a671f5",
         "name": "Keg Smash",
         "description": "Deal 50 (+4% per level) damage and soak enemies in Brew for 3 seconds, Slowing them by 10%. After 1.25 seconds, the Slow is increased to 40%.  After being used, this ability becomes Breath of Fire.  Breath of Fire Deal damage and Ignite Brew-soaked enemies.",
         "hotkey": "W",
@@ -44,28 +44,17 @@
         "type": "basic"
       },
       {
-        "uid": "168e272",
-        "name": "Breath of Fire",
-        "description": "Breathe a cone of flames, dealing 85 (+4% per level) damage. Enemies that are soaked in Brew are Ignited, dealing 165 (+4% per level) additional damage over 3 seconds and adding 1.5 seconds to the duration of the Slow from Keg Smash.   After being used or after 6 seconds, this ability becomes Keg Smash.  Keg Smash Damage and Slow enemies.",
-        "hotkey": "W",
-        "abilityId": "Chen|W3",
-        "cooldown": 5,
-        "manaCost": 10,
-        "icon": "storm_ui_icon_chen_breathoffire.png",
+        "uid": "7a7f80",
+        "name": "Stagger",
+        "description": "Damage taken over the next 3 seconds is prevented.  Once this effect ends, Chen receives 75% of the damage taken over 5 seconds.  This damage cannot be modified.",
+        "hotkey": "E",
+        "abilityId": "Chen|E1",
+        "cooldown": 18,
+        "icon": "storm_ui_icon_chen_stagger.png",
         "type": "basic"
       },
       {
-        "uid": "db53a29",
-        "name": "Wandering Keg",
-        "description": "Roll around inside an Unstoppable barrel with 70% increased Movement Speed and 25 Armor, dealing 59 (+4% per level) damage to enemies in the way and knocking them back. Lasts for 5 seconds.",
-        "hotkey": "R",
-        "abilityId": "Chen|R2",
-        "cooldown": 60,
-        "icon": "storm_ui_icon_chen_wanderingkeg.png",
-        "type": "heroic"
-      },
-      {
-        "uid": "4d90b68",
+        "uid": "e0a3b8",
         "name": "Storm, Earth, Fire",
         "description": "After 1 second, Chen splits into three elemental spirits for 12 seconds, each with 70% of Chen's maximum Health and a unique Ability.  The last spirit Ability that is cast is empowered. If all three spirits are killed, Chen will die as well.  Storm can grant the spirits a Shield.  Earth can leap to an area and Slow enemies.  Fire can grant the spirits Attack Speed, damage.",
         "hotkey": "R",
@@ -75,10 +64,19 @@
         "type": "heroic"
       },
       {
-        "uid": "ca6467f",
+        "uid": "3d7575",
+        "name": "Wandering Keg",
+        "description": "Roll around inside an Unstoppable barrel with 70% increased Movement Speed and 25 Armor, dealing 59 (+4% per level) damage to enemies in the way and knocking them back. Lasts for 5 seconds.",
+        "hotkey": "R",
+        "abilityId": "Chen|R2",
+        "cooldown": 60,
+        "icon": "storm_ui_icon_chen_wanderingkeg.png",
+        "type": "heroic"
+      },
+      {
+        "uid": "c98538",
         "name": "Fortifying Brew",
         "description": "Chen drinks from his keg, gaining 50 Brew and 180 (+4% per level) temporary Shields per second, up to a maximum of 540 (+4% per level) while drinking. Shields persist for 4 seconds after he stops drinking.",
-        "hotkey": "D",
         "trait": true,
         "abilityId": "Chen|D1",
         "cooldown": 7,
@@ -86,46 +84,52 @@
         "type": "trait"
       },
       {
-        "uid": "8340c2e",
-        "name": "Stagger",
-        "description": "Damage taken over the next 3 seconds is prevented.  Once this effect ends, Chen receives 75% of the damage taken over 5 seconds.  This damage cannot be modified.",
-        "hotkey": "E",
-        "abilityId": "Chen|E1",
-        "cooldown": 18,
-        "icon": "storm_ui_icon_chen_stagger.png",
-        "type": "basic"
+        "uid": "4cc15c",
+        "name": "Hearthstone",
+        "description": "After Channeling for 6 seconds, teleport back to the Hall of Storms, instantly restoring 1125 Health and 150 Brew.",
+        "hotkey": "B",
+        "abilityId": "Chen|B1",
+        "icon": "storm_ui_icon_miscrune_1.png",
+        "type": "hearth"
       }
     ],
     "ChenStormEarthFire": [
       {
-        "uid": "c56f29d",
-        "name": "Fire",
-        "description": "Increase the Attack Speed and Basic Attack damage of the spirits by 50% for 5 seconds.  If this is the final Ability cast, the Attack Speed and damage bonus is increased to 75% and the spirits gain 50% Movement Speed for its duration.",
-        "hotkey": "E",
-        "abilityId": "Chen|E2",
-        "cooldown": 12,
-        "icon": "storm_temp_war3_btnmarkoffire.png",
-        "type": "subunit"
-      },
-      {
-        "uid": "2abec17",
-        "name": "Earth",
-        "description": "Fire and Earth leap to the target location, dealing 32 (+4% per level) damage and Slowing enemies in a large area by 70% for 1.5 seconds.  If this is the final Ability cast, increase the damage dealt by 300% and instead of Slowing, the leap Roots enemy Heroes hit for 1.75 seconds.",
-        "hotkey": "W",
-        "abilityId": "Chen|W2",
-        "cooldown": 6,
-        "icon": "storm_temp_war3_btnearthquake.png",
-        "type": "subunit"
-      },
-      {
-        "uid": "02dd017",
+        "uid": "eee284",
         "name": "Storm",
         "description": "The spirits gain a Shield for 400 (+4% per level) over 3 seconds.  If this is the final Ability cast, the shield amount is increased to 750 (+4% per level) with no limited duration, and the duration of Storm, Earth, Fire is increased by 5 seconds.",
         "hotkey": "Q",
         "abilityId": "Chen|Q2",
-        "cooldown": 12,
         "icon": "storm_temp_war3_btntornado.png",
-        "type": "subunit"
+        "type": "basic"
+      },
+      {
+        "uid": "4e5a22",
+        "name": "Earth",
+        "description": "Fire and Earth leap to the target location, dealing 32 (+4% per level) damage and Slowing enemies in a large area by 70% for 1.5 seconds.  If this is the final Ability cast, increase the damage dealt by 300% and instead of Slowing, the leap Roots enemy Heroes hit for 1.75 seconds.",
+        "hotkey": "W",
+        "abilityId": "Chen|W2",
+        "icon": "storm_temp_war3_btnearthquake.png",
+        "type": "basic"
+      },
+      {
+        "uid": "48b037",
+        "name": "Fire",
+        "description": "Increase the Attack Speed and Basic Attack damage of the spirits by 50% for 5 seconds.  If this is the final Ability cast, the Attack Speed and damage bonus is increased to 75% and the spirits gain 50% Movement Speed for its duration.",
+        "hotkey": "E",
+        "abilityId": "Chen|E2",
+        "icon": "storm_temp_war3_btnmarkoffire.png",
+        "type": "basic"
+      },
+      {
+        "uid": "727df0",
+        "name": "Breath of Fire",
+        "description": "Breathe a cone of flames, dealing 85 (+4% per level) damage. Enemies that are soaked in Brew are Ignited, dealing 165 (+4% per level) additional damage over 3 seconds and adding 1.5 seconds to the duration of the Slow from Keg Smash.   After being used or after 6 seconds, this ability becomes Keg Smash.  Keg Smash Damage and Slow enemies.",
+        "hotkey": "W",
+        "abilityId": "Chen|W3",
+        "manaCost": 10,
+        "icon": "storm_ui_icon_chen_breathoffire.png",
+        "type": "basic"
       }
     ]
   },
@@ -139,10 +143,10 @@
         "icon": "storm_ui_icon_chen_kegsmash.png",
         "type": "W",
         "sort": 1,
-        "abilityId": "Chen|W1",
+        "abilityId": "Chen|W3",
         "abilityLinks": [
-          "Chen|W1",
-          "Chen|W3"
+          "Chen|W3",
+          "Chen|W1"
         ]
       },
       {
@@ -195,11 +199,10 @@
         "icon": "storm_ui_icon_chen_breathoffire.png",
         "type": "W",
         "sort": 2,
-        "isQuest": true,
-        "abilityId": "Chen|W1",
+        "abilityId": "Chen|W3",
         "abilityLinks": [
-          "Chen|W1",
-          "Chen|W3"
+          "Chen|W3",
+          "Chen|W1"
         ]
       },
       {
@@ -210,10 +213,10 @@
         "icon": "storm_ui_icon_chen_breathoffire_a.png",
         "type": "W",
         "sort": 3,
-        "abilityId": "Chen|W1",
+        "abilityId": "Chen|W3",
         "abilityLinks": [
-          "Chen|W1",
-          "Chen|W3"
+          "Chen|W3",
+          "Chen|W1"
         ]
       }
     ],
@@ -308,10 +311,10 @@
         "icon": "storm_ui_icon_chen_kegsmash.png",
         "type": "W",
         "sort": 2,
-        "abilityId": "Chen|W1",
+        "abilityId": "Chen|W3",
         "abilityLinks": [
-          "Chen|W1",
-          "Chen|W3"
+          "Chen|W3",
+          "Chen|W1"
         ]
       },
       {
@@ -322,10 +325,10 @@
         "icon": "storm_ui_icon_chen_breathoffire.png",
         "type": "W",
         "sort": 3,
-        "abilityId": "Chen|W1",
+        "abilityId": "Chen|W3",
         "abilityLinks": [
-          "Chen|W1",
-          "Chen|W3"
+          "Chen|W3",
+          "Chen|W1"
         ]
       },
       {
@@ -408,9 +411,9 @@
         "abilityId": "Chen|R1",
         "abilityLinks": [
           "Chen|R1",
-          "Chen|E2",
+          "Chen|Q2",
           "Chen|W2",
-          "Chen|Q2"
+          "Chen|E2"
         ]
       },
       {

--- a/hero/chogall.json
+++ b/hero/chogall.json
@@ -121,9 +121,8 @@
         "icon": "storm_ui_icon_cho_ogrehide.png",
         "type": "Trait",
         "sort": 3,
-        "abilityId": "Chogall|D2",
+        "abilityId": "Chogall|D1",
         "abilityLinks": [
-          "Chogall|D2",
           "Chogall|D1"
         ]
       }
@@ -137,9 +136,8 @@
         "icon": "storm_ui_icon_cho_moltensurge_a.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "Chogall|Q2",
+        "abilityId": "Chogall|Q1",
         "abilityLinks": [
-          "Chogall|Q2",
           "Chogall|Q1"
         ]
       },
@@ -176,9 +174,8 @@
         "icon": "storm_ui_icon_cho_moltensurge_a.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "Chogall|Q2",
+        "abilityId": "Chogall|Q1",
         "abilityLinks": [
-          "Chogall|Q2",
           "Chogall|Q1"
         ]
       },
@@ -203,9 +200,8 @@
         "icon": "storm_ui_icon_cho_ogrehide.png",
         "type": "Trait",
         "sort": 3,
-        "abilityId": "Chogall|D2",
+        "abilityId": "Chogall|D1",
         "abilityLinks": [
-          "Chogall|D2",
           "Chogall|D1"
         ]
       }
@@ -249,9 +245,8 @@
         "icon": "storm_ui_icon_cho_moltensurge_a.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "Chogall|Q2",
+        "abilityId": "Chogall|Q1",
         "abilityLinks": [
-          "Chogall|Q2",
           "Chogall|Q1"
         ]
       },
@@ -287,9 +282,8 @@
         "icon": "storm_ui_icon_cho_moltensurge_a.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "Chogall|Q2",
+        "abilityId": "Chogall|Q1",
         "abilityLinks": [
-          "Chogall|Q2",
           "Chogall|Q1"
         ]
       },
@@ -352,9 +346,8 @@
         "icon": "storm_ui_icon_cho_ogrehide.png",
         "type": "Trait",
         "sort": 3,
-        "abilityId": "Chogall|D2",
+        "abilityId": "Chogall|D1",
         "abilityLinks": [
-          "Chogall|D2",
           "Chogall|D1"
         ]
       },

--- a/hero/chogall.json
+++ b/hero/chogall.json
@@ -1,5 +1,5 @@
 {
-  "id": "45",
+  "id": 45,
   "shortName": "chogall",
   "attributeId": "CCho",
   "cHeroId": "Cho",
@@ -21,64 +21,63 @@
     "SoloLaner"
   ],
   "abilities": {
-    "Cho": [
+    "Chogall": [
       {
-        "uid": "a68a82e",
+        "uid": "050806",
         "name": "Surging Fist",
         "description": "Activate to begin charging Surging Fist. Activate again to dash forward, knocking aside enemies and dealing 46 (+4% per level) damage. The dash range increases by up to 250%, depending on how long it is charged.",
         "hotkey": "Q",
-        "abilityId": "Cho|Q1",
+        "abilityId": "Chogall|Q1",
         "cooldown": 12,
         "icon": "storm_ui_icon_cho_moltensurge_a.png",
         "type": "basic"
       },
       {
-        "uid": "7b37529",
+        "uid": "514f9f",
         "name": "Consuming Blaze",
         "description": "Ignite nearby enemies, dealing 150 (+4% per level) damage over 5 seconds. Basic Attacking burning enemies re-Ignites them. Cho is healed for 40 (+4% per level) when an enemy is Ignited.",
         "hotkey": "W",
-        "abilityId": "Cho|W1",
+        "abilityId": "Chogall|W1",
         "cooldown": 12,
         "icon": "storm_ui_icon_cho_consumingflame.png",
         "type": "basic"
       },
       {
-        "uid": "1840b85",
+        "uid": "120901",
         "name": "Rune Bomb",
         "description": "Roll a bomb dealing 91 (+4% per level) damage to enemies in its path. Gall can use Runic Blast to detonate it to deal 210 (+4% per level) damage in an area.",
         "hotkey": "E",
-        "abilityId": "Cho|E1",
+        "abilityId": "Chogall|E1",
         "cooldown": 8,
         "icon": "storm_ui_icon_cho_runebomb.png",
         "type": "basic"
       },
       {
-        "uid": "995e072",
-        "name": "Hammer of Twilight",
-        "description": "Activate to swing the Hammer of Twilight, dealing 150 (+4.5% per level) damage, pushing enemies away, and Stunning them for 0.75 seconds.  Passive: Cho's Basic Attacks deal 25% increased damage.",
-        "hotkey": "R",
-        "abilityId": "Cho|R2",
-        "cooldown": 15,
-        "icon": "storm_ui_icon_cho_hammeroftwilight.png",
-        "type": "heroic"
-      },
-      {
-        "uid": "5e16468",
+        "uid": "f59acd",
         "name": "Upheaval",
         "description": "After 1 second, pull enemies towards Cho'gall, slowing them by 25% for 3 seconds and dealing 175 (+4% per level) damage.",
         "hotkey": "R",
-        "abilityId": "Cho|R1",
+        "abilityId": "Chogall|R1",
         "cooldown": 60,
         "icon": "storm_ui_icon_cho_upheaval.png",
         "type": "heroic"
       },
       {
-        "uid": "bda088b",
+        "uid": "410c9f",
+        "name": "Hammer of Twilight",
+        "description": "Activate to swing the Hammer of Twilight, dealing 150 (+4.5% per level) damage, pushing enemies away, and Stunning them for 0.75 seconds.  Passive: Cho's Basic Attacks deal 25% increased damage.",
+        "hotkey": "R",
+        "abilityId": "Chogall|R2",
+        "cooldown": 15,
+        "icon": "storm_ui_icon_cho_hammeroftwilight.png",
+        "type": "heroic"
+      },
+      {
+        "uid": "097ddc",
         "name": "Ogre Hide",
         "description": "Activate to gain 25 Armor, but reduce Gall's damage by 25%.",
-        "hotkey": "D",
         "trait": true,
-        "abilityId": "Cho|D1",
+        "abilityId": "Chogall|D1",
         "cooldown": 5,
         "icon": "storm_ui_icon_cho_ogrehide.png",
         "type": "trait"
@@ -95,9 +94,9 @@
         "icon": "storm_ui_icon_cho_consumingflame.png",
         "type": "W",
         "sort": 1,
-        "abilityId": "Cho|W1",
+        "abilityId": "Chogall|W1",
         "abilityLinks": [
-          "Cho|W1"
+          "Chogall|W1"
         ]
       },
       {
@@ -109,9 +108,9 @@
         "type": "W",
         "sort": 2,
         "isQuest": true,
-        "abilityId": "Cho|W1",
+        "abilityId": "Chogall|W1",
         "abilityLinks": [
-          "Cho|W1"
+          "Chogall|W1"
         ]
       },
       {
@@ -122,9 +121,10 @@
         "icon": "storm_ui_icon_cho_ogrehide.png",
         "type": "Trait",
         "sort": 3,
-        "abilityId": "Cho|D1",
+        "abilityId": "Chogall|D2",
         "abilityLinks": [
-          "Cho|D1"
+          "Chogall|D2",
+          "Chogall|D1"
         ]
       }
     ],
@@ -137,9 +137,10 @@
         "icon": "storm_ui_icon_cho_moltensurge_a.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "Cho|Q1",
+        "abilityId": "Chogall|Q2",
         "abilityLinks": [
-          "Cho|Q1"
+          "Chogall|Q2",
+          "Chogall|Q1"
         ]
       },
       {
@@ -150,9 +151,9 @@
         "icon": "storm_ui_icon_cho_runebomb.png",
         "type": "E",
         "sort": 2,
-        "abilityId": "Cho|E1",
+        "abilityId": "Chogall|E1",
         "abilityLinks": [
-          "Cho|E1"
+          "Chogall|E1"
         ]
       },
       {
@@ -163,7 +164,7 @@
         "icon": "storm_ui_icon_talent_autoattack_damage.png",
         "type": "Passive",
         "sort": 3,
-        "abilityId": "Cho|Passive"
+        "abilityId": "Chogall|Passive"
       }
     ],
     "7": [
@@ -175,9 +176,10 @@
         "icon": "storm_ui_icon_cho_moltensurge_a.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "Cho|Q1",
+        "abilityId": "Chogall|Q2",
         "abilityLinks": [
-          "Cho|Q1"
+          "Chogall|Q2",
+          "Chogall|Q1"
         ]
       },
       {
@@ -188,9 +190,9 @@
         "icon": "storm_ui_icon_cho_consumingflame.png",
         "type": "W",
         "sort": 2,
-        "abilityId": "Cho|W1",
+        "abilityId": "Chogall|W1",
         "abilityLinks": [
-          "Cho|W1"
+          "Chogall|W1"
         ]
       },
       {
@@ -201,9 +203,10 @@
         "icon": "storm_ui_icon_cho_ogrehide.png",
         "type": "Trait",
         "sort": 3,
-        "abilityId": "Cho|D1",
+        "abilityId": "Chogall|D2",
         "abilityLinks": [
-          "Cho|D1"
+          "Chogall|D2",
+          "Chogall|D1"
         ]
       }
     ],
@@ -217,9 +220,9 @@
         "type": "Heroic",
         "sort": 1,
         "cooldown": 15,
-        "abilityId": "Cho|R2",
+        "abilityId": "Chogall|R2",
         "abilityLinks": [
-          "Cho|R2"
+          "Chogall|R2"
         ]
       },
       {
@@ -231,9 +234,9 @@
         "type": "Heroic",
         "sort": 2,
         "cooldown": 60,
-        "abilityId": "Cho|R1",
+        "abilityId": "Chogall|R1",
         "abilityLinks": [
-          "Cho|R1"
+          "Chogall|R1"
         ]
       }
     ],
@@ -246,9 +249,10 @@
         "icon": "storm_ui_icon_cho_moltensurge_a.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "Cho|Q1",
+        "abilityId": "Chogall|Q2",
         "abilityLinks": [
-          "Cho|Q1"
+          "Chogall|Q2",
+          "Chogall|Q1"
         ]
       },
       {
@@ -260,7 +264,7 @@
         "type": "Active",
         "sort": 2,
         "cooldown": 30,
-        "abilityId": "Cho|Active"
+        "abilityId": "Chogall|Active"
       },
       {
         "tooltipId": "ChoTalentMoltenBlock",
@@ -271,7 +275,7 @@
         "type": "Active",
         "sort": 3,
         "cooldown": 60,
-        "abilityId": "Cho|Active"
+        "abilityId": "Chogall|Active"
       }
     ],
     "16": [
@@ -283,9 +287,10 @@
         "icon": "storm_ui_icon_cho_moltensurge_a.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "Cho|Q1",
+        "abilityId": "Chogall|Q2",
         "abilityLinks": [
-          "Cho|Q1"
+          "Chogall|Q2",
+          "Chogall|Q1"
         ]
       },
       {
@@ -296,9 +301,9 @@
         "icon": "storm_ui_icon_cho_runebomb.png",
         "type": "E",
         "sort": 2,
-        "abilityId": "Cho|E1",
+        "abilityId": "Chogall|E1",
         "abilityLinks": [
-          "Cho|E1"
+          "Chogall|E1"
         ]
       },
       {
@@ -309,7 +314,7 @@
         "icon": "storm_ui_icon_talent_autoattack_cooldown.png",
         "type": "Passive",
         "sort": 3,
-        "abilityId": "Cho|Passive"
+        "abilityId": "Chogall|Passive"
       }
     ],
     "20": [
@@ -321,9 +326,9 @@
         "icon": "storm_ui_icon_cho_hammeroftwilight.png",
         "type": "Heroic",
         "sort": 1,
-        "abilityId": "Cho|R2",
+        "abilityId": "Chogall|R2",
         "abilityLinks": [
-          "Cho|R2"
+          "Chogall|R2"
         ]
       },
       {
@@ -334,9 +339,9 @@
         "icon": "storm_ui_icon_cho_upheaval.png",
         "type": "Heroic",
         "sort": 2,
-        "abilityId": "Cho|R1",
+        "abilityId": "Chogall|R1",
         "abilityLinks": [
-          "Cho|R1"
+          "Chogall|R1"
         ]
       },
       {
@@ -347,9 +352,10 @@
         "icon": "storm_ui_icon_cho_ogrehide.png",
         "type": "Trait",
         "sort": 3,
-        "abilityId": "Cho|D1",
+        "abilityId": "Chogall|D2",
         "abilityLinks": [
-          "Cho|D1"
+          "Chogall|D2",
+          "Chogall|D1"
         ]
       },
       {
@@ -360,7 +366,7 @@
         "icon": "storm_ui_icon_gall_psychoticbreak.png",
         "type": "Passive",
         "sort": 4,
-        "abilityId": "Cho|Passive"
+        "abilityId": "Chogall|Passive"
       }
     ]
   }

--- a/hero/chromie.json
+++ b/hero/chromie.json
@@ -1,5 +1,5 @@
 {
-  "id": "52",
+  "id": 52,
   "shortName": "chromie",
   "attributeId": "Chro",
   "cHeroId": "Chromie",
@@ -18,7 +18,7 @@
   "abilities": {
     "Chromie": [
       {
-        "uid": "185d1c3",
+        "uid": "2cf39e",
         "name": "Sand Blast",
         "description": "After 0.5 seconds, fire a missile that deals 305 (+4% per level) damage to the first enemy hit. Deals 50% damage to Structures.  Casting Sand Blast leaves an Echo behind that mimics Chromie's Sand Blast and Basic Attack, dealing 40% damage. Maximum of 1 Echo active at a time.",
         "hotkey": "Q",
@@ -29,8 +29,8 @@
         "type": "basic"
       },
       {
-        "uid": "17c6861",
-        "name": "Dragon's Breath",
+        "uid": "282aa0",
+        "name": "Dragon’s Breath",
         "description": "Vector Targeting Launch 3 blasts into the air that land every 0.75 seconds towards the targeted direction, dealing 204 (+4% per level) damage each.",
         "hotkey": "W",
         "abilityId": "Chromie|W1",
@@ -40,7 +40,7 @@
         "type": "basic"
       },
       {
-        "uid": "9d35e5f",
+        "uid": "90eb5b",
         "name": "Time Trap",
         "description": "Place a Time Trap that arms and Stealths after 2 seconds. Chromie's Trait can be activated to detonate the trap, placing all nearby allied or enemy Heroes in Time Stop for 2 seconds. Maximum of 1 trap active at a time.",
         "hotkey": "E",
@@ -51,7 +51,7 @@
         "type": "basic"
       },
       {
-        "uid": "aee5d5d",
+        "uid": "bd8ed1",
         "name": "Temporal Loop",
         "description": "Choose an enemy Hero. After 3 seconds, they are teleported back to the location where Temporal Loop was cast on them.  Basic Abilities recharge 500% faster for 3 seconds after casting Temporal Loop.",
         "hotkey": "R",
@@ -62,19 +62,18 @@
         "type": "heroic"
       },
       {
-        "uid": "918f88d",
+        "uid": "e6b892",
         "name": "Slowing Sands",
         "description": "Summon a sand vortex that Slows enemies by 5% every 0.25 seconds, up to 70%.",
         "hotkey": "R",
         "abilityId": "Chromie|R2",
         "cooldown": 5,
-        "manaCost": 3,
-        "manaPerSecond": true,
+        "manaCost": "second",
         "icon": "storm_ui_icon_chromie_timewarp.png",
         "type": "heroic"
       },
       {
-        "uid": "6519614",
+        "uid": "185342",
         "name": "Timewalker",
         "description": "Chromie has traveled to the future, and as such, will learn her Talents 2 levels earlier than her teammates!  Detonate Time Trap  Detonates active Time Traps.",
         "trait": true,
@@ -124,7 +123,7 @@
         "sort": 3,
         "cooldown": 25,
         "isQuest": true,
-        "abilityId": "Chromie|D1",
+        "abilityId": "Chromie|Active",
         "abilityLinks": [
           "Chromie|D1"
         ]
@@ -141,7 +140,8 @@
         "sort": 1,
         "abilityId": "Chromie|E1",
         "abilityLinks": [
-          "Chromie|E1"
+          "Chromie|E1",
+          "Chromie|D2"
         ]
       },
       {
@@ -167,7 +167,8 @@
         "sort": 3,
         "abilityId": "Chromie|E1",
         "abilityLinks": [
-          "Chromie|E1"
+          "Chromie|E1",
+          "Chromie|D2"
         ]
       }
     ],
@@ -367,7 +368,7 @@
         "type": "Active",
         "sort": 4,
         "cooldown": 90,
-        "abilityId": "Chromie|D1",
+        "abilityId": "Chromie|Active",
         "abilityLinks": [
           "Chromie|D1"
         ]

--- a/hero/chromie.json
+++ b/hero/chromie.json
@@ -140,8 +140,7 @@
         "sort": 1,
         "abilityId": "Chromie|E1",
         "abilityLinks": [
-          "Chromie|E1",
-          "Chromie|D2"
+          "Chromie|E1"
         ]
       },
       {
@@ -167,8 +166,7 @@
         "sort": 3,
         "abilityId": "Chromie|E1",
         "abilityLinks": [
-          "Chromie|E1",
-          "Chromie|D2"
+          "Chromie|E1"
         ]
       }
     ],

--- a/hero/deckard.json
+++ b/hero/deckard.json
@@ -308,9 +308,8 @@
         "icon": "storm_ui_icon_deckard_study_time.png",
         "type": "Trait",
         "sort": 2,
-        "abilityId": "Deckard|D2",
+        "abilityId": "Deckard|D1",
         "abilityLinks": [
-          "Deckard|D2",
           "Deckard|D1"
         ]
       },

--- a/hero/deckard.json
+++ b/hero/deckard.json
@@ -1,5 +1,5 @@
 {
-  "id": "79",
+  "id": 79,
   "shortName": "deckard",
   "attributeId": "DECK",
   "cHeroId": "Deckard",
@@ -21,7 +21,7 @@
   "abilities": {
     "Deckard": [
       {
-        "uid": "23299d2",
+        "uid": "a63024",
         "name": "Healing Potion",
         "description": "Throw a Healing Potion on the ground that heals the first allied Hero that comes in contact with it for 270 (+4% per level).  Limit 5 active Potions.",
         "hotkey": "Q",
@@ -32,7 +32,7 @@
         "type": "basic"
       },
       {
-        "uid": "1500465",
+        "uid": "012875",
         "name": "Horadric Cube",
         "description": "Release the Horadric Cube. After 0.5 seconds it explodes, dealing 80 (+4% per level) damage to all enemies in the area and Slowing them by 35% for 1.75 seconds.",
         "hotkey": "W",
@@ -43,7 +43,7 @@
         "type": "basic"
       },
       {
-        "uid": "079c0f4",
+        "uid": "d06fdf",
         "name": "Scroll Of Sealing",
         "description": "Unfurl an enchanted scroll over 2.25 seconds, forming a triangle that deals 150 (+4% per level) damage to enemies inside and Roots them for 1.5 seconds.",
         "hotkey": "E",
@@ -54,7 +54,7 @@
         "type": "basic"
       },
       {
-        "uid": "ddc1c81",
+        "uid": "1fb023",
         "name": "Stay Awhile and Listen",
         "description": "After 1 second, Channel for 3 seconds, putting enemy Heroes in front of Deckard to Sleep while Channeling, and for 2 seconds after.  Enemies can only be put to Sleep once per cast, and Sleep's effects end instantly if they take damage.",
         "hotkey": "R",
@@ -65,7 +65,7 @@
         "type": "heroic"
       },
       {
-        "uid": "865504f",
+        "uid": "35271a",
         "name": "Lorenado",
         "description": "Vector Targeting After 1 second, create a twirling tome tornado that travels towards the targeted direction, continually knocking away enemies that come into contact with it.",
         "hotkey": "R",
@@ -76,7 +76,7 @@
         "type": "heroic"
       },
       {
-        "uid": "b87d628",
+        "uid": "f135ca",
         "name": "Fortitude of the Faithful",
         "description": "When at least 1 other allied Hero is nearby, Deckard gains 10 Armor and his Basic Abilities recharge 50% faster.",
         "trait": true,
@@ -119,12 +119,12 @@
         "tooltipId": "DeckardGemSapphire",
         "talentTreeId": "DeckardGemSapphire",
         "name": "Sapphire",
-        "description": "Activate to increase the Slow of the next Horadric Cube by 30%.  Only 1 Gem may be active at a time.",
+        "description": "Activate to increase the damage of the next Horadric Cube by 100% and its slow by 30%.  Only 1 Gem may be active at a time.",
         "icon": "storm_ui_icon_deckard_sapphire.png",
         "type": "Active",
         "sort": 3,
         "cooldown": 30,
-        "abilityId": "Deckard|W1",
+        "abilityId": "Deckard|Active",
         "abilityLinks": [
           "Deckard|W1"
         ]
@@ -161,12 +161,12 @@
         "tooltipId": "DeckardGemRuby",
         "talentTreeId": "DeckardGemRuby",
         "name": "Ruby",
-        "description": "Activate to make the next Horadric Cube spawn 3 Lesser Healing Potions from each enemy Hero hit, healing allied Heroes for 250 (+4% per level) when picked up. Lesser Healing Potions last for 10 seconds.  Only 1 Gem may be active at a time.",
+        "description": "Activate to increase the damage of the next Horadric Cube by 100%  and it spawns 3 Lesser Healing Potions from each enemy Hero hit, healing allied Heroes for 250 (+4% per level) when picked up. Lesser Healing Potions last for 10 seconds.  Only 1 Gem may be active at a time.",
         "icon": "storm_ui_icon_deckard_ruby.png",
         "type": "Active",
         "sort": 3,
-        "cooldown": 30,
-        "abilityId": "Deckard|W1",
+        "cooldown": 20,
+        "abilityId": "Deckard|Active",
         "abilityLinks": [
           "Deckard|W1"
         ]
@@ -203,12 +203,12 @@
         "tooltipId": "DeckardGemEmerald",
         "talentTreeId": "DeckardGemEmerald",
         "name": "Emerald",
-        "description": "Activate to make the next Horadric Cube reduce the healing received of enemy Heroes by 75% for 4 seconds.  Only 1 Gem may be active at a time.",
+        "description": "Activate to increase the damage of the next Horadric Cube by 100% and have it reduce the healing received of enemy Heroes by 75% for 4 seconds.  Only 1 Gem may be active at a time.",
         "icon": "storm_ui_icon_deckard_emerald.png",
         "type": "Active",
         "sort": 3,
         "cooldown": 30,
-        "abilityId": "Deckard|W1",
+        "abilityId": "Deckard|Active",
         "abilityLinks": [
           "Deckard|W1"
         ]
@@ -308,8 +308,9 @@
         "icon": "storm_ui_icon_deckard_study_time.png",
         "type": "Trait",
         "sort": 2,
-        "abilityId": "Deckard|D1",
+        "abilityId": "Deckard|D2",
         "abilityLinks": [
+          "Deckard|D2",
           "Deckard|D1"
         ]
       },
@@ -368,7 +369,7 @@
         "tooltipId": "DeckardPerfectGems",
         "talentTreeId": "DeckardPerfectGems",
         "name": "Perfect Gems",
-        "description": "Reduce the cooldown of all Gems by 25 seconds and the cooldown of Horadric Cube by 6 seconds.",
+        "description": "Reduce the cooldown of all Gems to 5 seconds and the cooldown of Horadric Cube by 6 seconds.",
         "icon": "storm_ui_icon_deckard_perfect_gems.png",
         "type": "W",
         "sort": 4,

--- a/hero/dehaka.json
+++ b/hero/dehaka.json
@@ -1,5 +1,5 @@
 {
-  "id": "50",
+  "id": 50,
   "shortName": "dehaka",
   "attributeId": "Deha",
   "cHeroId": "Dehaka",
@@ -23,7 +23,7 @@
   "abilities": {
     "Dehaka": [
       {
-        "uid": "51bc862",
+        "uid": "f0ef71",
         "name": "Drag",
         "description": "Dehaka lashes out his tongue, dealing 160 (+4% per level) damage to the first enemy hit, Stunning and dragging them with him for 1.75 seconds.  If Dehaka is Stunned or Silenced while using Drag, the effect ends.",
         "hotkey": "Q",
@@ -34,7 +34,7 @@
         "type": "basic"
       },
       {
-        "uid": "0abfb4a",
+        "uid": "3e4760",
         "name": "Dark Swarm",
         "description": "Deal 47 (+4% per level) damage every 0.5 seconds to nearby enemies for 3.5 seconds. While active, you are able to move through units. Can be cast during Drag and Burrow.",
         "hotkey": "W",
@@ -45,7 +45,7 @@
         "type": "basic"
       },
       {
-        "uid": "8b762c0",
+        "uid": "45fd30",
         "name": "Burrow",
         "description": "Burrow into the ground, entering Stasis and becoming Invulnerable for 2 seconds.",
         "hotkey": "E",
@@ -56,7 +56,7 @@
         "type": "basic"
       },
       {
-        "uid": "c5527a4",
+        "uid": "8fbeb3",
         "name": "Isolation",
         "description": "Launch biomass that hits the first enemy Hero dealing 200 (+4% per level) damage, revealing, Silencing, and Slowing them 30% for 3 seconds. Additionally, their vision radius is greatly reduced for 6 seconds.",
         "hotkey": "R",
@@ -67,7 +67,7 @@
         "type": "heroic"
       },
       {
-        "uid": "b975167",
+        "uid": "ba1849",
         "name": "Adaptation",
         "description": "After 4 seconds, heal for 100% of the damage Dehaka took over this period.",
         "hotkey": "R",
@@ -78,10 +78,9 @@
         "type": "heroic"
       },
       {
-        "uid": "ed6ae16",
+        "uid": "c2eb8f",
         "name": "Essence Collection",
         "description": "Heal Dehaka for 29 (+4% per level) Health per stored Essence over 5 seconds. Can be cast during Drag and Burrow.  Passive: Gain 10 Essence from Takedowns and 2 Essence from nearby Minions dying. Maximum of 50 Essence.",
-        "hotkey": "D",
         "trait": true,
         "abilityId": "Dehaka|D1",
         "cooldown": 5,
@@ -89,7 +88,7 @@
         "type": "trait"
       },
       {
-        "uid": "0dce7a8",
+        "uid": "253126",
         "name": "Brushstalker",
         "description": "Activate to burrow to a bush on the Battleground.  Passive: Gain 20% movement speed while in a bush and for 2 seconds after leaving.",
         "hotkey": "Z",
@@ -123,11 +122,7 @@
         "icon": "storm_ui_icon_dehaka_essencecollection.png",
         "type": "Trait",
         "sort": 2,
-        "isQuest": true,
-        "abilityId": "Dehaka|D1",
-        "abilityLinks": [
-          "Dehaka|D1"
-        ]
+        "isQuest": true
       },
       {
         "tooltipId": "DehakaEssenceCollectionTalentEnhancedAgility",
@@ -165,11 +160,7 @@
         "description": "Increases Essence collected from Minions by 50%.",
         "icon": "storm_ui_icon_dehaka_essencecollection.png",
         "type": "Trait",
-        "sort": 2,
-        "abilityId": "Dehaka|D1",
-        "abilityLinks": [
-          "Dehaka|D1"
-        ]
+        "sort": 2
       },
       {
         "tooltipId": "DehakaEssenceCollectionTalentHeroStalker",
@@ -264,11 +255,7 @@
         "description": "Gain 1% increased Attack Damage per Essence stored.",
         "icon": "storm_ui_icon_dehaka_essencecollection.png",
         "type": "Trait",
-        "sort": 1,
-        "abilityId": "Dehaka|D1",
-        "abilityLinks": [
-          "Dehaka|D1"
-        ]
+        "sort": 1
       },
       {
         "tooltipId": "DehakaBrushstalkerFerociousStalkerTalent",
@@ -385,11 +372,7 @@
         "description": "Dehaka's Basic Attacks slow the target by 20% for 1 second. If the target is a Hero, Dehaka gains 5 Essence.",
         "icon": "storm_ui_icon_dehaka_essencecollection.png",
         "type": "Trait",
-        "sort": 4,
-        "abilityId": "Dehaka|D1",
-        "abilityLinks": [
-          "Dehaka|D1"
-        ]
+        "sort": 4
       }
     ]
   }

--- a/hero/diablo.json
+++ b/hero/diablo.json
@@ -1,5 +1,5 @@
 {
-  "id": "3",
+  "id": 3,
   "shortName": "diablo",
   "attributeId": "Diab",
   "cHeroId": "Diablo",
@@ -21,7 +21,7 @@
   "abilities": {
     "Diablo": [
       {
-        "uid": "c859827",
+        "uid": "913085",
         "name": "Shadow Charge",
         "description": "Charge an enemy, knocking them back, dealing 40 (+4% per level) damage and gaining 15% Movement Speed for 2 seconds. If the enemy hits terrain, they are Stunned for 1 second and take an additional 120 (+4% per level) damage.",
         "hotkey": "Q",
@@ -32,7 +32,7 @@
         "type": "basic"
       },
       {
-        "uid": "fb53a0d",
+        "uid": "92a76c",
         "name": "Fire Stomp",
         "description": "Unleashes fire waves toward the targeted area that deal 12 (+4% per level) damage each. Once they reach maximum range they return, dealing an additional 36 (+4% per level) damage. Diablo heals for 130% of the damage dealt to Heroes.",
         "hotkey": "W",
@@ -43,7 +43,7 @@
         "type": "basic"
       },
       {
-        "uid": "aff7968",
+        "uid": "1ecf57",
         "name": "Overpower",
         "description": "Grabs the target and slams it behind Diablo, dealing 73 (+4% per level) damage and Stunning for 0.25 seconds.",
         "hotkey": "E",
@@ -54,18 +54,18 @@
         "type": "basic"
       },
       {
-        "uid": "83fdc9f",
+        "uid": "c58687",
         "name": "Apocalypse",
         "description": "Create a demonic rune under each enemy Hero on the battleground. After 1.75 seconds the rune explodes dealing 137 (+4% per level) damage and Stunning them for 1.75 seconds.",
         "hotkey": "R",
         "abilityId": "Diablo|R1",
         "cooldown": 90,
-        "manaCost": 100,
+        "manaCost": 50,
         "icon": "storm_ui_icon_diablo_apocalypse.png",
         "type": "heroic"
       },
       {
-        "uid": "96b2559",
+        "uid": "39518c",
         "name": "Lightning Breath",
         "description": "After 0.5 seconds, become Unstoppable and Channel for up to 4 seconds, dealing 50 (+4% per level) damage every 0.25 seconds to enemies in front of Diablo. Enemies affected are Slowed by 4% for 2 seconds, up to 40%.  Lightning Breath's direction changes with your mouse cursor position.",
         "hotkey": "R",
@@ -76,12 +76,11 @@
         "type": "heroic"
       },
       {
-        "uid": "1a8084f",
+        "uid": "5ed7f3",
         "name": "Black Soulstone",
-        "description": "Repeatable Quest: Gain 10 Souls per Hero killed and 1 Soul per Minion, up to 100. For each Soul, gain 0.4% maximum Health. If Diablo has 100 Souls upon dying, he will resurrect in 5 seconds but lose 100 Souls.",
+        "description": "Repeatable Quest: Gain 10 Souls per Hero killed and 1 Soul per Minion, up to 100. For each Soul, gain 0.3% maximum Health. If Diablo has 100 Souls upon dying, he will resurrect in 5 seconds but lose 100 Souls.",
         "trait": true,
         "abilityId": "Diablo|D1",
-        "cooldown": 30,
         "icon": "storm_ui_icon_diablo_blacksoulstone_var1.png",
         "type": "trait"
       }

--- a/hero/dva.json
+++ b/hero/dva.json
@@ -1,5 +1,5 @@
 {
-  "id": "67",
+  "id": 67,
   "shortName": "dva",
   "attributeId": "DVA0",
   "cHeroId": "DVa",
@@ -18,114 +18,162 @@
     "RoleTank"
   ],
   "abilities": {
-    "D.Va": [
+    "DVa": [
       {
-        "uid": "113bf0d",
+        "uid": "dd269b",
         "name": "Boosters",
         "description": "Increase D.Va's Movement Speed by 125% for 2 seconds. Enemies that are hit take 135 (+4% per level) damage and are knocked away.  D.Va cannot be Slowed while Boosters are active, and each enemy can only be hit once per use.",
         "hotkey": "Q",
-        "abilityId": "D.Va|Q1",
+        "abilityId": "DVa|Q1",
         "cooldown": 9,
         "icon": "storm_ui_icon_dva_boosters.png",
         "type": "basic"
       },
       {
-        "uid": "728a060",
+        "uid": "040cda",
         "name": "Defense Matrix",
         "description": "Channel a defensive field in the target direction for 3 seconds, reducing the damage dealt by enemy Heroes inside it by 75%. The Mech can move while channeling, but cannot turn.  Damage dealt to the Mech from enemies within Defense Matrix still grants the same amount of Self-Destruct Charge.",
         "hotkey": "W",
-        "abilityId": "D.Va|W1",
+        "abilityId": "DVa|W1",
         "cooldown": 10,
         "icon": "storm_ui_icon_dva_defensematrix.png",
         "type": "basic"
       },
       {
-        "uid": "2f4bf70",
+        "uid": "7cd57d",
         "name": "Self-Destruct",
         "description": "Eject from the Mech, setting it to self-destruct after 4 seconds. Deals 1200 (+4% per level) to 400 (+4% per level) damage in a large area, depending on distance from center. Only deals 50% damage against Structures.  Gain 1% Charge for every 2 seconds spent Basic Attacking, and 30% Charge per 100% of Mech Health lost.",
         "hotkey": "E",
-        "abilityId": "D.Va|E1",
+        "abilityId": "DVa|E1",
         "icon": "storm_ui_icon_dva_selfdestruct.png",
         "type": "basic"
       },
       {
-        "uid": "ccb521e",
+        "uid": "0366da",
         "name": "Big Shot",
         "description": "Deal 250 (+4% per level) damage to all enemies in a line. The cooldown of Call Mech is reduced by 8 seconds for each enemy Hero hit.  Requires Pilot Mode.",
         "hotkey": "R",
-        "abilityId": "D.Va|R1",
+        "abilityId": "DVa|R1",
         "cooldown": 4,
         "icon": "storm_ui_icon_dva_bigshot.png",
         "type": "heroic"
       },
       {
-        "uid": "a56988e",
+        "uid": "2240d9",
+        "name": "Bunny Hop",
+        "description": "D.Va's Mech becomes Unstoppable and stomps every 0.5 seconds, dealing 60 (+4% per level) damage and Slowing enemies by 40%. Lasts 4 seconds.  Requires Mech Mode.",
+        "hotkey": "R",
+        "abilityId": "DVa|R2",
+        "cooldown": 100,
+        "icon": "storm_ui_icon_dva_bunnyhop.png",
+        "type": "heroic"
+      },
+      {
+        "uid": "d32b79",
         "name": "Mech Mode",
         "description": "When D.Va's Mech dies, she is ejected out after 0.75 seconds and can continue to fight. D.Va's Mech only awards 50% of a normal Hero's experience upon dying.",
         "trait": true,
-        "abilityId": "D.Va|D1",
+        "abilityId": "DVa|D1",
         "icon": "storm_ui_icon_dva_mechmode.png",
         "type": "trait"
       },
       {
-        "uid": "4969200",
+        "uid": "2269e2",
         "name": "Mechanized Walker",
         "description": "While in her Mech, D.Va can shoot while moving, but her base Movement Speed is reduced by 15%.",
         "hotkey": "Z",
-        "abilityId": "D.Va|Z1",
+        "abilityId": "DVa|Z1",
         "icon": "storm_ui_icon_dva_mount.png",
         "type": "mount"
-      },
-      {
-        "uid": "115b944",
-        "name": "Pilot Mode",
-        "description": "Basic Attacks reduce the cooldown of Call Mech by 0.5 seconds. As a Pilot, D.Va only awards 50% of a normal Hero's experience upon dying.",
-        "trait": true,
-        "abilityId": "D.Va|D2",
-        "icon": "storm_ui_icon_dva_pilotmode.png",
-        "type": "trait"
-      },
-      {
-        "uid": "e84f915",
-        "name": "Bunny Hop",
-        "description": "D.Va's Mech becomes Unstoppable and stomps every 0.5 seconds, dealing 60 (+4% per level) damage and Slowing enemies by 40%. Lasts 4 seconds.  Requires Mech Mode.",
-        "hotkey": "R",
-        "abilityId": "D.Va|R2",
-        "cooldown": 100,
-        "icon": "storm_ui_icon_dva_bunnyhop.png",
-        "type": "heroic"
       }
     ],
     "D.VaPilot": [
       {
-        "uid": "8103aa1",
+        "uid": "97c248",
+        "name": "Bunny Hop",
+        "description": "Cancel Bunny Hop",
+        "hotkey": "R",
+        "abilityId": "DVa|R3",
+        "cooldown": 1,
+        "icon": "hud_btn_bg_ability_cancel.png",
+        "type": "heroic"
+      },
+      {
+        "uid": "f40f4f",
+        "name": "Cancel Boosters",
+        "description": "Cancel Boosters",
+        "hotkey": "Q",
+        "abilityId": "DVa|Q2",
+        "icon": "hud_btn_bg_ability_cancel.png",
+        "type": "basic"
+      },
+      {
+        "uid": "fef6f9",
+        "name": "Cancel Defense Matrix",
+        "description": "Cancel Defense Matrix",
+        "hotkey": "W",
+        "abilityId": "DVa|W2",
+        "icon": "hud_btn_bg_ability_cancel.png",
+        "type": "basic"
+      },
+      {
+        "uid": "64f1f0",
         "name": "Call Mech",
         "description": "Call a new Mech and enter Mech Mode.  Basic Attacks lower this cooldown by 0.5 seconds each.",
         "hotkey": "E",
-        "abilityId": "D.Va|E2",
+        "abilityId": "DVa|E2",
         "cooldown": 45,
         "icon": "storm_ui_icon_dva_callmech.png",
-        "type": "subunit"
+        "type": "basic"
       },
       {
-        "uid": "f14b14e",
+        "uid": "c2a7b9",
+        "name": "Pilot Mode",
+        "description": "Basic Attacks reduce the cooldown of Call Mech by 0.5 seconds. As a Pilot, D.Va only awards 50% of a normal Hero's experience upon dying.",
+        "trait": true,
+        "abilityId": "DVa|D2",
+        "icon": "storm_ui_icon_dva_pilotmode.png",
+        "type": "trait"
+      },
+      {
+        "uid": "a71285",
         "name": "Torpedo Dash",
         "description": "Dash towards the target location, passing through enemies along the way.",
         "hotkey": "Q",
-        "abilityId": "D.Va|Q2",
+        "abilityId": "DVa|Q3",
         "cooldown": 12,
         "icon": "storm_ui_icon_dva_jetpackattack.png",
-        "type": "subunit"
+        "type": "basic"
       },
       {
-        "uid": "a000597",
+        "uid": "a9902a",
         "name": "Concussive Pulse",
         "description": "Deal 141 (+4% per level) damage to enemies in a cone and knock them back.",
         "hotkey": "W",
-        "abilityId": "D.Va|W2",
+        "abilityId": "DVa|W3",
         "cooldown": 7,
         "icon": "storm_ui_icon_dva_concussivecharge.png",
-        "type": "subunit"
+        "type": "basic"
+      },
+      {
+        "uid": "0366da",
+        "name": "Big Shot",
+        "description": "Deal 250 (+4% per level) damage to all enemies in a line. The cooldown of Call Mech is reduced by 8 seconds for each enemy Hero hit.  Requires Pilot Mode.",
+        "hotkey": "R",
+        "abilityId": "DVa|R4",
+        "cooldown": 4,
+        "icon": "storm_ui_icon_dva_bigshot.png",
+        "type": "heroic"
+      },
+      {
+        "uid": "65869a",
+        "name": "Call Mech",
+        "description": "Call a new Mech and enter Mech Mode.  Basic Attacks lower this cooldown by 0.5 seconds each.",
+        "hotkey": "E",
+        "abilityId": "DVa|E3",
+        "cooldown": 45,
+        "icon": "storm_ui_icon_dva_callmech.png",
+        "type": "basic"
       }
     ]
   },
@@ -139,9 +187,9 @@
         "icon": "storm_ui_icon_dva_boosters.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "D.Va|Q1",
+        "abilityId": "DVa|Q1",
         "abilityLinks": [
-          "D.Va|Q1"
+          "DVa|Q1"
         ]
       },
       {
@@ -152,9 +200,9 @@
         "icon": "storm_ui_icon_dva_boosters_a.png",
         "type": "Q",
         "sort": 2,
-        "abilityId": "D.Va|Q1",
+        "abilityId": "DVa|Q1",
         "abilityLinks": [
-          "D.Va|Q1"
+          "DVa|Q1"
         ]
       },
       {
@@ -166,9 +214,9 @@
         "type": "Q",
         "sort": 3,
         "isQuest": true,
-        "abilityId": "D.Va|Q1",
+        "abilityId": "DVa|Q1",
         "abilityLinks": [
-          "D.Va|Q1"
+          "DVa|Q1"
         ]
       },
       {
@@ -179,9 +227,9 @@
         "icon": "storm_ui_icon_dva_mechmode.png",
         "type": "Trait",
         "sort": 4,
-        "abilityId": "D.Va|D1",
+        "abilityId": "DVa|D1",
         "abilityLinks": [
-          "D.Va|D1"
+          "DVa|D1"
         ]
       }
     ],
@@ -194,9 +242,9 @@
         "icon": "storm_ui_icon_dva_defensematrix.png",
         "type": "W",
         "sort": 1,
-        "abilityId": "D.Va|W1",
+        "abilityId": "DVa|W1",
         "abilityLinks": [
-          "D.Va|W1"
+          "DVa|W1"
         ]
       },
       {
@@ -207,9 +255,9 @@
         "icon": "storm_ui_icon_dva_defensematrix_a.png",
         "type": "W",
         "sort": 2,
-        "abilityId": "D.Va|W1",
+        "abilityId": "DVa|W1",
         "abilityLinks": [
-          "D.Va|W1"
+          "DVa|W1"
         ]
       },
       {
@@ -220,9 +268,9 @@
         "icon": "storm_ui_icon_dva_defensematrix_b.png",
         "type": "W",
         "sort": 3,
-        "abilityId": "D.Va|W1",
+        "abilityId": "DVa|W1",
         "abilityLinks": [
-          "D.Va|W1"
+          "DVa|W1"
         ]
       },
       {
@@ -233,9 +281,9 @@
         "icon": "storm_ui_icon_dva_selfdestruct.png",
         "type": "E",
         "sort": 4,
-        "abilityId": "D.Va|E1",
+        "abilityId": "DVa|E1",
         "abilityLinks": [
-          "D.Va|E1"
+          "DVa|E1"
         ]
       }
     ],
@@ -248,9 +296,9 @@
         "icon": "storm_ui_icon_dva_boosters.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "D.Va|Q1",
+        "abilityId": "DVa|Q1",
         "abilityLinks": [
-          "D.Va|Q1"
+          "DVa|Q1"
         ]
       },
       {
@@ -261,9 +309,9 @@
         "icon": "storm_ui_icon_dva_defensematrix.png",
         "type": "W",
         "sort": 2,
-        "abilityId": "D.Va|W1",
+        "abilityId": "DVa|W1",
         "abilityLinks": [
-          "D.Va|W1"
+          "DVa|W1"
         ]
       },
       {
@@ -274,9 +322,9 @@
         "icon": "storm_ui_icon_dva_defensematrix_a.png",
         "type": "W",
         "sort": 3,
-        "abilityId": "D.Va|W1",
+        "abilityId": "DVa|W1",
         "abilityLinks": [
-          "D.Va|W1"
+          "DVa|W1"
         ]
       },
       {
@@ -287,9 +335,9 @@
         "icon": "storm_ui_icon_dva_selfdestruct.png",
         "type": "E",
         "sort": 4,
-        "abilityId": "D.Va|E1",
+        "abilityId": "DVa|E1",
         "abilityLinks": [
-          "D.Va|E1"
+          "DVa|E1"
         ]
       }
     ],
@@ -303,9 +351,9 @@
         "type": "Heroic",
         "sort": 1,
         "cooldown": 100,
-        "abilityId": "D.Va|R2",
+        "abilityId": "DVa|R3",
         "abilityLinks": [
-          "D.Va|R2"
+          "DVa|R3"
         ]
       },
       {
@@ -317,9 +365,9 @@
         "type": "Heroic",
         "sort": 2,
         "cooldown": 4,
-        "abilityId": "D.Va|R1",
+        "abilityId": "DVa|R4",
         "abilityLinks": [
-          "D.Va|R1"
+          "DVa|R4"
         ]
       }
     ],
@@ -332,11 +380,11 @@
         "icon": "storm_ui_icon_dva_callmech.png",
         "type": "E",
         "sort": 1,
-        "abilityId": "D.Va|D1",
+        "abilityId": "DVa|D1",
         "abilityLinks": [
-          "D.Va|D1",
-          "D.Va|E2",
-          "D.Va|E3"
+          "DVa|D1",
+          "DVa|E3",
+          "DVa|E2"
         ]
       },
       {
@@ -347,9 +395,9 @@
         "icon": "storm_ui_icon_dva_mechmode.png",
         "type": "Trait",
         "sort": 2,
-        "abilityId": "D.Va|D1",
+        "abilityId": "DVa|D1",
         "abilityLinks": [
-          "D.Va|D1"
+          "DVa|D1"
         ]
       },
       {
@@ -360,9 +408,9 @@
         "icon": "storm_ui_icon_dva_mechmode_a.png",
         "type": "Trait",
         "sort": 3,
-        "abilityId": "D.Va|D1",
+        "abilityId": "DVa|D1",
         "abilityLinks": [
-          "D.Va|D1"
+          "DVa|D1"
         ]
       }
     ],
@@ -375,8 +423,7 @@
         "icon": "storm_ui_icon_dva_jetpackattack.png",
         "type": "Q",
         "sort": 1,
-        "cooldown": 12,
-        "abilityId": "D.Va|Q"
+        "cooldown": 12
       },
       {
         "tooltipId": "DVaPilotGGWP",
@@ -386,9 +433,9 @@
         "icon": "storm_ui_icon_dva_pilotmode.png",
         "type": "Trait",
         "sort": 2,
-        "abilityId": "D.Va|D2",
+        "abilityId": "DVa|D2",
         "abilityLinks": [
-          "D.Va|D2"
+          "DVa|D2"
         ]
       },
       {
@@ -399,9 +446,9 @@
         "icon": "storm_ui_icon_dva_pilotmode_a.png",
         "type": "Trait",
         "sort": 3,
-        "abilityId": "D.Va|D2",
+        "abilityId": "DVa|D2",
         "abilityLinks": [
-          "D.Va|D2"
+          "DVa|D2"
         ]
       },
       {
@@ -412,9 +459,9 @@
         "icon": "storm_ui_icon_dva_pilotmode_b.png",
         "type": "Trait",
         "sort": 4,
-        "abilityId": "D.Va|D2",
+        "abilityId": "DVa|D2",
         "abilityLinks": [
-          "D.Va|D2"
+          "DVa|D2"
         ]
       }
     ],
@@ -427,9 +474,9 @@
         "icon": "storm_ui_icon_dva_bunnyhop.png",
         "type": "Heroic",
         "sort": 1,
-        "abilityId": "D.Va|R2",
+        "abilityId": "DVa|R3",
         "abilityLinks": [
-          "D.Va|R2"
+          "DVa|R3"
         ]
       },
       {
@@ -440,9 +487,9 @@
         "icon": "storm_ui_icon_dva_bigshot.png",
         "type": "Heroic",
         "sort": 2,
-        "abilityId": "D.Va|R1",
+        "abilityId": "DVa|R4",
         "abilityLinks": [
-          "D.Va|R1"
+          "DVa|R4"
         ]
       },
       {
@@ -453,8 +500,7 @@
         "icon": "storm_ui_icon_dva_concussivecharge.png",
         "type": "W",
         "sort": 3,
-        "cooldown": 7,
-        "abilityId": "D.Va|W"
+        "cooldown": 7
       },
       {
         "tooltipId": "DVaPilotCallMechMEKAfallTalent",
@@ -465,9 +511,9 @@
         "type": "E",
         "sort": 4,
         "cooldown": 45,
-        "abilityId": "D.Va|E2",
+        "abilityId": "DVa|E2",
         "abilityLinks": [
-          "D.Va|E2"
+          "DVa|E2"
         ]
       }
     ]

--- a/hero/etc.json
+++ b/hero/etc.json
@@ -1,5 +1,5 @@
 {
-  "id": "4",
+  "id": 4,
   "shortName": "etc",
   "attributeId": "L90E",
   "cHeroId": "L90ETC",
@@ -21,68 +21,68 @@
     "SelfHealer"
   ],
   "abilities": {
-    "E.T.C.": [
+    "ETC": [
       {
-        "uid": "0292d79",
+        "uid": "0288ab",
         "name": "Powerslide",
         "description": "Slide to a location dealing 91 (+4% per level) damage and stunning enemies hit for 1.25 second.",
         "hotkey": "Q",
-        "abilityId": "E.T.C.|Q1",
+        "abilityId": "ETC|Q1",
         "cooldown": 12,
         "manaCost": 60,
         "icon": "storm_ui_icon_etc_powerslide.png",
         "type": "basic"
       },
       {
-        "uid": "4353106",
+        "uid": "99dc9f",
         "name": "Face Melt",
         "description": "Deals 68 (+4% per level) damage to nearby enemies, knocking them back.",
         "hotkey": "W",
-        "abilityId": "E.T.C.|W1",
+        "abilityId": "ETC|W1",
         "cooldown": 10,
         "manaCost": 50,
         "icon": "storm_ui_icon_etc_facemelt.png",
         "type": "basic"
       },
       {
-        "uid": "b9e6751",
+        "uid": "d10411",
         "name": "Guitar Solo",
         "description": "Regenerate 66 (+4% per level) Health per second for 4 seconds.",
         "hotkey": "E",
-        "abilityId": "E.T.C.|E1",
+        "abilityId": "ETC|E1",
         "cooldown": 9,
         "manaCost": 40,
         "icon": "storm_ui_icon_etc_guitarsolo.png",
         "type": "basic"
       },
       {
-        "uid": "016f0ee",
+        "uid": "111753",
         "name": "Mosh Pit",
         "description": "After 0.75 seconds, channel to stun nearby enemies for 4 seconds.",
         "hotkey": "R",
-        "abilityId": "E.T.C.|R1",
+        "abilityId": "ETC|R1",
         "cooldown": 120,
         "manaCost": 100,
         "icon": "storm_ui_icon_etc_moshpit.png",
         "type": "heroic"
       },
       {
-        "uid": "c8bd85b",
+        "uid": "1156f3",
         "name": "Stage Dive",
         "description": "Leap to target location, landing after 2.75 seconds, dealing 330 (+4% per level) damage to enemies in the area, and slowing them by 50% for 3 seconds.",
         "hotkey": "R",
-        "abilityId": "E.T.C.|R2",
+        "abilityId": "ETC|R2",
         "cooldown": 75,
         "manaCost": 100,
         "icon": "storm_ui_icon_etc_stagedive.png",
         "type": "heroic"
       },
       {
-        "uid": "c9addce",
+        "uid": "687b0a",
         "name": "Rockstar",
         "description": "After E.T.C. uses a Basic or Heroic ability, he gains 25 Armor for 2 seconds.  This effect does not stack with itself.",
         "trait": true,
-        "abilityId": "E.T.C.|D1",
+        "abilityId": "ETC|D1",
         "icon": "storm_ui_icon_etc_rockstar.png",
         "type": "trait"
       }
@@ -98,9 +98,9 @@
         "icon": "storm_ui_icon_etc_guitarsolo.png",
         "type": "E",
         "sort": 1,
-        "abilityId": "E.T.C.|E1",
+        "abilityId": "ETC|E1",
         "abilityLinks": [
-          "E.T.C.|E1"
+          "ETC|E1"
         ]
       },
       {
@@ -112,9 +112,9 @@
         "type": "E",
         "sort": 2,
         "isQuest": true,
-        "abilityId": "E.T.C.|E1",
+        "abilityId": "ETC|E1",
         "abilityLinks": [
-          "E.T.C.|E1"
+          "ETC|E1"
         ]
       },
       {
@@ -125,9 +125,9 @@
         "icon": "storm_ui_icon_etc_rockstar.png",
         "type": "Trait",
         "sort": 3,
-        "abilityId": "E.T.C.|D1",
+        "abilityId": "ETC|D1",
         "abilityLinks": [
-          "E.T.C.|D1"
+          "ETC|D1"
         ]
       }
     ],
@@ -140,9 +140,9 @@
         "icon": "storm_ui_icon_etc_powerslide.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "E.T.C.|Q1",
+        "abilityId": "ETC|Q1",
         "abilityLinks": [
-          "E.T.C.|Q1"
+          "ETC|Q1"
         ]
       },
       {
@@ -153,9 +153,9 @@
         "icon": "storm_ui_icon_etc_facemelt.png",
         "type": "W",
         "sort": 2,
-        "abilityId": "E.T.C.|W1",
+        "abilityId": "ETC|W1",
         "abilityLinks": [
-          "E.T.C.|W1"
+          "ETC|W1"
         ]
       },
       {
@@ -166,9 +166,9 @@
         "icon": "storm_ui_icon_etc_speedmetal.png",
         "type": "Trait",
         "sort": 3,
-        "abilityId": "E.T.C.|D1",
+        "abilityId": "ETC|D1",
         "abilityLinks": [
-          "E.T.C.|D1"
+          "ETC|D1"
         ]
       }
     ],
@@ -181,9 +181,9 @@
         "icon": "storm_ui_icon_etc_facemelt.png",
         "type": "W",
         "sort": 1,
-        "abilityId": "E.T.C.|W1",
+        "abilityId": "ETC|W1",
         "abilityLinks": [
-          "E.T.C.|W1"
+          "ETC|W1"
         ]
       },
       {
@@ -194,9 +194,9 @@
         "icon": "storm_ui_icon_etc_echopedal.png",
         "type": "Passive",
         "sort": 2,
-        "abilityId": "E.T.C.|Passive",
+        "abilityId": "ETC|Passive",
         "abilityLinks": [
-          "E.T.C.|D1"
+          "ETC|D1"
         ]
       },
       {
@@ -207,9 +207,9 @@
         "icon": "storm_ui_icon_talent_autoattack_damage.png",
         "type": "Passive",
         "sort": 3,
-        "abilityId": "E.T.C.|Passive",
+        "abilityId": "ETC|Passive",
         "abilityLinks": [
-          "E.T.C.|D1"
+          "ETC|D1"
         ]
       }
     ],
@@ -223,9 +223,9 @@
         "type": "Heroic",
         "sort": 1,
         "cooldown": 120,
-        "abilityId": "E.T.C.|R1",
+        "abilityId": "ETC|R1",
         "abilityLinks": [
-          "E.T.C.|R1"
+          "ETC|R1"
         ]
       },
       {
@@ -237,9 +237,9 @@
         "type": "Heroic",
         "sort": 2,
         "cooldown": 75,
-        "abilityId": "E.T.C.|R2",
+        "abilityId": "ETC|R2",
         "abilityLinks": [
-          "E.T.C.|R2"
+          "ETC|R2"
         ]
       }
     ],
@@ -252,9 +252,9 @@
         "icon": "storm_ui_icon_etc_facemelt.png",
         "type": "W",
         "sort": 1,
-        "abilityId": "E.T.C.|W1",
+        "abilityId": "ETC|W1",
         "abilityLinks": [
-          "E.T.C.|W1"
+          "ETC|W1"
         ]
       },
       {
@@ -265,9 +265,9 @@
         "icon": "storm_ui_icon_etc_facemelt_a.png",
         "type": "W",
         "sort": 2,
-        "abilityId": "E.T.C.|W1",
+        "abilityId": "ETC|W1",
         "abilityLinks": [
-          "E.T.C.|W1"
+          "ETC|W1"
         ]
       },
       {
@@ -278,9 +278,9 @@
         "icon": "storm_ui_icon_etc_facemelt_b.png",
         "type": "W",
         "sort": 3,
-        "abilityId": "E.T.C.|W1",
+        "abilityId": "ETC|W1",
         "abilityLinks": [
-          "E.T.C.|W1"
+          "ETC|W1"
         ]
       }
     ],
@@ -293,9 +293,9 @@
         "icon": "storm_ui_icon_etc_powerslide.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "E.T.C.|Q1",
+        "abilityId": "ETC|Q1",
         "abilityLinks": [
-          "E.T.C.|Q1"
+          "ETC|Q1"
         ]
       },
       {
@@ -306,9 +306,9 @@
         "icon": "storm_ui_icon_etc_guitarsolo.png",
         "type": "E",
         "sort": 2,
-        "abilityId": "E.T.C.|E1",
+        "abilityId": "ETC|E1",
         "abilityLinks": [
-          "E.T.C.|E1"
+          "ETC|E1"
         ]
       },
       {
@@ -320,7 +320,7 @@
         "type": "Active",
         "sort": 3,
         "cooldown": 20,
-        "abilityId": "E.T.C.|Active"
+        "abilityId": "ETC|Active"
       }
     ],
     "20": [
@@ -332,9 +332,9 @@
         "icon": "storm_ui_icon_etc_moshpit.png",
         "type": "Heroic",
         "sort": 1,
-        "abilityId": "E.T.C.|R1",
+        "abilityId": "ETC|R1",
         "abilityLinks": [
-          "E.T.C.|R1"
+          "ETC|R1"
         ]
       },
       {
@@ -345,9 +345,9 @@
         "icon": "storm_ui_icon_etc_stagedive.png",
         "type": "Heroic",
         "sort": 2,
-        "abilityId": "E.T.C.|R2",
+        "abilityId": "ETC|R2",
         "abilityLinks": [
-          "E.T.C.|R2"
+          "ETC|R2"
         ]
       },
       {
@@ -358,9 +358,9 @@
         "icon": "storm_ui_icon_etc_moshpit_a.png",
         "type": "Passive",
         "sort": 3,
-        "abilityId": "E.T.C.|Passive",
+        "abilityId": "ETC|Passive",
         "abilityLinks": [
-          "E.T.C.|D1"
+          "ETC|D1"
         ]
       },
       {
@@ -372,7 +372,7 @@
         "type": "Active",
         "sort": 4,
         "cooldown": 45,
-        "abilityId": "E.T.C.|Active"
+        "abilityId": "ETC|Active"
       },
       {
         "tooltipId": "GenericBoltoftheStormTalent",
@@ -383,7 +383,7 @@
         "type": "Active",
         "sort": 5,
         "cooldown": 70,
-        "abilityId": "E.T.C.|Active"
+        "abilityId": "ETC|Active"
       }
     ]
   }

--- a/hero/falstad.json
+++ b/hero/falstad.json
@@ -1,5 +1,5 @@
 {
-  "id": "5",
+  "id": 5,
   "shortName": "falstad",
   "attributeId": "Fals",
   "cHeroId": "Falstad",
@@ -21,7 +21,7 @@
   "abilities": {
     "Falstad": [
       {
-        "uid": "ecd777f",
+        "uid": "a6eba5",
         "name": "Hammerang",
         "description": "Throw out a Hammer that returns to Falstad, dealing 121 (+4% per level) damage and slowing enemies by 25% for 2 seconds.",
         "hotkey": "Q",
@@ -32,7 +32,7 @@
         "type": "basic"
       },
       {
-        "uid": "df83282",
+        "uid": "fbe0b2",
         "name": "Lightning Rod",
         "description": "Deal 107 (+4% per level) damage to an enemy, and an additional 75 (+4% per level) damage per second for 4 seconds while close to the target.",
         "hotkey": "W",
@@ -43,7 +43,7 @@
         "type": "basic"
       },
       {
-        "uid": "d4771fe",
+        "uid": "273040",
         "name": "Barrel Roll",
         "description": "Dashes forward and grants a 171 (+4% per level) point Shield for 3 seconds.",
         "hotkey": "E",
@@ -54,18 +54,7 @@
         "type": "basic"
       },
       {
-        "uid": "f76343f",
-        "name": "Hinterland Blast",
-        "description": "After 1 second, deal 475 (+4.75% per level) damage to enemies within a long line. The cooldown is reduced by 25 seconds for every enemy Hero hit.",
-        "hotkey": "R",
-        "abilityId": "Falstad|R2",
-        "cooldown": 120,
-        "manaCost": 100,
-        "icon": "storm_ui_icon_falstad_hinterlandblast.png",
-        "type": "heroic"
-      },
-      {
-        "uid": "6bd6556",
+        "uid": "8ca841",
         "name": "Mighty Gust",
         "description": "Push enemies away, and slow their Movement Speed by 40% decaying over 4 seconds.",
         "hotkey": "R",
@@ -76,17 +65,18 @@
         "type": "heroic"
       },
       {
-        "uid": "052c116",
-        "name": "Flight",
-        "description": "Instead of mounting, Falstad can fly a great distance over terrain.",
-        "hotkey": "Z",
-        "abilityId": "Falstad|Z1",
-        "cooldown": 75,
-        "icon": "storm_ui_icon_falstad_mount.png",
-        "type": "mount"
+        "uid": "5aff81",
+        "name": "Hinterland Blast",
+        "description": "After 1 second, deal 475 (+4.75% per level) damage to enemies within a long line. The cooldown is reduced by 25 seconds for every enemy Hero hit.",
+        "hotkey": "R",
+        "abilityId": "Falstad|R2",
+        "cooldown": 120,
+        "manaCost": 100,
+        "icon": "storm_ui_icon_falstad_hinterlandblast.png",
+        "type": "heroic"
       },
       {
-        "uid": "3a376a9",
+        "uid": "c3bc73",
         "name": "Tailwind",
         "description": "Gain 15% increased Movement Speed after not taking damage for 6 seconds.",
         "trait": true,
@@ -94,6 +84,16 @@
         "cooldown": 6,
         "icon": "storm_ui_icon_falstad_tailwind.png",
         "type": "trait"
+      },
+      {
+        "uid": "bd615a",
+        "name": "Flight",
+        "description": "Instead of mounting, Falstad can fly a great distance over terrain.",
+        "hotkey": "Z",
+        "abilityId": "Falstad|Z1",
+        "cooldown": 75,
+        "icon": "storm_ui_icon_falstad_mount.png",
+        "type": "mount"
       }
     ]
   },
@@ -132,7 +132,7 @@
         "icon": "storm_ui_icon_talent_bribe.png",
         "type": "Active",
         "sort": 3,
-        "abilityId": "Falstad|W1",
+        "abilityId": "Falstad|Active",
         "abilityLinks": [
           "Falstad|W1"
         ]

--- a/hero/fenix.json
+++ b/hero/fenix.json
@@ -1,5 +1,5 @@
 {
-  "id": "78",
+  "id": 78,
   "shortName": "fenix",
   "attributeId": "FENX",
   "cHeroId": "Fenix",
@@ -20,7 +20,7 @@
   "abilities": {
     "Fenix": [
       {
-        "uid": "b24a7df",
+        "uid": "7bc76a",
         "name": "Plasma Cutter",
         "description": "Create a laser beam at the target point that circles around Fenix twice, dealing 135 (+4% per level) damage to enemies hit and Slowing them by 25% for 4 seconds.",
         "hotkey": "Q",
@@ -30,7 +30,7 @@
         "type": "basic"
       },
       {
-        "uid": "ce8f347",
+        "uid": "3f062b",
         "name": "Weapon Mode: Repeater Cannon",
         "description": "Basic Attack speed increased by 150%.  Activate to change to Weapon Mode: Phase Bomb, increasing Basic Attack range and damage, and causing Basic Attacks to splash.",
         "hotkey": "W",
@@ -39,7 +39,7 @@
         "type": "basic"
       },
       {
-        "uid": "291ccac",
+        "uid": "01759b",
         "name": "Warp",
         "description": "Warp to a targeted location, phasing out after 0.5 seconds, and arriving 0.75 seconds later.",
         "hotkey": "E",
@@ -49,17 +49,7 @@
         "type": "basic"
       },
       {
-        "uid": "ea70829",
-        "name": "Purification Salvo",
-        "description": "Channel for 1.5 seconds, sweeping a laser in front of Fenix that locks onto enemy Heroes. Once Channeling finishes, fire 5 missiles at each locked Hero, dealing 79 (+4% per level) damage each. Deals 50% increased damage to Slowed targets.",
-        "hotkey": "R",
-        "abilityId": "Fenix|R2",
-        "cooldown": 90,
-        "icon": "storm_ui_icon_fenix_r_scan.png",
-        "type": "heroic"
-      },
-      {
-        "uid": "4781e49",
+        "uid": "479715",
         "name": "Planet Cracker",
         "description": "After 0.5 seconds, Channel a powerful beam that spans across the battleground for 4 seconds, dealing 112 (+4% per level) damage every 0.25 seconds to non-Structure enemies hit.",
         "hotkey": "R",
@@ -69,7 +59,17 @@
         "type": "heroic"
       },
       {
-        "uid": "d2658c2",
+        "uid": "6adf00",
+        "name": "Purification Salvo",
+        "description": "Channel for 1.5 seconds, sweeping a laser in front of Fenix that locks onto enemy Heroes. Once Channeling finishes, fire 5 missiles at each locked Hero, dealing 79 (+4% per level) damage each. Deals 50% increased damage to Slowed targets.",
+        "hotkey": "R",
+        "abilityId": "Fenix|R2",
+        "cooldown": 90,
+        "icon": "storm_ui_icon_fenix_r_scan.png",
+        "type": "heroic"
+      },
+      {
+        "uid": "e00d4f",
         "name": "Shield Capacitor",
         "description": "Fenix has a permanent 760 (+4% per level) Shield which regenerates at 10% per second after not taking damage for 5 seconds.",
         "trait": true,
@@ -80,13 +80,13 @@
     ],
     "FenixPhaseBomb": [
       {
-        "uid": "9bb3ae7",
+        "uid": "657fba",
         "name": "Weapon Mode: Phase Bomb",
         "description": "Basic Attacks have 1.25 increased range, deal 25% more damage, and splash to nearby enemies.  Activate to change to Weapon Mode: Repeater Cannon, increasing Basic Attack speed.",
         "hotkey": "W",
         "abilityId": "Fenix|W2",
         "icon": "storm_ui_icon_fenix_w_1.png",
-        "type": "subunit"
+        "type": "basic"
       }
     ]
   },
@@ -114,10 +114,10 @@
         "icon": "storm_ui_icon_fenix_w_1.png",
         "type": "W",
         "sort": 2,
-        "abilityId": "Fenix|W1",
+        "abilityId": "Fenix|W2",
         "abilityLinks": [
-          "Fenix|W1",
-          "Fenix|W2"
+          "Fenix|W2",
+          "Fenix|W1"
         ]
       },
       {
@@ -128,10 +128,10 @@
         "icon": "storm_ui_icon_fenix_w_2.png",
         "type": "W",
         "sort": 3,
-        "abilityId": "Fenix|W1",
+        "abilityId": "Fenix|W2",
         "abilityLinks": [
-          "Fenix|W1",
-          "Fenix|W2"
+          "Fenix|W2",
+          "Fenix|W1"
         ]
       }
     ],
@@ -212,7 +212,7 @@
         "type": "Active",
         "sort": 3,
         "cooldown": 40,
-        "abilityId": "Fenix|D1",
+        "abilityId": "Fenix|Active",
         "abilityLinks": [
           "Fenix|D1"
         ]
@@ -362,10 +362,10 @@
         "icon": "storm_ui_icon_fenix_w_2.png",
         "type": "W",
         "sort": 2,
-        "abilityId": "Fenix|W1",
+        "abilityId": "Fenix|W2",
         "abilityLinks": [
-          "Fenix|W1",
-          "Fenix|W2"
+          "Fenix|W2",
+          "Fenix|W1"
         ]
       },
       {

--- a/hero/gall.json
+++ b/hero/gall.json
@@ -220,8 +220,7 @@
         "sort": 3,
         "abilityId": "Gall|D1",
         "abilityLinks": [
-          "Gall|D1",
-          "Gall|D2"
+          "Gall|D1"
         ]
       }
     ],
@@ -359,9 +358,8 @@
         "icon": "storm_ui_icon_gall_twistingnether_a.png",
         "type": "Heroic",
         "sort": 2,
-        "abilityId": "Gall|R3",
+        "abilityId": "Gall|R1",
         "abilityLinks": [
-          "Gall|R3",
           "Gall|R1"
         ]
       },
@@ -375,8 +373,7 @@
         "sort": 3,
         "abilityId": "Gall|D1",
         "abilityLinks": [
-          "Gall|D1",
-          "Gall|D2"
+          "Gall|D1"
         ]
       },
       {

--- a/hero/gall.json
+++ b/hero/gall.json
@@ -1,5 +1,5 @@
 {
-  "id": "44",
+  "id": 44,
   "shortName": "gall",
   "attributeId": "Gall",
   "cHeroId": "Gall",
@@ -18,7 +18,7 @@
   "abilities": {
     "Gall": [
       {
-        "uid": "b20ba22",
+        "uid": "83e6b0",
         "name": "Shadowflame",
         "description": "Deal 135 (+5% per level) damage to enemies in the area.",
         "hotkey": "Q",
@@ -28,7 +28,7 @@
         "type": "basic"
       },
       {
-        "uid": "e0f8884",
+        "uid": "95060a",
         "name": "Dread Orb",
         "description": "Throw a bomb that will bounce three times, dealing 126 (+5% per level) damage to enemies.",
         "hotkey": "W",
@@ -38,27 +38,26 @@
         "type": "basic"
       },
       {
-        "uid": "462aca7",
+        "uid": "192cd0",
         "name": "Runic Blast",
         "description": "Detonate Cho's Rune Bomb, dealing 210 (+4% per level) damage around it.",
         "hotkey": "E",
         "abilityId": "Gall|E1",
-        "cooldown": 1,
         "icon": "storm_ui_icon_gall_detonaterunes.png",
         "type": "basic"
       },
       {
-        "uid": "cc8b7ee",
-        "name": "Shadow Bolt Volley",
-        "description": "After 1 second, unleash 20 Shadow Bolts over 4 seconds, each dealing 87 (+4% per level) damage to the first target hit. The bolts fire towards your mouse.",
-        "hotkey": "R",
-        "abilityId": "Gall|R2",
-        "cooldown": 60,
-        "icon": "storm_ui_icon_gall_shadowboltvolley.png",
-        "type": "heroic"
+        "uid": "a130e8",
+        "name": "Eye of Kilrogg",
+        "description": "Place an eye, granting vision of a large area around it for 45 seconds. The eye can be killed by enemies with 2 Basic Attacks. Stores up to 2 charges.",
+        "hotkey": 1,
+        "abilityId": "Gall|11",
+        "cooldown": 45,
+        "icon": "storm_ui_icon_gall_eyeofkilrogg.png",
+        "type": "activable"
       },
       {
-        "uid": "224e63c",
+        "uid": "3569aa",
         "name": "Twisting Nether",
         "description": "After 1 second, nearby enemies are slowed by 50% while Gall channels, up to 5 seconds. Activate to deal 353 (+5% per level) damage.",
         "hotkey": "R",
@@ -68,10 +67,19 @@
         "type": "heroic"
       },
       {
-        "uid": "450eca7",
+        "uid": "ba0387",
+        "name": "Shadow Bolt Volley",
+        "description": "After 1 second, unleash 20 Shadow Bolts over 4 seconds, each dealing 87 (+4% per level) damage to the first target hit. The bolts fire towards your mouse.",
+        "hotkey": "R",
+        "abilityId": "Gall|R2",
+        "cooldown": 60,
+        "icon": "storm_ui_icon_gall_shadowboltvolley.png",
+        "type": "heroic"
+      },
+      {
+        "uid": "50623f",
         "name": "Ogre Rage",
         "description": "Activate to increase Gall's damage by 25%, but reduce Cho's Armor by 25.  Passive: Gall is permanently immune to Stun and Silence effects.",
-        "hotkey": "D",
         "trait": true,
         "abilityId": "Gall|D1",
         "cooldown": 5,
@@ -79,7 +87,7 @@
         "type": "trait"
       },
       {
-        "uid": "c4791e7",
+        "uid": "2cd39d",
         "name": "Shove",
         "description": "Nudge Cho a small distance and grant him 25% Movement Speed for 2 seconds.",
         "hotkey": "Z",
@@ -87,16 +95,6 @@
         "cooldown": 30,
         "icon": "storm_ui_icon_gall_shove.png",
         "type": "mount"
-      },
-      {
-        "uid": "349b09b",
-        "name": "Eye of Kilrogg",
-        "description": "Place an eye, granting vision of a large area around it for 45 seconds. The eye can be killed by enemies with 2 Basic Attacks. Stores up to 2 charges.",
-        "hotkey": "1",
-        "abilityId": "Gall|11",
-        "cooldown": 45,
-        "icon": "storm_ui_icon_gall_eyeofkilrogg.png",
-        "type": "activable"
       }
     ]
   },
@@ -222,7 +220,8 @@
         "sort": 3,
         "abilityId": "Gall|D1",
         "abilityLinks": [
-          "Gall|D1"
+          "Gall|D1",
+          "Gall|D2"
         ]
       }
     ],
@@ -360,8 +359,9 @@
         "icon": "storm_ui_icon_gall_twistingnether_a.png",
         "type": "Heroic",
         "sort": 2,
-        "abilityId": "Gall|R1",
+        "abilityId": "Gall|R3",
         "abilityLinks": [
+          "Gall|R3",
           "Gall|R1"
         ]
       },
@@ -375,7 +375,8 @@
         "sort": 3,
         "abilityId": "Gall|D1",
         "abilityLinks": [
-          "Gall|D1"
+          "Gall|D1",
+          "Gall|D2"
         ]
       },
       {

--- a/hero/garrosh.json
+++ b/hero/garrosh.json
@@ -1,5 +1,5 @@
 {
-  "id": "70",
+  "id": 70,
   "shortName": "garrosh",
   "attributeId": "Garr",
   "cHeroId": "Garrosh",
@@ -21,7 +21,7 @@
   "abilities": {
     "Garrosh": [
       {
-        "uid": "bc66e97",
+        "uid": "449148",
         "name": "Groundbreaker",
         "description": "Deal 81 (+4% per level) damage to enemies in an area. Heroes hit on the outer edge are Stunned for 0.5 seconds and then Slowed by 40% for 2 seconds.",
         "hotkey": "Q",
@@ -32,7 +32,7 @@
         "type": "basic"
       },
       {
-        "uid": "8ccf1fe",
+        "uid": "aa0321",
         "name": "Bloodthirst",
         "description": "Deal 156 (+4% per level) damage to an enemy and heal for 10% of Garrosh's missing Health. Healing is increased by 100% against Heroes.",
         "hotkey": "W",
@@ -43,7 +43,7 @@
         "type": "basic"
       },
       {
-        "uid": "8b0f1d7",
+        "uid": "2967d2",
         "name": "Wrecking Ball",
         "description": "Throw a nearby enemy Hero, Minion, or Mercenary to the target location, dealing 91 (+4% per level) damage to enemies near the impact and Slowing them by 30% for 2.5 seconds.",
         "hotkey": "E",
@@ -54,7 +54,7 @@
         "type": "basic"
       },
       {
-        "uid": "86b16f6",
+        "uid": "fe030a",
         "name": "Warlord's Challenge",
         "description": "Silence nearby Heroes and force them to attack Garrosh for 2 seconds.",
         "hotkey": "R",
@@ -65,7 +65,7 @@
         "type": "heroic"
       },
       {
-        "uid": "525e948",
+        "uid": "a04c13",
         "name": "Decimate",
         "description": "Deal 50 (+4% per level) damage to nearby enemies and Slow them by 40% for 1.5 seconds. Deals 100% more damage to Heroes, and each Hero hit reduces the cooldown by 1 second.  Stores up to 3 charges.",
         "hotkey": "R",
@@ -76,7 +76,7 @@
         "type": "heroic"
       },
       {
-        "uid": "a3605a7",
+        "uid": "aa733e",
         "name": "Armor Up",
         "description": "Garrosh gains 1 Armor for every 2% of maximum Health missing.",
         "trait": true,
@@ -183,7 +183,7 @@
       {
         "tooltipId": "GarroshOppressor",
         "talentTreeId": "GarroshOppressor",
-        "name": "Oppressor",
+        "name": "Oppressor ",
         "description": "Basic Attacks against Heroes reduce the target's Spell Power by 40% for 2.5 seconds.",
         "icon": "storm_ui_icon_talent_autoattack_slow.png",
         "type": "Passive",
@@ -363,10 +363,8 @@
         "icon": "storm_ui_icon_garrosh_slam.png",
         "type": "Active",
         "sort": 4,
-        "abilityId": "Garrosh|11",
-        "abilityLinks": [
-          "Garrosh|11"
-        ]
+        "abilityId": "Garrosh|Active",
+        "abilityLinks": []
       }
     ]
   }

--- a/hero/gazlowe.json
+++ b/hero/gazlowe.json
@@ -1,5 +1,5 @@
 {
-  "id": "6",
+  "id": 6,
   "shortName": "gazlowe",
   "attributeId": "Tink",
   "cHeroId": "Tinker",
@@ -22,7 +22,7 @@
   "abilities": {
     "Gazlowe": [
       {
-        "uid": "c70bdc5",
+        "uid": "c31436",
         "name": "Rock-It! Turret",
         "description": "Creates a turret that deals 62 (+4% per level) damage. Lasts for 30 seconds.  Stores up to 2 charges.",
         "hotkey": "Q",
@@ -33,7 +33,7 @@
         "type": "basic"
       },
       {
-        "uid": "9b1ddd5",
+        "uid": "8a7b6e",
         "name": "Deth Lazor",
         "description": "Charged attack that deals 137 (+4% per level) damage to enemies in a line. Damage and range increase the longer the Ability is charged, up to 100% after 3 seconds.  Deth Lazor can be channeled indefinitely.",
         "hotkey": "W",
@@ -44,7 +44,7 @@
         "type": "basic"
       },
       {
-        "uid": "2b1f1d9",
+        "uid": "8f8fb4",
         "name": "Xplodium Charge",
         "description": "Places a bomb that deals 233 (+4% per level) damage to enemies within target area after 2.5 seconds, stunning them for 1.75 seconds.",
         "hotkey": "E",
@@ -55,7 +55,17 @@
         "type": "basic"
       },
       {
-        "uid": "7674f64",
+        "uid": "9236e5",
+        "name": "Focus Turrets!",
+        "description": "Orders any nearby Rock-It! Turrets to focus the target.",
+        "hotkey": 1,
+        "abilityId": "Gazlowe|11",
+        "cooldown": 1,
+        "icon": "storm_ui_icon_gazlowe_rockitturret_var1.png",
+        "type": "activable"
+      },
+      {
+        "uid": "0de520",
         "name": "Grav-O-Bomb 3000",
         "description": "After a 2 second delay, pull enemies toward the center of an area and deal 251 (+4% per level) damage.",
         "hotkey": "R",
@@ -66,7 +76,7 @@
         "type": "heroic"
       },
       {
-        "uid": "66818b8",
+        "uid": "5a140f",
         "name": "Robo-Goblin",
         "description": "Activate to gain 40 Armor and 30% Movement Speed for 4 seconds.  Passive: Basic Attacks deal 100% bonus damage.",
         "hotkey": "R",
@@ -76,24 +86,13 @@
         "type": "heroic"
       },
       {
-        "uid": "dd49e53",
+        "uid": "0bdf5b",
         "name": "Salvager",
         "description": "Destroyed enemy Structures and Rock-it! Turrets drop Scrap. Collecting Scrap restores 30 Mana and causes Abilities to recharge three times as fast over 3 seconds.  Activate Salvager to dismantle a target Rock-it! Turret and turn it into Scrap.",
-        "hotkey": "D",
         "trait": true,
         "abilityId": "Gazlowe|D1",
         "icon": "storm_ui_icon_gazlowe_salvager.png",
         "type": "trait"
-      },
-      {
-        "uid": "1cfd392",
-        "name": "Focus Turrets!",
-        "description": "Orders any nearby Rock-It! Turrets to focus the target.",
-        "hotkey": "1",
-        "abilityId": "Gazlowe|11",
-        "cooldown": 1,
-        "icon": "storm_ui_icon_gazlowe_rockitturret_var1.png",
-        "type": "activable"
       }
     ]
   },

--- a/hero/genji.json
+++ b/hero/genji.json
@@ -1,5 +1,5 @@
 {
-  "id": "66",
+  "id": 66,
   "shortName": "genji",
   "attributeId": "Genj",
   "cHeroId": "Genji",
@@ -21,7 +21,7 @@
   "abilities": {
     "Genji": [
       {
-        "uid": "b02b4cf",
+        "uid": "c2ed1a",
         "name": "Shuriken",
         "description": "Throw 3 Shuriken in a spread pattern, each dealing 65 (+4% per level) damage to the first enemy hit.  Stores up to 3 charges.  Shuriken's cooldown replenishes all charges at the same time.",
         "hotkey": "Q",
@@ -32,7 +32,7 @@
         "type": "basic"
       },
       {
-        "uid": "e3695ec",
+        "uid": "27468d",
         "name": "Deflect",
         "description": "Channel for 1.25 seconds, becoming Protected and blocking damage. Any damage blocked while channeling causes Genji to throw a Kunai toward the nearest enemy, prioritizing Heroes and dealing 55 (+4% per level) damage.  Total Damage Deflected: 0",
         "hotkey": "W",
@@ -43,7 +43,7 @@
         "type": "basic"
       },
       {
-        "uid": "18d4acf",
+        "uid": "a01ab8",
         "name": "Swift Strike",
         "description": "Dash forward, dealing 190 (+4% per level) damage to all enemies in a line. Enemy Heroes that die within 1.5 seconds of being hit with Swift Strike cause the cooldown and mana cost to be refunded.",
         "hotkey": "E",
@@ -54,7 +54,7 @@
         "type": "basic"
       },
       {
-        "uid": "3d18aab",
+        "uid": "ba877b",
         "name": "Dragonblade",
         "description": "Unleash the Dragonblade for 8 seconds. While active, Dragonblade can be reactivated to lunge forward and slash in a huge arc, dealing 240 (+4% per level) damage.",
         "hotkey": "R",
@@ -65,7 +65,7 @@
         "type": "heroic"
       },
       {
-        "uid": "d577507",
+        "uid": "06f87e",
         "name": "X-Strike",
         "description": "Perform two slashes dealing 135 (+4% per level) damage. The slashes detonate after 1.25 seconds causing an additional 270 (+4% per level) damage to enemies in their area.",
         "hotkey": "R",
@@ -76,10 +76,9 @@
         "type": "heroic"
       },
       {
-        "uid": "20bf795",
+        "uid": "c4d7cf",
         "name": "Cyber Agility",
         "description": "Activate to jump to the target area.",
-        "hotkey": "D",
         "trait": true,
         "abilityId": "Genji|D1",
         "cooldown": 15,
@@ -166,7 +165,7 @@
         "icon": "storm_ui_icon_genji_shurikens_dragonsoul.png",
         "type": "Active",
         "sort": 3,
-        "abilityId": "Genji|W1",
+        "abilityId": "Genji|Active",
         "abilityLinks": [
           "Genji|W1"
         ]
@@ -344,8 +343,9 @@
         "icon": "storm_ui_icon_genji_dragonblade.png",
         "type": "Heroic",
         "sort": 1,
-        "abilityId": "Genji|R1",
+        "abilityId": "Genji|R3",
         "abilityLinks": [
+          "Genji|R3",
           "Genji|R1"
         ]
       },

--- a/hero/genji.json
+++ b/hero/genji.json
@@ -343,9 +343,8 @@
         "icon": "storm_ui_icon_genji_dragonblade.png",
         "type": "Heroic",
         "sort": 1,
-        "abilityId": "Genji|R3",
+        "abilityId": "Genji|R1",
         "abilityLinks": [
-          "Genji|R3",
           "Genji|R1"
         ]
       },

--- a/hero/greymane.json
+++ b/hero/greymane.json
@@ -1,5 +1,5 @@
 {
-  "id": "47",
+  "id": 47,
   "shortName": "greymane",
   "attributeId": "Genn",
   "cHeroId": "Greymane",
@@ -22,7 +22,7 @@
   "abilities": {
     "Greymane": [
       {
-        "uid": "dcb7e59",
+        "uid": "ae9951",
         "name": "Gilnean Cocktail",
         "description": "Hurl a flask that deals 55 (+4% per level) damage to the first enemy hit and explodes for 220 (+4% per level) damage to enemies in a cone behind them.  Worgen: Razor Swipe Swipe forward, damaging enemies hit.",
         "hotkey": "Q",
@@ -33,7 +33,7 @@
         "type": "basic"
       },
       {
-        "uid": "0b51f72",
+        "uid": "c6ff90",
         "name": "Inner Beast",
         "description": "Gain 50% Attack Speed for 3 seconds. Basic Attacks refresh this duration, and reduce the cooldown of Inner Beast by 0.5 seconds.",
         "hotkey": "W",
@@ -44,7 +44,7 @@
         "type": "basic"
       },
       {
-        "uid": "eb4795d",
+        "uid": "5f25d1",
         "name": "Darkflight",
         "description": "Shapeshift into a Worgen and leap at an enemy dealing 88 (+4% per level) damage.  Worgen: Disengage Roll away and shapeshift into a Human.",
         "hotkey": "E",
@@ -55,7 +55,7 @@
         "type": "basic"
       },
       {
-        "uid": "435df61",
+        "uid": "9b2a0f",
         "name": "Go for the Throat",
         "description": "Leap at an enemy Hero and shapeshift into a Worgen, slashing for 355 (+4% per level) damage. If this kills them, the Ability can be used a second time within 10 seconds for free.",
         "hotkey": "R",
@@ -66,7 +66,7 @@
         "type": "heroic"
       },
       {
-        "uid": "0059168",
+        "uid": "eb39a6",
         "name": "Cursed Bullet",
         "description": "Greymane shapeshifts into a Human and fires a bullet that hits the first enemy Hero in its path, dealing 40% of their current Health in damage.  Does not affect Vehicles.",
         "hotkey": "R",
@@ -77,18 +77,28 @@
         "type": "heroic"
       },
       {
-        "uid": "bf6ce9e",
+        "uid": "cc4a83",
         "name": "Curse of the Worgen",
         "description": "Greymane can use certain Abilities to shapeshift between a Human and a Worgen.  While Human, Greymane's Basic Attacks are ranged.  While Worgen, Greymane gains 10 Armor, and his Basic Attacks become melee but deal 40% more damage.",
         "trait": true,
         "abilityId": "Greymane|D1",
         "icon": "storm_ui_icon_greymane_curseoftheworgen.png",
         "type": "trait"
+      },
+      {
+        "uid": "4a0bc2",
+        "name": "Summon Mount",
+        "description": "Shapeshift into Human form and increase Greymane's Movement Speed by 40%.",
+        "hotkey": "Z",
+        "abilityId": "Greymane|Z1",
+        "cooldown": 4,
+        "icon": "storm_ui_icon_generic_mount.png",
+        "type": "mount"
       }
     ],
     "GreymaneWorgenForm": [
       {
-        "uid": "a3476c2",
+        "uid": "ef6f41",
         "name": "Razor Swipe",
         "description": "Swipe in the targeted direction, dealing 126 (+4% per level) damage to enemies hit.  Human: Gilnean Cocktail Damage the first enemy hit and deal heavy damage behind them.",
         "hotkey": "Q",
@@ -96,17 +106,26 @@
         "cooldown": 4,
         "manaCost": 25,
         "icon": "storm_ui_icon_greymane_swipe.png",
-        "type": "subunit"
+        "type": "basic"
       },
       {
-        "uid": "4602adf",
+        "uid": "fbdd1d",
+        "name": "Inner Beast",
+        "description": "Gain 50% Attack Speed for 3 seconds. Basic Attacks refresh this duration, and reduce the cooldown of Inner Beast by 0.5 seconds.",
+        "hotkey": "W",
+        "abilityId": "Greymane|W2",
+        "icon": "storm_ui_icon_greymane_worgen_beastfocus.png",
+        "type": "basic"
+      },
+      {
+        "uid": "32f9f4",
         "name": "Disengage",
         "description": "Roll away and shapeshift into a Human.  Human: Darkflight Leap at an enemy and shapeshift into a Worgen.",
         "hotkey": "E",
         "abilityId": "Greymane|E2",
         "cooldown": 5,
         "icon": "storm_ui_icon_greymane_disengage.png",
-        "type": "subunit"
+        "type": "basic"
       }
     ]
   },
@@ -120,10 +139,10 @@
         "icon": "storm_ui_icon_greymane_beastfocus.png",
         "type": "W",
         "sort": 1,
-        "abilityId": "Greymane|W1",
+        "abilityId": "Greymane|W2",
         "abilityLinks": [
-          "Greymane|W1",
-          "Greymane|W2"
+          "Greymane|W2",
+          "Greymane|W1"
         ]
       },
       {
@@ -147,10 +166,10 @@
         "icon": "storm_ui_icon_greymane_beastfocus_var1.png",
         "type": "W",
         "sort": 3,
-        "abilityId": "Greymane|W1",
+        "abilityId": "Greymane|W2",
         "abilityLinks": [
-          "Greymane|W1",
-          "Greymane|W2"
+          "Greymane|W2",
+          "Greymane|W1"
         ]
       }
     ],
@@ -189,10 +208,10 @@
         "icon": "storm_ui_icon_greymane_beastfocus.png",
         "type": "W",
         "sort": 3,
-        "abilityId": "Greymane|W1",
+        "abilityId": "Greymane|W2",
         "abilityLinks": [
-          "Greymane|W1",
-          "Greymane|W2"
+          "Greymane|W2",
+          "Greymane|W1"
         ]
       }
     ],
@@ -278,10 +297,10 @@
         "icon": "storm_ui_icon_greymane_darkflight.png",
         "type": "E",
         "sort": 1,
-        "abilityId": "Greymane|E1",
+        "abilityId": "Greymane|E2",
         "abilityLinks": [
-          "Greymane|E1",
-          "Greymane|E2"
+          "Greymane|E2",
+          "Greymane|E1"
         ]
       },
       {
@@ -305,10 +324,10 @@
         "icon": "storm_ui_icon_greymane_beastfocus.png",
         "type": "W",
         "sort": 3,
-        "abilityId": "Greymane|W1",
+        "abilityId": "Greymane|W2",
         "abilityLinks": [
-          "Greymane|W1",
-          "Greymane|W2"
+          "Greymane|W2",
+          "Greymane|W1"
         ]
       }
     ],
@@ -321,10 +340,10 @@
         "icon": "storm_ui_icon_greymane_beastfocus.png",
         "type": "W",
         "sort": 1,
-        "abilityId": "Greymane|W1",
+        "abilityId": "Greymane|W2",
         "abilityLinks": [
-          "Greymane|W1",
-          "Greymane|W2"
+          "Greymane|W2",
+          "Greymane|W1"
         ]
       },
       {

--- a/hero/guldan.json
+++ b/hero/guldan.json
@@ -1,5 +1,5 @@
 {
-  "id": "54",
+  "id": 54,
   "shortName": "guldan",
   "attributeId": "Guld",
   "cHeroId": "Guldan",
@@ -18,68 +18,67 @@
     "WaveClearer"
   ],
   "abilities": {
-    "Gul'dan": [
+    "Guldan": [
       {
-        "uid": "c450c34",
+        "uid": "4484ac",
         "name": "Fel Flame",
         "description": "Release a wave of flame, dealing 200 (+4.5% per level) damage to enemies.",
         "hotkey": "Q",
-        "abilityId": "Gul'dan|Q1",
-        "cooldown": 1.5,
+        "abilityId": "Guldan|Q1",
+        "cooldown": 15,
         "manaCost": 75,
         "icon": "storm_ui_icon_guldan_felflame.png",
         "type": "basic"
       },
       {
-        "uid": "8737073",
+        "uid": "3d947d",
         "name": "Drain Life",
         "description": "Drain the life from an enemy over 3 seconds, dealing 132 (+4% per level) damage per second and healing Gul'dan for 188 (+4% per level) Health per second.",
         "hotkey": "W",
-        "abilityId": "Gul'dan|W1",
+        "abilityId": "Guldan|W1",
         "cooldown": 10,
         "icon": "storm_ui_icon_guldan_healthfunnel.png",
         "type": "basic"
       },
       {
-        "uid": "6bdcadc",
+        "uid": "cb334a",
         "name": "Corruption",
         "description": "Call forth three bursts of shadow energy, dealing 204 (+4.5% per level) damage over 6 seconds. Corruption can stack up to 3 times on an enemy.",
         "hotkey": "E",
-        "abilityId": "Gul'dan|E1",
+        "abilityId": "Guldan|E1",
         "cooldown": 14,
         "manaCost": 80,
         "icon": "storm_ui_icon_guldan_handofguldan.png",
         "type": "basic"
       },
       {
-        "uid": "1654a2c",
+        "uid": "7493b6",
         "name": "Horrify",
         "description": "After 0.5 seconds, deal 120 (+4% per level) damage to enemy Heroes in an area and Fear them for 2 seconds. While Feared, Heroes are Silenced and are forced to run away from Horrify's center.",
         "hotkey": "R",
-        "abilityId": "Gul'dan|R1",
+        "abilityId": "Guldan|R1",
         "cooldown": 80,
         "manaCost": 90,
         "icon": "storm_ui_icon_guldan_horrify.png",
         "type": "heroic"
       },
       {
-        "uid": "ee5e369",
+        "uid": "cbd573",
         "name": "Rain of Destruction",
         "description": "After 1.5 seconds, summon a rain of meteors in an area for 7 seconds. Each meteor deals 165 (+4% per level) damage in a small area.",
         "hotkey": "R",
-        "abilityId": "Gul'dan|R2",
+        "abilityId": "Guldan|R2",
         "cooldown": 70,
         "manaCost": 80,
         "icon": "storm_ui_icon_guldan_rainoffire.png",
         "type": "heroic"
       },
       {
-        "uid": "947bc86",
+        "uid": "945e06",
         "name": "Life Tap",
         "description": "Gul'dan does not regenerate Mana.  Activate to restore 25% of Gul'dan's Mana.",
-        "hotkey": "D",
         "trait": true,
-        "abilityId": "Gul'dan|D1",
+        "abilityId": "Guldan|D1",
         "icon": "storm_ui_icon_guldan_lifetap.png",
         "type": "trait"
       }
@@ -96,9 +95,9 @@
         "type": "Q",
         "sort": 1,
         "isQuest": true,
-        "abilityId": "Gul'dan|Q1",
+        "abilityId": "Guldan|Q1",
         "abilityLinks": [
-          "Gul'dan|Q1"
+          "Guldan|Q1"
         ]
       },
       {
@@ -110,9 +109,9 @@
         "type": "W",
         "sort": 2,
         "isQuest": true,
-        "abilityId": "Gul'dan|W1",
+        "abilityId": "Guldan|W1",
         "abilityLinks": [
-          "Gul'dan|W1"
+          "Guldan|W1"
         ]
       },
       {
@@ -124,9 +123,9 @@
         "type": "E",
         "sort": 3,
         "isQuest": true,
-        "abilityId": "Gul'dan|E1",
+        "abilityId": "Guldan|E1",
         "abilityLinks": [
-          "Gul'dan|E1"
+          "Guldan|E1"
         ]
       }
     ],
@@ -139,9 +138,9 @@
         "icon": "storm_ui_icon_guldan_healthfunnel.png",
         "type": "W",
         "sort": 1,
-        "abilityId": "Gul'dan|W1",
+        "abilityId": "Guldan|W1",
         "abilityLinks": [
-          "Gul'dan|W1"
+          "Guldan|W1"
         ]
       },
       {
@@ -152,9 +151,10 @@
         "icon": "storm_ui_icon_guldan_lifetap.png",
         "type": "Trait",
         "sort": 2,
-        "abilityId": "Gul'dan|D1",
+        "abilityId": "Guldan|D2",
         "abilityLinks": [
-          "Gul'dan|D1"
+          "Guldan|D2",
+          "Guldan|D1"
         ]
       },
       {
@@ -166,7 +166,7 @@
         "type": "Active",
         "sort": 3,
         "cooldown": 30,
-        "abilityId": "Gul'dan|Active"
+        "abilityId": "Guldan|Active"
       }
     ],
     "7": [
@@ -178,9 +178,9 @@
         "icon": "storm_ui_icon_guldan_felflame.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "Gul'dan|Q1",
+        "abilityId": "Guldan|Q1",
         "abilityLinks": [
-          "Gul'dan|Q1"
+          "Guldan|Q1"
         ]
       },
       {
@@ -191,9 +191,9 @@
         "icon": "storm_ui_icon_guldan_healthfunnel.png",
         "type": "W",
         "sort": 2,
-        "abilityId": "Gul'dan|W1",
+        "abilityId": "Guldan|W1",
         "abilityLinks": [
-          "Gul'dan|W1"
+          "Guldan|W1"
         ]
       },
       {
@@ -204,9 +204,10 @@
         "icon": "storm_ui_icon_guldan_hungerforpower.png",
         "type": "Passive",
         "sort": 3,
-        "abilityId": "Gul'dan|Passive",
+        "abilityId": "Guldan|Passive",
         "abilityLinks": [
-          "Gul'dan|D1"
+          "Guldan|D2",
+          "Guldan|D1"
         ]
       }
     ],
@@ -220,9 +221,9 @@
         "type": "Heroic",
         "sort": 1,
         "cooldown": 80,
-        "abilityId": "Gul'dan|R1",
+        "abilityId": "Guldan|R1",
         "abilityLinks": [
-          "Gul'dan|R1"
+          "Guldan|R1"
         ]
       },
       {
@@ -234,9 +235,9 @@
         "type": "Heroic",
         "sort": 2,
         "cooldown": 70,
-        "abilityId": "Gul'dan|R2",
+        "abilityId": "Guldan|R2",
         "abilityLinks": [
-          "Gul'dan|R2"
+          "Guldan|R2"
         ]
       }
     ],
@@ -249,9 +250,9 @@
         "icon": "storm_ui_icon_guldan_felflame.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "Gul'dan|Q1",
+        "abilityId": "Guldan|Q1",
         "abilityLinks": [
-          "Gul'dan|Q1"
+          "Guldan|Q1"
         ]
       },
       {
@@ -262,9 +263,9 @@
         "icon": "storm_ui_icon_guldan_healthfunnel.png",
         "type": "W",
         "sort": 2,
-        "abilityId": "Gul'dan|W1",
+        "abilityId": "Guldan|W1",
         "abilityLinks": [
-          "Gul'dan|W1"
+          "Guldan|W1"
         ]
       },
       {
@@ -275,9 +276,10 @@
         "icon": "storm_ui_icon_guldan_darkbargain.png",
         "type": "Passive",
         "sort": 3,
-        "abilityId": "Gul'dan|Passive",
+        "abilityId": "Guldan|Passive",
         "abilityLinks": [
-          "Gul'dan|D1"
+          "Guldan|D2",
+          "Guldan|D1"
         ]
       },
       {
@@ -289,7 +291,7 @@
         "type": "Active",
         "sort": 4,
         "cooldown": 60,
-        "abilityId": "Gul'dan|Active"
+        "abilityId": "Guldan|Active"
       }
     ],
     "16": [
@@ -301,9 +303,9 @@
         "icon": "storm_ui_icon_guldan_felflame.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "Gul'dan|Q1",
+        "abilityId": "Guldan|Q1",
         "abilityLinks": [
-          "Gul'dan|Q1"
+          "Guldan|Q1"
         ]
       },
       {
@@ -314,9 +316,9 @@
         "icon": "storm_ui_icon_guldan_handofguldan.png",
         "type": "E",
         "sort": 2,
-        "abilityId": "Gul'dan|E1",
+        "abilityId": "Guldan|E1",
         "abilityLinks": [
-          "Gul'dan|E1"
+          "Guldan|E1"
         ]
       },
       {
@@ -327,9 +329,10 @@
         "icon": "storm_ui_icon_guldan_lifetap.png",
         "type": "Trait",
         "sort": 3,
-        "abilityId": "Gul'dan|D1",
+        "abilityId": "Guldan|D2",
         "abilityLinks": [
-          "Gul'dan|D1"
+          "Guldan|D2",
+          "Guldan|D1"
         ]
       }
     ],
@@ -342,9 +345,9 @@
         "icon": "storm_ui_icon_guldan_horrify.png",
         "type": "Heroic",
         "sort": 1,
-        "abilityId": "Gul'dan|R1",
+        "abilityId": "Guldan|R1",
         "abilityLinks": [
-          "Gul'dan|R1"
+          "Guldan|R1"
         ]
       },
       {
@@ -355,9 +358,9 @@
         "icon": "storm_ui_icon_guldan_rainoffire.png",
         "type": "Heroic",
         "sort": 2,
-        "abilityId": "Gul'dan|R2",
+        "abilityId": "Guldan|R2",
         "abilityLinks": [
-          "Gul'dan|R2"
+          "Guldan|R2"
         ]
       },
       {
@@ -369,7 +372,7 @@
         "type": "Active",
         "sort": 3,
         "cooldown": 60,
-        "abilityId": "Gul'dan|Active"
+        "abilityId": "Guldan|Active"
       }
     ]
   }

--- a/hero/guldan.json
+++ b/hero/guldan.json
@@ -151,9 +151,8 @@
         "icon": "storm_ui_icon_guldan_lifetap.png",
         "type": "Trait",
         "sort": 2,
-        "abilityId": "Guldan|D2",
+        "abilityId": "Guldan|D1",
         "abilityLinks": [
-          "Guldan|D2",
           "Guldan|D1"
         ]
       },
@@ -206,7 +205,6 @@
         "sort": 3,
         "abilityId": "Guldan|Passive",
         "abilityLinks": [
-          "Guldan|D2",
           "Guldan|D1"
         ]
       }
@@ -278,7 +276,6 @@
         "sort": 3,
         "abilityId": "Guldan|Passive",
         "abilityLinks": [
-          "Guldan|D2",
           "Guldan|D1"
         ]
       },
@@ -329,9 +326,8 @@
         "icon": "storm_ui_icon_guldan_lifetap.png",
         "type": "Trait",
         "sort": 3,
-        "abilityId": "Guldan|D2",
+        "abilityId": "Guldan|D1",
         "abilityLinks": [
-          "Guldan|D2",
           "Guldan|D1"
         ]
       }

--- a/hero/hanzo.json
+++ b/hero/hanzo.json
@@ -1,5 +1,5 @@
 {
-  "id": "75",
+  "id": 75,
   "shortName": "hanzo",
   "attributeId": "Hanz",
   "cHeroId": "Hanzo",
@@ -20,7 +20,7 @@
   "abilities": {
     "Hanzo": [
       {
-        "uid": "0fbc39f",
+        "uid": "8fb841",
         "name": "Storm Bow",
         "description": "Activate to charge an arrow that deals 291 (+4% per level) damage to the first enemy hit. Storm Bow's range increases the longer it is Channeled.",
         "hotkey": "Q",
@@ -31,7 +31,7 @@
         "type": "basic"
       },
       {
-        "uid": "3548759",
+        "uid": "f60295",
         "name": "Scatter Arrow",
         "description": "Fire an arrow that deals 88 (+4% per level) to the first enemy Hero hit. Scatter Arrow can collide with terrain and Structures, splitting into 5 arrows that travel extra distance, ricochet up to 4 additional times, and deal 88 (+4% per level) damage each to the first enemy hit.",
         "hotkey": "W",
@@ -42,7 +42,7 @@
         "type": "basic"
       },
       {
-        "uid": "1e95798",
+        "uid": "ec8325",
         "name": "Sonic Arrow",
         "description": "Fire an arrow that grants vision in a large area for 5 seconds. Enemies inside are revealed for 1 second. If Sonic Arrow lands directly on an enemy, it deals 165 (+4% per level) damage to them and follows them as they move.",
         "hotkey": "E",
@@ -53,7 +53,7 @@
         "type": "basic"
       },
       {
-        "uid": "667b317",
+        "uid": "4c8480",
         "name": "Dragonstrike",
         "description": "After 1.5 seconds, summon a pair of Spirit Dragons which travel forward, dealing 78 (+4% per level) damage every 0.25 seconds to enemy Heroes in its area.  Enemies in the center take 50% increased damage.",
         "hotkey": "R",
@@ -64,7 +64,7 @@
         "type": "heroic"
       },
       {
-        "uid": "d37df44",
+        "uid": "826707",
         "name": "Dragon's Arrow",
         "description": "Fire a missile that travels across the battleground. Explodes upon hitting an enemy Hero, dealing 130 (+4% per level) damage to all nearby enemies and Stunning them for 0.5 seconds.  After traveling a medium distance, the damage is increased to 260 (+4% per level) and the Stun duration to 1.25 seconds.  After traveling a long distance, the damage is increased to 390 (+4% per level) and the Stun duration to 2 seconds.",
         "hotkey": "R",
@@ -75,10 +75,9 @@
         "type": "heroic"
       },
       {
-        "uid": "87dc3d5",
+        "uid": "6a03c9",
         "name": "Natural Agility",
         "description": "Jump over unpathable terrain or Structures, up to a maximum range.",
-        "hotkey": "D",
         "trait": true,
         "abilityId": "Hanzo|D1",
         "cooldown": 30,

--- a/hero/illidan.json
+++ b/hero/illidan.json
@@ -1,5 +1,5 @@
 {
-  "id": "7",
+  "id": 7,
   "shortName": "illidan",
   "attributeId": "Illi",
   "cHeroId": "Illidan",
@@ -22,7 +22,7 @@
   "abilities": {
     "Illidan": [
       {
-        "uid": "e4d7a7d",
+        "uid": "b8575f",
         "name": "Dive",
         "description": "Dive at the target, dealing 66 (+4% per level) damage and flipping to the other side of the target.",
         "hotkey": "Q",
@@ -32,7 +32,7 @@
         "type": "basic"
       },
       {
-        "uid": "3efe928",
+        "uid": "4ec130",
         "name": "Sweeping Strike",
         "description": "Dash towards target point, dealing 119 (+4% per level) damage to enemies along the way. Hitting an enemy increases Illidan's Basic Attack damage by 35% for 3 seconds.",
         "hotkey": "W",
@@ -42,7 +42,7 @@
         "type": "basic"
       },
       {
-        "uid": "142d7a7",
+        "uid": "c4c90a",
         "name": "Evasion",
         "description": "Evade enemy Basic Attacks for 2.5 seconds.",
         "hotkey": "E",
@@ -52,7 +52,7 @@
         "type": "basic"
       },
       {
-        "uid": "735a3eb",
+        "uid": "d73afa",
         "name": "The Hunt",
         "description": "Charge to target unit, dealing 251 (+4% per level) damage on impact and stunning for 1 second.",
         "hotkey": "R",
@@ -62,7 +62,7 @@
         "type": "heroic"
       },
       {
-        "uid": "dbf3940",
+        "uid": "cd88ed",
         "name": "Metamorphosis",
         "description": "Transform into Demon Form at the target location, dealing 46 (+4% per level) damage in the area. Temporarily increases maximum Health by 220 (+4% per level) for each Hero hit by the initial impact. Lasts for 18 seconds.",
         "hotkey": "R",
@@ -72,7 +72,7 @@
         "type": "heroic"
       },
       {
-        "uid": "69ec116",
+        "uid": "a5b5be",
         "name": "Betrayer's Thirst",
         "description": "Basic Attacks heal for 30% of damage dealt and reduce Ability cooldowns by 1 second.",
         "trait": true,

--- a/hero/imperius.json
+++ b/hero/imperius.json
@@ -1,5 +1,5 @@
 {
-  "id": "85",
+  "id": 85,
   "shortName": "imperius",
   "attributeId": "IMPE",
   "cHeroId": "Imperius",
@@ -21,7 +21,7 @@
   "abilities": {
     "Imperius": [
       {
-        "uid": "fa58df2",
+        "uid": "ee8629",
         "name": "Celestial Charge",
         "description": "Lunge towards a targeted direction and stab, dealing 35 (+4% per level) damage. If an enemy Hero is hit, Channel to Stun for 1 second and deal 70 (+4% per level) additional damage when it fully finishes.",
         "hotkey": "Q",
@@ -32,7 +32,7 @@
         "type": "basic"
       },
       {
-        "uid": "caa3920",
+        "uid": "bbf815",
         "name": "Solarion's Fire",
         "description": "Release a fiery wave that deals 100 (+4% per level) damage. Enemies hit by the center take 50% bonus damage and are Slowed by 40% for 3 seconds.",
         "hotkey": "W",
@@ -43,7 +43,7 @@
         "type": "basic"
       },
       {
-        "uid": "fbe9031",
+        "uid": "125540",
         "name": "Molten Armor",
         "description": "Shroud Imperius in flames for 3 seconds, striking a nearby enemy for 19 (+4% per level) damage every 0.25 seconds. Imperius heals for 50% of the damage dealt, increased to 100% against Heroes.",
         "hotkey": "E",
@@ -54,7 +54,7 @@
         "type": "basic"
       },
       {
-        "uid": "d880ca7",
+        "uid": "527325",
         "name": "Angelic Armaments",
         "description": "Summon a ring of blazing swords that grants 1000 (+4% per level) Shield for 3 seconds.  If the Shield lasts the full duration, this ability can be reactivated within 5 seconds to launch 6 swords toward an area, each dealing 140 (+4% per level) damage to the first enemy hit.",
         "hotkey": "R",
@@ -65,7 +65,7 @@
         "type": "heroic"
       },
       {
-        "uid": "1ad7970",
+        "uid": "1014e2",
         "name": "Wrath of the Angiris",
         "description": "After 0.75 seconds, charge in the target direction, lifting the first enemy Hero hit into the Heavens. While in the air, Imperius can steer the landing location by moving.  After 2 seconds, slam the target into the ground, dealing 375 (+4% per level) damage and Stunning them for 1 second.",
         "hotkey": "R",
@@ -76,7 +76,7 @@
         "type": "heroic"
       },
       {
-        "uid": "bd732d6",
+        "uid": "3a747a",
         "name": "Valorous Brand",
         "description": "Each Basic Ability marks enemy Heroes hit for 10 seconds. Basic Attacks consume the target's marks, dealing 20% bonus damage per mark and healing for 75 (+4% per level) per mark.",
         "trait": true,
@@ -96,7 +96,6 @@
         "icon": "storm_ui_icon_imperius_q.png",
         "type": "Q",
         "sort": 1,
-        "isQuest": true,
         "abilityId": "Imperius|Q1",
         "abilityLinks": [
           "Imperius|Q1"
@@ -110,7 +109,6 @@
         "icon": "storm_ui_icon_imperius_w.png",
         "type": "W",
         "sort": 2,
-        "isQuest": true,
         "abilityId": "Imperius|W1",
         "abilityLinks": [
           "Imperius|W1"

--- a/hero/jaina.json
+++ b/hero/jaina.json
@@ -94,15 +94,6 @@
         "cooldown": 40,
         "icon": "storm_ui_icon_jaina_improvediceblock_new_active.png",
         "type": "activable"
-      },
-      {
-        "uid": "b4dc9c",
-        "name": "Command Water Elemental",
-        "description": "Wills the Water Elemental to attack an enemy or move to an area.",
-        "hotkey": "R",
-        "abilityId": "Jaina|R3",
-        "icon": "storm_ui_icon_jaina_commandwaterelemental.png",
-        "type": "heroic"
       }
     ]
   },

--- a/hero/jaina.json
+++ b/hero/jaina.json
@@ -1,5 +1,5 @@
 {
-  "id": "32",
+  "id": 32,
   "shortName": "jaina",
   "attributeId": "Jain",
   "cHeroId": "Jaina",
@@ -20,7 +20,7 @@
   "abilities": {
     "Jaina": [
       {
-        "uid": "0c6f9e6",
+        "uid": "a6068f",
         "name": "Frostbolt",
         "description": "Deal 184 (+4% per level) damage and Chill the target.",
         "hotkey": "Q",
@@ -31,7 +31,7 @@
         "type": "basic"
       },
       {
-        "uid": "2eb6b76",
+        "uid": "78aa84",
         "name": "Blizzard",
         "description": "Bombard an area with 3 waves of ice, dealing 142 (+4% per level) damage each. Damaged enemies are Chilled.",
         "hotkey": "W",
@@ -42,7 +42,7 @@
         "type": "basic"
       },
       {
-        "uid": "24404be",
+        "uid": "0aaf29",
         "name": "Cone of Cold",
         "description": "Deal 220 (+4% per level) damage and Chill targets.",
         "hotkey": "E",
@@ -53,7 +53,7 @@
         "type": "basic"
       },
       {
-        "uid": "c1309e2",
+        "uid": "7b4a49",
         "name": "Summon Water Elemental",
         "description": "Summon a Water Elemental at target location. The Water Elemental's Basic Attacks deal 62 (+4% per level) damage, splash for 25% damage and Chill. The Ability can be reactivated to retarget the Water Elemental.  Lasts 20 seconds.",
         "hotkey": "R",
@@ -64,7 +64,7 @@
         "type": "heroic"
       },
       {
-        "uid": "36b5187",
+        "uid": "81a200",
         "name": "Ring of Frost",
         "description": "After a 1.5 second delay, create a Ring of Frost in an area that deals 310 (+4% per level) damage and Roots enemies for 3 seconds. The ring persists for 3 seconds afterward, Chilling any enemies who touch it.",
         "hotkey": "R",
@@ -75,23 +75,34 @@
         "type": "heroic"
       },
       {
-        "uid": "25fea55",
+        "uid": "c1474e",
         "name": "Frostbite",
         "description": "Jaina's Abilities Chill targets, Slowing them by 25% and amplifying damage taken from her Abilities by 50%. Lasts 4 seconds.  Quest: Deal 15,000 Ability damage to Chilled Heroes.  Reward: Unlock the Improved Ice Block Ability, allowing Jaina to become temporarily Invulnerable.",
         "trait": true,
         "abilityId": "Jaina|D1",
         "icon": "storm_ui_icon_jaina_frostbite.png",
         "type": "trait"
-      },
+      }
+    ],
+    "JainaTraitFrostbite": [
       {
-        "uid": "346dd30",
+        "uid": "fbd5a2",
         "name": "Improved Ice Block",
         "description": "Activate to place Jaina in Stasis and gain Invulnerability for 2.5 seconds. When this effect expires, nearby enemies are Chilled.",
-        "hotkey": "1",
+        "hotkey": 1,
         "abilityId": "Jaina|11",
         "cooldown": 40,
         "icon": "storm_ui_icon_jaina_improvediceblock_new_active.png",
         "type": "activable"
+      },
+      {
+        "uid": "b4dc9c",
+        "name": "Command Water Elemental",
+        "description": "Wills the Water Elemental to attack an enemy or move to an area.",
+        "hotkey": "R",
+        "abilityId": "Jaina|R3",
+        "icon": "storm_ui_icon_jaina_commandwaterelemental.png",
+        "type": "heroic"
       }
     ]
   },

--- a/hero/johanna.json
+++ b/hero/johanna.json
@@ -1,5 +1,5 @@
 {
-  "id": "37",
+  "id": 37,
   "shortName": "johanna",
   "attributeId": "Crus",
   "cHeroId": "Crusader",
@@ -20,7 +20,7 @@
   "abilities": {
     "Johanna": [
       {
-        "uid": "6a776cd",
+        "uid": "fa7805",
         "name": "Punish",
         "description": "Step forward dealing 113 (+4% per level) damage and Slowing enemies by 60% decaying over 2 seconds.",
         "hotkey": "Q",
@@ -31,7 +31,7 @@
         "type": "basic"
       },
       {
-        "uid": "2df3893",
+        "uid": "cf15e0",
         "name": "Condemn",
         "description": "After 1 second, Johanna pulls nearby enemies toward her, stunning them for 0.25 seconds and dealing 58 (+4% per level) damage. Deals 200% increased damage to Minions and Mercenaries.",
         "hotkey": "W",
@@ -42,7 +42,7 @@
         "type": "basic"
       },
       {
-        "uid": "a18dc5a",
+        "uid": "df98e2",
         "name": "Shield Glare",
         "description": "Deal 59 (+4% per level) damage to enemies and Blind them for 1.5 seconds.",
         "hotkey": "E",
@@ -53,7 +53,7 @@
         "type": "basic"
       },
       {
-        "uid": "2b16e94",
+        "uid": "a8f0a2",
         "name": "Falling Sword",
         "description": "Johanna leaps towards an area.  While in the air, she can steer the landing location by moving.  After 2 seconds Johanna lands, dealing 210 (+4% per level) damage to nearby enemies, Stunning them for 0.2 seconds, and Slowing them by 50% for 3 seconds.",
         "hotkey": "R",
@@ -64,7 +64,7 @@
         "type": "heroic"
       },
       {
-        "uid": "53cf2ec",
+        "uid": "953b44",
         "name": "Blessed Shield",
         "description": "Deal 114 (+4% per level) damage and Stun the first enemy hit for 1.5 seconds. Blessed Shield then bounces to 2 nearby enemies, dealing 57 (+4% per level) damage and Stunning them for 0.75 seconds.",
         "hotkey": "R",
@@ -75,10 +75,9 @@
         "type": "heroic"
       },
       {
-        "uid": "31937f2",
+        "uid": "98a8c3",
         "name": "Iron Skin",
         "description": "Activate to grant Johanna a Shield that absorbs 674 (+4% per level) damage for 4 seconds. While this Shield is active, Johanna is Unstoppable.",
-        "hotkey": "D",
         "trait": true,
         "abilityId": "Johanna|D1",
         "cooldown": 20,
@@ -347,7 +346,6 @@
         "icon": "storm_ui_icon_johanna_indestructible.png",
         "type": "Passive",
         "sort": 3,
-        "cooldown": 120,
         "abilityId": "Johanna|Passive"
       },
       {

--- a/hero/junkrat.json
+++ b/hero/junkrat.json
@@ -1,5 +1,5 @@
 {
-  "id": "73",
+  "id": 73,
   "shortName": "junkrat",
   "attributeId": "Junk",
   "cHeroId": "Junkrat",
@@ -19,7 +19,7 @@
   "abilities": {
     "Junkrat": [
       {
-        "uid": "9f5e4c7",
+        "uid": "52b38e",
         "name": "Frag Launcher",
         "description": "Launch a grenade that explodes at the end of its path or upon hitting an enemy, dealing 118 (+4% per level) damage to nearby enemies. Grenades can ricochet off of terrain. Deals 50% less damage to Structures.  Stores up to 4 charges. Frag Launcher's cooldown replenishes all charges at the same time.",
         "hotkey": "Q",
@@ -29,7 +29,7 @@
         "type": "basic"
       },
       {
-        "uid": "c8a0317",
+        "uid": "2d29c5",
         "name": "Concussion Mine",
         "description": "Place a mine on the ground. Junkrat's Trait can be activated to detonate the mine, dealing 180 (+4% per level) damage to nearby enemies and knocking them back. Junkrat can also be affected by Concussion Mine, but takes no damage.  Limit 1 active mine.",
         "hotkey": "W",
@@ -39,7 +39,7 @@
         "type": "basic"
       },
       {
-        "uid": "af4c53c",
+        "uid": "9403d8",
         "name": "Steel Trap",
         "description": "Place a trap on the ground that arms after 2 seconds. Deals 130 (+4% per level) damage to the first enemy that walks over it and Roots them for 2 seconds.  Limit 1 active trap.",
         "hotkey": "E",
@@ -49,7 +49,7 @@
         "type": "basic"
       },
       {
-        "uid": "844ea2c",
+        "uid": "340033",
         "name": "RIP-Tire",
         "description": "Create a motorized bomb with 530 (+4% per level) Health that lasts 15 seconds. While active, Junkrat is immobile but gains control of RIP-Tire's movement.  RIP-Tire can be reactivated to detonate immediately, knocking nearby enemies back and dealing 775 (+4% per level) damage to enemies near the center gradually reduced to 475 (+4% per level) to enemies on the edge.",
         "hotkey": "R",
@@ -59,9 +59,9 @@
         "type": "heroic"
       },
       {
-        "uid": "82ec8fc",
+        "uid": "6dc8b5",
         "name": "Rocket Ride",
-        "description": "After 1.25 seconds, Junkrat launches into the air. While in the air, he can steer the landing location by moving.  After 3.75 seconds, Junkrat lands, dealing 815 (+4% per level) damage to nearby enemies and activating Total Mayhem. 5 seconds after landing, Junkrat reappears at the Hall of Storms and gains 150% additional Movement Speed until dismounted.",
+        "description": "After 1.25 seconds, Junkrat launches into the air. While in the air, he can steer the landing location by moving.  After 3.75 seconds, Junkrat lands, dealing 890 (+4% per level) damage to nearby enemies and activating Total Mayhem. 5 seconds after landing, Junkrat reappears at the Hall of Storms and gains 150% additional Movement Speed until dismounted.",
         "hotkey": "R",
         "abilityId": "Junkrat|R2",
         "cooldown": 75,
@@ -69,7 +69,7 @@
         "type": "heroic"
       },
       {
-        "uid": "9ffd8c2",
+        "uid": "e8888f",
         "name": "Total Mayhem",
         "description": "Upon dying, drop 5 grenades that explode after 0.75 seconds, each dealing 250 (+4% per level) damage to nearby enemies. Deals 75% less damage to Structures.  Detonate Mine  Detonate an active Concussion Mine.",
         "trait": true,
@@ -141,13 +141,14 @@
         "tooltipId": "JunkratBOOMPOWConcussionMineTalent",
         "talentTreeId": "JunkratConcussionMineBOOMPOW",
         "name": "BOOM POW",
-        "description": "Hitting an enemy Hero with Concussion Mine reduces its cooldown by 8 seconds.",
+        "description": "Hitting an enemy Hero with Concussion Mine reduces its cooldown by 9 seconds.",
         "icon": "storm_ui_icon_junkrat_concussion_mine.png",
         "type": "W",
         "sort": 2,
         "abilityId": "Junkrat|W1",
         "abilityLinks": [
-          "Junkrat|W1"
+          "Junkrat|W1",
+          "Junkrat|D2"
         ]
       },
       {
@@ -175,14 +176,15 @@
         "sort": 1,
         "abilityId": "Junkrat|W1",
         "abilityLinks": [
-          "Junkrat|W1"
+          "Junkrat|W1",
+          "Junkrat|D2"
         ]
       },
       {
         "tooltipId": "JunkratBigAsSteelTrapTalent",
         "talentTreeId": "JunkratSteelTrapBigAs",
         "name": "Big As",
-        "description": "Increase Steel Trap's radius and damage by 50% and enemy Heroes who are hit have their Armor reduced by 10 for 3 seconds.",
+        "description": "Increase Steel Trap's radius and damage by 50% and enemy Heroes who are hit have their Armor reduced by 15 for 3 seconds.",
         "icon": "storm_ui_icon_junkrat_steel_trap.png",
         "type": "E",
         "sort": 2,
@@ -237,7 +239,7 @@
         "tooltipId": "JunkratRocketRide",
         "talentTreeId": "JunkratRocketRide",
         "name": "Rocket Ride",
-        "description": "After 1.25 seconds, Junkrat launches into the air. While in the air, he can steer the landing location by moving.  After 3.75 seconds, Junkrat lands, dealing 815 (+4% per level) damage to nearby enemies and activating Total Mayhem. 5 seconds after landing, Junkrat reappears at the Hall of Storms and gains 150% additional Movement Speed until dismounted.",
+        "description": "After 1.25 seconds, Junkrat launches into the air. While in the air, he can steer the landing location by moving.  After 3.75 seconds, Junkrat lands, dealing 890 (+4% per level) damage to nearby enemies and activating Total Mayhem. 5 seconds after landing, Junkrat reappears at the Hall of Storms and gains 150% additional Movement Speed until dismounted.",
         "icon": "storm_ui_icon_junkrat_rocket_ride.png",
         "type": "Heroic",
         "sort": 2,
@@ -272,7 +274,8 @@
         "sort": 2,
         "abilityId": "Junkrat|W1",
         "abilityLinks": [
-          "Junkrat|W1"
+          "Junkrat|W1",
+          "Junkrat|D2"
         ]
       },
       {
@@ -283,7 +286,6 @@
         "icon": "storm_ui_icon_junkrat_steel_trap.png",
         "type": "E",
         "sort": 3,
-        "isQuest": true,
         "abilityId": "Junkrat|E1",
         "abilityLinks": [
           "Junkrat|E1"

--- a/hero/junkrat.json
+++ b/hero/junkrat.json
@@ -147,8 +147,7 @@
         "sort": 2,
         "abilityId": "Junkrat|W1",
         "abilityLinks": [
-          "Junkrat|W1",
-          "Junkrat|D2"
+          "Junkrat|W1"
         ]
       },
       {
@@ -176,8 +175,7 @@
         "sort": 1,
         "abilityId": "Junkrat|W1",
         "abilityLinks": [
-          "Junkrat|W1",
-          "Junkrat|D2"
+          "Junkrat|W1"
         ]
       },
       {
@@ -274,8 +272,7 @@
         "sort": 2,
         "abilityId": "Junkrat|W1",
         "abilityLinks": [
-          "Junkrat|W1",
-          "Junkrat|D2"
+          "Junkrat|W1"
         ]
       },
       {

--- a/hero/kaelthas.json
+++ b/hero/kaelthas.json
@@ -111,9 +111,8 @@
         "icon": "storm_ui_icon_kaelthas_verdantspheres.png",
         "type": "Trait",
         "sort": 2,
-        "abilityId": "Kaelthas|D2",
+        "abilityId": "Kaelthas|D1",
         "abilityLinks": [
-          "Kaelthas|D2",
           "Kaelthas|D1"
         ]
       },
@@ -164,9 +163,8 @@
         "icon": "storm_ui_icon_kaelthas_verdantspheres.png",
         "type": "Trait",
         "sort": 3,
-        "abilityId": "Kaelthas|D2",
+        "abilityId": "Kaelthas|D1",
         "abilityLinks": [
-          "Kaelthas|D2",
           "Kaelthas|D1"
         ]
       }
@@ -206,9 +204,8 @@
         "icon": "storm_ui_icon_kaelthas_verdantspheres.png",
         "type": "Trait",
         "sort": 3,
-        "abilityId": "Kaelthas|D2",
+        "abilityId": "Kaelthas|D1",
         "abilityLinks": [
-          "Kaelthas|D2",
           "Kaelthas|D1"
         ]
       }
@@ -319,9 +316,8 @@
         "icon": "storm_ui_icon_kaelthas_verdantspheres.png",
         "type": "Trait",
         "sort": 3,
-        "abilityId": "Kaelthas|D2",
+        "abilityId": "Kaelthas|D1",
         "abilityLinks": [
-          "Kaelthas|D2",
           "Kaelthas|D1"
         ]
       }

--- a/hero/kaelthas.json
+++ b/hero/kaelthas.json
@@ -1,5 +1,5 @@
 {
-  "id": "36",
+  "id": 36,
   "shortName": "kaelthas",
   "attributeId": "Kael",
   "cHeroId": "Kaelthas",
@@ -19,70 +19,69 @@
     "WaveClearer"
   ],
   "abilities": {
-    "Kael'thas": [
+    "Kaelthas": [
       {
-        "uid": "a0a66cb",
+        "uid": "2beb76",
         "name": "Flamestrike",
         "description": "After 1 second, deal 345 (+4% per level) damage in an area.  Verdant Spheres increases the radius by 50%.",
         "hotkey": "Q",
-        "abilityId": "Kael'thas|Q1",
+        "abilityId": "Kaelthas|Q1",
         "cooldown": 7,
         "manaCost": 70,
         "icon": "storm_ui_icon_kaelthas_flamestrike.png",
         "type": "basic"
       },
       {
-        "uid": "55fda32",
+        "uid": "2d2805",
         "name": "Living Bomb",
         "description": "Deal 126 (+4% per level) damage over 3 seconds to an enemy, then they explode dealing 215 (+4% per level) damage to all nearby enemies.  Other Heroes damaged by this explosion are also affected by Living Bomb, though the secondary explosions cannot spread.  Verdant Spheres makes this Ability cost no Mana and have no cooldown.",
         "hotkey": "W",
-        "abilityId": "Kael'thas|W1",
+        "abilityId": "Kaelthas|W1",
         "cooldown": 10,
         "manaCost": 50,
         "icon": "storm_ui_icon_kaelthas_livingbomb.png",
         "type": "basic"
       },
       {
-        "uid": "2e60a7b",
+        "uid": "6094d7",
         "name": "Gravity Lapse",
         "description": "Stun the first enemy hit for 1 second.  Verdant Spheres causes Gravity Lapse to stun the first 3 enemies hit and increases the stun duration by 50%.",
         "hotkey": "E",
-        "abilityId": "Kael'thas|E1",
+        "abilityId": "Kaelthas|E1",
         "cooldown": 14,
         "manaCost": 90,
         "icon": "storm_ui_icon_kaelthas_gravitylapse.png",
         "type": "basic"
       },
       {
-        "uid": "1ce0f7f",
+        "uid": "6d1e06",
         "name": "Pyroblast",
         "description": "After 1.5 seconds, cast a slow-moving fireball that deals 810 (+5% per level) damage to an enemy Hero and 405 (+5% per level) damage to enemies nearby.",
         "hotkey": "R",
-        "abilityId": "Kael'thas|R1",
+        "abilityId": "Kaelthas|R1",
         "cooldown": 100,
         "manaCost": 80,
         "icon": "storm_ui_icon_kaelthas_pyroblast.png",
         "type": "heroic"
       },
       {
-        "uid": "258a1b9",
+        "uid": "8448f2",
         "name": "Phoenix",
         "description": "Launch a Phoenix to an area, dealing 78 (+4% per level) damage to enemies along the way. The Phoenix persists for 7 seconds, attacking enemies for 78 (+4% per level) damage and splashing for 39 (+4% per level) damage.",
         "hotkey": "R",
-        "abilityId": "Kael'thas|R2",
+        "abilityId": "Kaelthas|R2",
         "cooldown": 60,
         "manaCost": 80,
         "icon": "storm_ui_icon_kaelthas_phoenix.png",
         "type": "heroic"
       },
       {
-        "uid": "1d363c1",
+        "uid": "b75df9",
         "name": "Verdant Spheres",
         "description": "Activate to make Kael'thas's next Basic Ability more powerful.",
-        "hotkey": "D",
         "trait": true,
-        "abilityId": "Kael'thas|D1",
-        "cooldown": 6,
+        "abilityId": "Kaelthas|D1",
+        "cooldown": 46,
         "icon": "storm_ui_icon_kaelthas_verdantspheres.png",
         "type": "trait"
       }
@@ -99,9 +98,9 @@
         "type": "Q",
         "sort": 1,
         "isQuest": true,
-        "abilityId": "Kael'thas|Q1",
+        "abilityId": "Kaelthas|Q1",
         "abilityLinks": [
-          "Kael'thas|Q1"
+          "Kaelthas|Q1"
         ]
       },
       {
@@ -112,9 +111,10 @@
         "icon": "storm_ui_icon_kaelthas_verdantspheres.png",
         "type": "Trait",
         "sort": 2,
-        "abilityId": "Kael'thas|D1",
+        "abilityId": "Kaelthas|D2",
         "abilityLinks": [
-          "Kael'thas|D1"
+          "Kaelthas|D2",
+          "Kaelthas|D1"
         ]
       },
       {
@@ -126,7 +126,7 @@
         "type": "Passive",
         "sort": 3,
         "isQuest": true,
-        "abilityId": "Kael'thas|Passive"
+        "abilityId": "Kaelthas|Passive"
       }
     ],
     "4": [
@@ -138,9 +138,9 @@
         "icon": "storm_ui_icon_kaelthas_gravitylapse.png",
         "type": "E",
         "sort": 1,
-        "abilityId": "Kael'thas|E1",
+        "abilityId": "Kaelthas|E1",
         "abilityLinks": [
-          "Kael'thas|E1"
+          "Kaelthas|E1"
         ]
       },
       {
@@ -151,9 +151,9 @@
         "icon": "storm_ui_icon_kaelthas_gravitylapse_a.png",
         "type": "E",
         "sort": 2,
-        "abilityId": "Kael'thas|E1",
+        "abilityId": "Kaelthas|E1",
         "abilityLinks": [
-          "Kael'thas|E1"
+          "Kaelthas|E1"
         ]
       },
       {
@@ -164,9 +164,10 @@
         "icon": "storm_ui_icon_kaelthas_verdantspheres.png",
         "type": "Trait",
         "sort": 3,
-        "abilityId": "Kael'thas|D1",
+        "abilityId": "Kaelthas|D2",
         "abilityLinks": [
-          "Kael'thas|D1"
+          "Kaelthas|D2",
+          "Kaelthas|D1"
         ]
       }
     ],
@@ -179,9 +180,9 @@
         "icon": "storm_ui_icon_kaelthas_flamestrike.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "Kael'thas|Q1",
+        "abilityId": "Kaelthas|Q1",
         "abilityLinks": [
-          "Kael'thas|Q1"
+          "Kaelthas|Q1"
         ]
       },
       {
@@ -192,9 +193,9 @@
         "icon": "storm_ui_icon_kaelthas_livingbomb.png",
         "type": "W",
         "sort": 2,
-        "abilityId": "Kael'thas|W1",
+        "abilityId": "Kaelthas|W1",
         "abilityLinks": [
-          "Kael'thas|W1"
+          "Kaelthas|W1"
         ]
       },
       {
@@ -205,9 +206,10 @@
         "icon": "storm_ui_icon_kaelthas_verdantspheres.png",
         "type": "Trait",
         "sort": 3,
-        "abilityId": "Kael'thas|D1",
+        "abilityId": "Kaelthas|D2",
         "abilityLinks": [
-          "Kael'thas|D1"
+          "Kaelthas|D2",
+          "Kaelthas|D1"
         ]
       }
     ],
@@ -221,9 +223,9 @@
         "type": "Heroic",
         "sort": 1,
         "cooldown": 60,
-        "abilityId": "Kael'thas|R2",
+        "abilityId": "Kaelthas|R2",
         "abilityLinks": [
-          "Kael'thas|R2"
+          "Kaelthas|R2"
         ]
       },
       {
@@ -235,9 +237,9 @@
         "type": "Heroic",
         "sort": 2,
         "cooldown": 100,
-        "abilityId": "Kael'thas|R1",
+        "abilityId": "Kaelthas|R1",
         "abilityLinks": [
-          "Kael'thas|R1"
+          "Kaelthas|R1"
         ]
       }
     ],
@@ -250,9 +252,9 @@
         "icon": "storm_ui_icon_kaelthas_livingbomb.png",
         "type": "W",
         "sort": 1,
-        "abilityId": "Kael'thas|W1",
+        "abilityId": "Kaelthas|W1",
         "abilityLinks": [
-          "Kael'thas|W1"
+          "Kaelthas|W1"
         ]
       },
       {
@@ -263,9 +265,9 @@
         "icon": "storm_ui_icon_kaelthas_livingbomb_var1.png",
         "type": "W",
         "sort": 2,
-        "abilityId": "Kael'thas|W1",
+        "abilityId": "Kaelthas|W1",
         "abilityLinks": [
-          "Kael'thas|W1"
+          "Kaelthas|W1"
         ]
       },
       {
@@ -276,9 +278,9 @@
         "icon": "storm_ui_icon_kaelthas_livingbomb_b.png",
         "type": "W",
         "sort": 3,
-        "abilityId": "Kael'thas|W1",
+        "abilityId": "Kaelthas|W1",
         "abilityLinks": [
-          "Kael'thas|W1"
+          "Kaelthas|W1"
         ]
       }
     ],
@@ -291,9 +293,9 @@
         "icon": "storm_ui_icon_kaelthas_flamestrike.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "Kael'thas|Q1",
+        "abilityId": "Kaelthas|Q1",
         "abilityLinks": [
-          "Kael'thas|Q1"
+          "Kaelthas|Q1"
         ]
       },
       {
@@ -304,9 +306,9 @@
         "icon": "storm_ui_icon_kaelthas_livingbomb.png",
         "type": "W",
         "sort": 2,
-        "abilityId": "Kael'thas|W1",
+        "abilityId": "Kaelthas|W1",
         "abilityLinks": [
-          "Kael'thas|W1"
+          "Kaelthas|W1"
         ]
       },
       {
@@ -317,9 +319,10 @@
         "icon": "storm_ui_icon_kaelthas_verdantspheres.png",
         "type": "Trait",
         "sort": 3,
-        "abilityId": "Kael'thas|D1",
+        "abilityId": "Kaelthas|D2",
         "abilityLinks": [
-          "Kael'thas|D1"
+          "Kaelthas|D2",
+          "Kaelthas|D1"
         ]
       }
     ],
@@ -332,9 +335,9 @@
         "icon": "storm_ui_icon_kaelthas_phoenix.png",
         "type": "Heroic",
         "sort": 1,
-        "abilityId": "Kael'thas|R2",
+        "abilityId": "Kaelthas|R2",
         "abilityLinks": [
-          "Kael'thas|R2"
+          "Kaelthas|R2"
         ]
       },
       {
@@ -345,9 +348,9 @@
         "icon": "storm_ui_icon_kaelthas_pyroblast.png",
         "type": "Heroic",
         "sort": 2,
-        "abilityId": "Kael'thas|R1",
+        "abilityId": "Kaelthas|R1",
         "abilityLinks": [
-          "Kael'thas|R1"
+          "Kaelthas|R1"
         ]
       },
       {
@@ -358,9 +361,9 @@
         "icon": "storm_ui_icon_kaelthas_livingbomb.png",
         "type": "W",
         "sort": 3,
-        "abilityId": "Kael'thas|W1",
+        "abilityId": "Kaelthas|W1",
         "abilityLinks": [
-          "Kael'thas|W1"
+          "Kaelthas|W1"
         ]
       },
       {
@@ -371,9 +374,9 @@
         "icon": "storm_ui_icon_kaelthas_flamestrike.png",
         "type": "Q",
         "sort": 4,
-        "abilityId": "Kael'thas|Q1",
+        "abilityId": "Kaelthas|Q1",
         "abilityLinks": [
-          "Kael'thas|Q1"
+          "Kaelthas|Q1"
         ]
       }
     ]

--- a/hero/kelthuzad.json
+++ b/hero/kelthuzad.json
@@ -94,15 +94,6 @@
         "cooldown": 30,
         "icon": "storm_ui_icon_kelthuzad_glacialspike.png",
         "type": "activable"
-      },
-      {
-        "uid": "473ccb",
-        "name": "Chains of Kel'Thuzad",
-        "description": "Launch a new chain from the currently chained enemy. Deals 97 (+2.5% per level) damage upon impacting a Hero and pulls both enemies together.",
-        "hotkey": "E",
-        "abilityId": "KelThuzad|E2",
-        "icon": "storm_ui_icon_kelthuzad_chains.png",
-        "type": "basic"
       }
     ]
   },

--- a/hero/kelthuzad.json
+++ b/hero/kelthuzad.json
@@ -1,5 +1,5 @@
 {
-  "id": "71",
+  "id": 71,
   "shortName": "kelthuzad",
   "attributeId": "KelT",
   "cHeroId": "KelThuzad",
@@ -18,80 +18,91 @@
     "RoleCaster"
   ],
   "abilities": {
-    "Kel'Thuzad": [
+    "KelThuzad": [
       {
-        "uid": "27ad874",
+        "uid": "1d4a1d",
         "name": "Death and Decay",
         "description": "After 0.5 seconds, launch an orb that explodes upon hitting an enemy, dealing 150 (+2.5% per level) damage to enemies in the area. The explosion leaves behind a pool of decay that lasts 2 seconds, dealing 82 (+2.5% per level) damage every 0.5 seconds to enemies.",
         "hotkey": "Q",
-        "abilityId": "Kel'Thuzad|Q1",
+        "abilityId": "KelThuzad|Q1",
         "cooldown": 5,
         "manaCost": 20,
         "icon": "storm_ui_icon_kelthuzad_deathanddecay.png",
         "type": "basic"
       },
       {
-        "uid": "e4774fe",
+        "uid": "039114",
         "name": "Frost Nova",
         "description": "Create a nova that explodes after 1 second, dealing 180 (+2.5% per level) damage to enemies inside and Slowing them by 35% for 2.5 seconds. Enemies in the center are Rooted for 1 second.",
         "hotkey": "W",
-        "abilityId": "Kel'Thuzad|W1",
+        "abilityId": "KelThuzad|W1",
         "cooldown": 8,
         "manaCost": 50,
         "icon": "storm_ui_icon_kelthuzad_frostnova.png",
         "type": "basic"
       },
       {
-        "uid": "08bd2e9",
+        "uid": "1927f2",
         "name": "Chains of Kel'Thuzad",
         "description": "Launch a chain, dealing 97 (+2.5% per level) damage to the first enemy Hero hit. For 3 seconds after hitting an enemy, Chains can be reactivated to launch to an additional enemy, pulling both enemies together and Stunning them for 0.5 seconds.",
         "hotkey": "E",
-        "abilityId": "Kel'Thuzad|E1",
+        "abilityId": "KelThuzad|E1",
         "cooldown": 10,
         "manaCost": 50,
         "icon": "storm_ui_icon_kelthuzad_chains.png",
         "type": "basic"
       },
       {
-        "uid": "423a912",
+        "uid": "2db793",
         "name": "Frost Blast",
         "description": "Launch a meteor of ice at an enemy Hero. Upon impact, the meteor deals 115 (+2.5% per level) damage to its target and 275 (+2.5% per level) damage to enemies in the area. All enemies hit by Frost Blast are Rooted for 2 seconds.",
         "hotkey": "R",
-        "abilityId": "Kel'Thuzad|R1",
+        "abilityId": "KelThuzad|R1",
         "cooldown": 50,
         "manaCost": 45,
         "icon": "storm_ui_icon_kelthuzad_frozentomb.png",
         "type": "heroic"
       },
       {
-        "uid": "7848710",
+        "uid": "da5e68",
         "name": "Shadow Fissure",
         "description": "Create a fissure anywhere on the Battleground that explodes after 1.5 seconds, dealing 320 (+2.5% per level) damage to enemy Heroes in its area. If an enemy Hero is hit, set its cooldown to 1.5 seconds.",
         "hotkey": "R",
-        "abilityId": "Kel'Thuzad|R2",
+        "abilityId": "KelThuzad|R2",
         "cooldown": 16,
         "manaCost": 40,
         "icon": "storm_ui_icon_kelthuzad_shadowfissure.png",
         "type": "heroic"
       },
       {
-        "uid": "1b72614",
+        "uid": "510a70",
         "name": "Master of the Cold Dark",
         "description": "Quest: Gain 1 Blight every time a Hero is Rooted by Frost Nova or hit by Chains of Kel'Thuzad.  Reward: After gaining 15 Blight, gain the Glacial Spike Ability.  Reward: After gaining 30 Blight, gain 75% Spell Power.  Blight: 0/30",
         "trait": true,
-        "abilityId": "Kel'Thuzad|D1",
+        "abilityId": "KelThuzad|D1",
         "icon": "storm_ui_icon_kelthuzad_powerofthecolddark.png",
         "type": "trait"
-      },
+      }
+    ],
+    "KelThuzadMasterOfTheColdDark": [
       {
-        "uid": "5725ae6",
+        "uid": "870ba5",
         "name": "Glacial Spike",
         "description": "Activate to create a spike that detonates after 4 seconds, dealing 60 (+2.5% per level) damage to nearby enemies. The spike can be affected by Chains of Kel'Thuzad.",
-        "hotkey": "1",
-        "abilityId": "Kel'Thuzad|11",
+        "hotkey": 1,
+        "abilityId": "KelThuzad|11",
         "cooldown": 30,
         "icon": "storm_ui_icon_kelthuzad_glacialspike.png",
         "type": "activable"
+      },
+      {
+        "uid": "473ccb",
+        "name": "Chains of Kel'Thuzad",
+        "description": "Launch a new chain from the currently chained enemy. Deals 97 (+2.5% per level) damage upon impacting a Hero and pulls both enemies together.",
+        "hotkey": "E",
+        "abilityId": "KelThuzad|E2",
+        "icon": "storm_ui_icon_kelthuzad_chains.png",
+        "type": "basic"
       }
     ]
   },
@@ -105,9 +116,9 @@
         "icon": "storm_ui_icon_kelthuzad_deathanddecay.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "Kel'Thuzad|Q1",
+        "abilityId": "KelThuzad|Q1",
         "abilityLinks": [
-          "Kel'Thuzad|Q1"
+          "KelThuzad|Q1"
         ]
       },
       {
@@ -118,9 +129,9 @@
         "icon": "storm_ui_icon_kelthuzad_frostnova.png",
         "type": "W",
         "sort": 2,
-        "abilityId": "Kel'Thuzad|W1",
+        "abilityId": "KelThuzad|W1",
         "abilityLinks": [
-          "Kel'Thuzad|W1"
+          "KelThuzad|W1"
         ]
       },
       {
@@ -131,9 +142,9 @@
         "icon": "storm_ui_icon_kelthuzad_chains.png",
         "type": "E",
         "sort": 3,
-        "abilityId": "Kel'Thuzad|E1",
+        "abilityId": "KelThuzad|E1",
         "abilityLinks": [
-          "Kel'Thuzad|E1"
+          "KelThuzad|E1"
         ]
       }
     ],
@@ -146,9 +157,9 @@
         "icon": "storm_ui_icon_kelthuzad_chains.png",
         "type": "E",
         "sort": 1,
-        "abilityId": "Kel'Thuzad|E1",
+        "abilityId": "KelThuzad|E1",
         "abilityLinks": [
-          "Kel'Thuzad|E1"
+          "KelThuzad|E1"
         ]
       },
       {
@@ -160,9 +171,9 @@
         "type": "Passive",
         "sort": 2,
         "isQuest": true,
-        "abilityId": "Kel'Thuzad|Passive",
+        "abilityId": "KelThuzad|Passive",
         "abilityLinks": [
-          "Kel'Thuzad|D1"
+          "KelThuzad|D1"
         ]
       },
       {
@@ -174,7 +185,7 @@
         "type": "Active",
         "sort": 3,
         "cooldown": 25,
-        "abilityId": "Kel'Thuzad|Active"
+        "abilityId": "KelThuzad|Active"
       }
     ],
     "7": [
@@ -186,9 +197,9 @@
         "icon": "storm_ui_icon_kelthuzad_deathanddecay.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "Kel'Thuzad|Q1",
+        "abilityId": "KelThuzad|Q1",
         "abilityLinks": [
-          "Kel'Thuzad|Q1"
+          "KelThuzad|Q1"
         ]
       },
       {
@@ -199,9 +210,9 @@
         "icon": "storm_ui_icon_kelthuzad_chillingtouch.png",
         "type": "Passive",
         "sort": 2,
-        "abilityId": "Kel'Thuzad|Passive",
+        "abilityId": "KelThuzad|Passive",
         "abilityLinks": [
-          "Kel'Thuzad|D1"
+          "KelThuzad|D1"
         ]
       },
       {
@@ -212,9 +223,9 @@
         "icon": "storm_ui_icon_kelthuzad_glacialspike.png",
         "type": "Passive",
         "sort": 3,
-        "abilityId": "Kel'Thuzad|Passive",
+        "abilityId": "KelThuzad|Passive",
         "abilityLinks": [
-          "Kel'Thuzad|11"
+          "KelThuzad|11"
         ]
       }
     ],
@@ -228,9 +239,9 @@
         "type": "Heroic",
         "sort": 1,
         "cooldown": 50,
-        "abilityId": "Kel'Thuzad|R1",
+        "abilityId": "KelThuzad|R1",
         "abilityLinks": [
-          "Kel'Thuzad|R1"
+          "KelThuzad|R1"
         ]
       },
       {
@@ -242,9 +253,9 @@
         "type": "Heroic",
         "sort": 2,
         "cooldown": 16,
-        "abilityId": "Kel'Thuzad|R2",
+        "abilityId": "KelThuzad|R2",
         "abilityLinks": [
-          "Kel'Thuzad|R2"
+          "KelThuzad|R2"
         ]
       }
     ],
@@ -257,9 +268,9 @@
         "icon": "storm_ui_icon_kelthuzad_frostnova.png",
         "type": "W",
         "sort": 1,
-        "abilityId": "Kel'Thuzad|W1",
+        "abilityId": "KelThuzad|W1",
         "abilityLinks": [
-          "Kel'Thuzad|W1"
+          "KelThuzad|W1"
         ]
       },
       {
@@ -270,9 +281,9 @@
         "icon": "storm_ui_icon_kelthuzad_chains.png",
         "type": "E",
         "sort": 2,
-        "abilityId": "Kel'Thuzad|E1",
+        "abilityId": "KelThuzad|E1",
         "abilityLinks": [
-          "Kel'Thuzad|E1"
+          "KelThuzad|E1"
         ]
       },
       {
@@ -283,9 +294,9 @@
         "icon": "storm_ui_icon_kelthuzad_chains_a.png",
         "type": "E",
         "sort": 3,
-        "abilityId": "Kel'Thuzad|E1",
+        "abilityId": "KelThuzad|E1",
         "abilityLinks": [
-          "Kel'Thuzad|E1"
+          "KelThuzad|E1"
         ]
       }
     ],
@@ -298,9 +309,9 @@
         "icon": "storm_ui_icon_kelthuzad_deathanddecay.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "Kel'Thuzad|Q1",
+        "abilityId": "KelThuzad|Q1",
         "abilityLinks": [
-          "Kel'Thuzad|Q1"
+          "KelThuzad|Q1"
         ]
       },
       {
@@ -311,9 +322,9 @@
         "icon": "storm_ui_icon_talent_abilitytalent_damage.png",
         "type": "Passive",
         "sort": 2,
-        "abilityId": "Kel'Thuzad|Passive",
+        "abilityId": "KelThuzad|Passive",
         "abilityLinks": [
-          "Kel'Thuzad|D1"
+          "KelThuzad|D1"
         ]
       },
       {
@@ -324,9 +335,9 @@
         "icon": "storm_ui_icon_kelthuzad_poweroficecrown.png",
         "type": "Passive",
         "sort": 3,
-        "abilityId": "Kel'Thuzad|Passive",
+        "abilityId": "KelThuzad|Passive",
         "abilityLinks": [
-          "Kel'Thuzad|D1"
+          "KelThuzad|D1"
         ]
       }
     ],
@@ -339,9 +350,9 @@
         "icon": "storm_ui_icon_kelthuzad_frozentomb.png",
         "type": "Heroic",
         "sort": 1,
-        "abilityId": "Kel'Thuzad|R1",
+        "abilityId": "KelThuzad|R1",
         "abilityLinks": [
-          "Kel'Thuzad|R1"
+          "KelThuzad|R1"
         ]
       },
       {
@@ -352,9 +363,9 @@
         "icon": "storm_ui_icon_kelthuzad_shadowfissure.png",
         "type": "Heroic",
         "sort": 2,
-        "abilityId": "Kel'Thuzad|R2",
+        "abilityId": "KelThuzad|R2",
         "abilityLinks": [
-          "Kel'Thuzad|R2"
+          "KelThuzad|R2"
         ]
       },
       {
@@ -366,7 +377,7 @@
         "type": "Active",
         "sort": 3,
         "cooldown": 240,
-        "abilityId": "Kel'Thuzad|Active"
+        "abilityId": "KelThuzad|Active"
       },
       {
         "tooltipId": "KelThuzadTheDamnedReturn",
@@ -377,7 +388,7 @@
         "type": "Active",
         "sort": 4,
         "cooldown": 15,
-        "abilityId": "Kel'Thuzad|Active"
+        "abilityId": "KelThuzad|Active"
       }
     ]
   }

--- a/hero/kerrigan.json
+++ b/hero/kerrigan.json
@@ -1,5 +1,5 @@
 {
-  "id": "8",
+  "id": 8,
   "shortName": "kerrigan",
   "attributeId": "Kerr",
   "cHeroId": "Kerrigan",
@@ -20,7 +20,7 @@
   "abilities": {
     "Kerrigan": [
       {
-        "uid": "b87c92d",
+        "uid": "9c5dff",
         "name": "Ravage",
         "description": "Leap to a target, dealing 130 (+4% per level) damage. If the enemy dies within 1.5 seconds, restore 1 charge and refund 20 Mana.",
         "hotkey": "Q",
@@ -31,7 +31,7 @@
         "type": "basic"
       },
       {
-        "uid": "b4ab2c8",
+        "uid": "438b28",
         "name": "Impaling Blades",
         "description": "After 1.25 seconds, deal 165 (+4% per level) damage to enemies within the target area, Stunning them for 1 second.",
         "hotkey": "W",
@@ -42,7 +42,7 @@
         "type": "basic"
       },
       {
-        "uid": "a49bb42",
+        "uid": "953b78",
         "name": "Primal Grasp",
         "description": "Pulls enemies within the target area towards Kerrigan, dealing 25 (+4% per level) damage. After 2.5 seconds, an explosion occurs around Kerrigan, dealing 195 (+4% per level) damage to nearby enemies.",
         "hotkey": "E",
@@ -53,7 +53,7 @@
         "type": "basic"
       },
       {
-        "uid": "c2af57c",
+        "uid": "788ef1",
         "name": "Summon Ultralisk",
         "description": "After 0.5 seconds, summon an Ultralisk that rushes forward upon spawning, dealing 250 (+4% per level) damage to the first enemy Hero hit and Stunning them for 0.5 seconds.  The Ultralisk's Basic Attacks deal 50% of their damage in an area around their target. Reactivate to retarget the Ultralisk.",
         "hotkey": "R",
@@ -64,7 +64,7 @@
         "type": "heroic"
       },
       {
-        "uid": "b791533",
+        "uid": "d4ed2d",
         "name": "Maelstrom",
         "description": "Deals 74 (+4% per level) damage per second to nearby enemies. Lasts for 7 seconds.",
         "hotkey": "R",
@@ -75,7 +75,7 @@
         "type": "heroic"
       },
       {
-        "uid": "b85742f",
+        "uid": "90d9e9",
         "name": "Assimilation",
         "description": "Gain 10% of damage dealt from Basic Attacks and Abilities as Shields for 6 seconds. Shield amount gained doubled against Heroes.  Current maximum: 1004 (+4% per level)",
         "trait": true,

--- a/hero/kharazim.json
+++ b/hero/kharazim.json
@@ -189,9 +189,8 @@
         "icon": "storm_ui_icon_monk_deadlyreach.png",
         "type": "E",
         "sort": 3,
-        "abilityId": "Kharazim|E2",
+        "abilityId": "Kharazim|E1",
         "abilityLinks": [
-          "Kharazim|E2",
           "Kharazim|E1"
         ]
       }

--- a/hero/kharazim.json
+++ b/hero/kharazim.json
@@ -1,5 +1,5 @@
 {
-  "id": "40",
+  "id": 40,
   "shortName": "kharazim",
   "attributeId": "Monk",
   "cHeroId": "Monk",
@@ -23,7 +23,7 @@
   "abilities": {
     "Kharazim": [
       {
-        "uid": "fdd06c9",
+        "uid": "6d4c81",
         "name": "Radiant Dash",
         "description": "Jump to an allied or enemy unit. Enemies are immediately hit with a Basic Attack.  Stores up to 2 charges.",
         "hotkey": "Q",
@@ -34,7 +34,7 @@
         "type": "basic"
       },
       {
-        "uid": "07eb472",
+        "uid": "8c1b7e",
         "name": "Breath of Heaven",
         "description": "Heal nearby Heroes for 276 (+4% per level) and give them 15% Movement Speed for 3 seconds.",
         "hotkey": "W",
@@ -45,7 +45,7 @@
         "type": "basic"
       },
       {
-        "uid": "4a00da2",
+        "uid": "fd0ae1",
         "name": "Deadly Reach",
         "description": "Kharazim's next Basic Attack increases his Attack Speed and Attack Range by 100% for 2 seconds.",
         "hotkey": "E",
@@ -56,7 +56,7 @@
         "type": "basic"
       },
       {
-        "uid": "40efe4f",
+        "uid": "7e3a11",
         "name": "Seven-Sided Strike",
         "description": "Become Invulnerable and strike 7 times over 2 seconds. Each strike hits the highest Health nearby Hero for 7% of their maximum Health.",
         "hotkey": "R",
@@ -67,7 +67,7 @@
         "type": "heroic"
       },
       {
-        "uid": "d2b3a8f",
+        "uid": "e790cd",
         "name": "Divine Palm",
         "description": "Protect an allied Hero from death, causing them to be healed for 1200 (+4% per level) if they take fatal damage in the next 3 seconds.",
         "hotkey": "R",
@@ -78,7 +78,7 @@
         "type": "heroic"
       },
       {
-        "uid": "9ac34a4",
+        "uid": "49a3fa",
         "name": "Pick Your Trait",
         "description": "Choose between Transcendence, Iron Fists, and Insight from the Talents panel.",
         "trait": true,
@@ -97,8 +97,7 @@
         "description": "Every 3rd Basic Attack heals the lowest nearby allied Hero for 104 (+4% per level) and gives 25% increased Move Speed for 2 seconds.",
         "icon": "storm_ui_icon_monk_trait_transcendence.png",
         "type": "Trait",
-        "sort": 1,
-        "abilityId": "Kharazim|Trait"
+        "sort": 1
       },
       {
         "tooltipId": "MonkIronFistsTalent",
@@ -107,8 +106,7 @@
         "description": "Every 3rd Basic Attack deals 110% bonus damage and gives 25% increased Move Speed for 2 seconds.",
         "icon": "storm_ui_icon_monk_trait_ironfist.png",
         "type": "Trait",
-        "sort": 2,
-        "abilityId": "Kharazim|Trait"
+        "sort": 2
       },
       {
         "tooltipId": "MonkInsightTalent",
@@ -118,8 +116,7 @@
         "icon": "storm_ui_icon_monk_trait_insight.png",
         "type": "Trait",
         "sort": 3,
-        "isQuest": true,
-        "abilityId": "Kharazim|Trait"
+        "isQuest": true
       }
     ],
     "4": [
@@ -192,8 +189,9 @@
         "icon": "storm_ui_icon_monk_deadlyreach.png",
         "type": "E",
         "sort": 3,
-        "abilityId": "Kharazim|E1",
+        "abilityId": "Kharazim|E2",
         "abilityLinks": [
+          "Kharazim|E2",
           "Kharazim|E1"
         ]
       }

--- a/hero/leoric.json
+++ b/hero/leoric.json
@@ -104,15 +104,6 @@
         "cooldown": 9,
         "icon": "storm_ui_icon_leoric_drainhope_undead.png",
         "type": "basic"
-      },
-      {
-        "uid": "797e59",
-        "name": "Cancel Wraith Walk",
-        "description": "End Wraith Walk early.",
-        "hotkey": "E",
-        "abilityId": "Leoric|E2",
-        "icon": "storm_ui_icon_leoric_wraithwalk_end.png",
-        "type": "basic"
       }
     ]
   },

--- a/hero/leoric.json
+++ b/hero/leoric.json
@@ -1,5 +1,5 @@
 {
-  "id": "39",
+  "id": 39,
   "shortName": "leoric",
   "attributeId": "Leor",
   "cHeroId": "Leoric",
@@ -20,7 +20,7 @@
   "abilities": {
     "Leoric": [
       {
-        "uid": "b6bef4b",
+        "uid": "545927",
         "name": "Skeletal Swing",
         "description": "Leoric swings his mace, dealing 150 (+4% per level) damage and Slowing enemies by 40% for 2.5 seconds. If an enemy Hero is hit, refund 50% of the cooldown and Mana cost. Peasants!",
         "hotkey": "Q",
@@ -31,7 +31,7 @@
         "type": "basic"
       },
       {
-        "uid": "ea460f4",
+        "uid": "a3d2a4",
         "name": "Drain Hope",
         "description": "Grab an enemy Hero's soul, dealing up to 20% of their maximum Health as damage and healing Leoric for up to 20% of his maximum Health while he is nearby, over 4 seconds. Leoric's Movement Speed is reduced by 20% while this is active.",
         "hotkey": "W",
@@ -42,7 +42,7 @@
         "type": "basic"
       },
       {
-        "uid": "5f918e8",
+        "uid": "519128",
         "name": "Wraith Walk",
         "description": "Leoric separates from his body, becoming Unstoppable and gaining Movement Speed accelerating up to 50% over 2.5 seconds. When Wraith Walk ends or is canceled, his body jumps to his wraith.",
         "hotkey": "E",
@@ -53,7 +53,7 @@
         "type": "basic"
       },
       {
-        "uid": "70fc23b",
+        "uid": "38b393",
         "name": "Entomb",
         "description": "Create an unpassable tomb for 4 seconds.",
         "hotkey": "R",
@@ -64,7 +64,7 @@
         "type": "heroic"
       },
       {
-        "uid": "628f1d9",
+        "uid": "3e16eb",
         "name": "March of the Black King",
         "description": "Leoric becomes Unstoppable and walks forward, swinging his mace 3 times. Enemies hit take 250 (+4% per level) damage, and Heroes hit heal Leoric for 12% of his maximum Health.",
         "hotkey": "R",
@@ -75,7 +75,7 @@
         "type": "heroic"
       },
       {
-        "uid": "43d6f54",
+        "uid": "245d5e",
         "name": "Undying",
         "description": "Leoric becomes a ghost when he dies, and resurrects upon reaching full Health. Leoric deals no damage while dead.  Wrath Of The Bone King  Leoric's first two Basic Attacks cleave for 100% damage, and his third Basic Attack deals 200% damage to a single target.",
         "trait": true,
@@ -86,24 +86,33 @@
     ],
     "LeoricUndyingTrait": [
       {
-        "uid": "8badff8",
+        "uid": "fcb128",
         "name": "Ghastly Swing",
         "description": "Slow enemies by 40% for 2.5 seconds.",
         "hotkey": "Q",
         "abilityId": "Leoric|Q2",
         "cooldown": 8,
         "icon": "storm_ui_icon_leoric_skeletalswing_undead.png",
-        "type": "subunit"
+        "type": "basic"
       },
       {
-        "uid": "6c60dec",
+        "uid": "53b8a3",
         "name": "Drain Essence",
         "description": "Throw out a chain, attaching to the first enemy Hero hit, healing Leoric for up to 10% of his maximum Health over 4 seconds as long as the enemy remains close.",
         "hotkey": "W",
         "abilityId": "Leoric|W2",
         "cooldown": 9,
         "icon": "storm_ui_icon_leoric_drainhope_undead.png",
-        "type": "subunit"
+        "type": "basic"
+      },
+      {
+        "uid": "797e59",
+        "name": "Cancel Wraith Walk",
+        "description": "End Wraith Walk early.",
+        "hotkey": "E",
+        "abilityId": "Leoric|E2",
+        "icon": "storm_ui_icon_leoric_wraithwalk_end.png",
+        "type": "basic"
       }
     ]
   },
@@ -197,10 +206,10 @@
         "icon": "storm_ui_icon_leoric_drainhope.png",
         "type": "W",
         "sort": 1,
-        "abilityId": "Leoric|W1",
+        "abilityId": "Leoric|W2",
         "abilityLinks": [
-          "Leoric|W1",
-          "Leoric|W2"
+          "Leoric|W2",
+          "Leoric|W1"
         ]
       },
       {

--- a/hero/lili.json
+++ b/hero/lili.json
@@ -1,5 +1,5 @@
 {
-  "id": "24",
+  "id": 24,
   "shortName": "lili",
   "attributeId": "LiLi",
   "cHeroId": "LiLi",
@@ -19,68 +19,68 @@
     "SelfHealer"
   ],
   "abilities": {
-    "Li Li": [
+    "LiLi": [
       {
-        "uid": "89be463",
+        "uid": "1b962d",
         "name": "Healing Brew",
         "description": "Heal lowest Health ally (prioritizing Heroes) within 6 range for 175 (+4% per level) Health.",
         "hotkey": "Q",
-        "abilityId": "Li Li|Q1",
+        "abilityId": "LiLi|Q1",
         "cooldown": 4,
         "manaCost": 25,
         "icon": "storm_ui_icon_lili_healingbrew.png",
         "type": "basic"
       },
       {
-        "uid": "f990f70",
+        "uid": "52e733",
         "name": "Cloud Serpent",
         "description": "Summon a Cloud Serpent on an allied Hero that attacks nearby enemies every second. Each attack deals 26 (+4% per level) damage and heals the ally for 20 (+4% per level). Lasts for 8 seconds.",
         "hotkey": "W",
-        "abilityId": "Li Li|W1",
+        "abilityId": "LiLi|W1",
         "cooldown": 11,
         "manaCost": 35,
         "icon": "storm_ui_icon_lili_cloudserpent.png",
         "type": "basic"
       },
       {
-        "uid": "60ae31d",
+        "uid": "5bae6f",
         "name": "Blinding Wind",
         "description": "Throw a cloud of wind at the 2 nearest enemies (prioritizing Heroes), dealing 133 (+4% per level) damage. Affected targets are Blinded for 1.5 seconds, causing their Basic Attacks to miss and deal no damage.",
         "hotkey": "E",
-        "abilityId": "Li Li|E1",
+        "abilityId": "LiLi|E1",
         "cooldown": 12,
         "manaCost": 30,
         "icon": "storm_ui_icon_lili_blindingwind.png",
         "type": "basic"
       },
       {
-        "uid": "034d107",
+        "uid": "8eb2db",
         "name": "Jug of 1,000 Cups",
         "description": "Channel for up to 6 seconds. Every 0.25 seconds, heal the lowest Health nearby allied Hero for 66 (+4% per level) Health and increase the cooldown of Jug of 1,000 Cups by 2 seconds, up to 50.",
         "hotkey": "R",
-        "abilityId": "Li Li|R1",
+        "abilityId": "LiLi|R1",
         "cooldown": 20,
         "manaCost": 80,
         "icon": "storm_ui_icon_lili_jugofathousandcups.png",
         "type": "heroic"
       },
       {
-        "uid": "497e5a1",
+        "uid": "4ea9c2",
         "name": "Water Dragon",
         "description": "Li Li channels for 2 seconds, summoning a Water Dragon that hits the nearest enemy Hero within 12 range and all enemies near them, dealing 300 (+4% per level) damage and slowing their Movement Speed by 70% for 4 seconds.",
         "hotkey": "R",
-        "abilityId": "Li Li|R2",
+        "abilityId": "LiLi|R2",
         "cooldown": 45,
         "manaCost": 50,
         "icon": "storm_ui_icon_lili_waterdragon.png",
         "type": "heroic"
       },
       {
-        "uid": "a61e0b3",
+        "uid": "68f1a0",
         "name": "Fast Feet",
         "description": "Upon taking damage, your Basic Ability cooldowns refresh 50% faster and you gain 10% Movement Speed for 1 second.",
         "trait": true,
-        "abilityId": "Li Li|D1",
+        "abilityId": "LiLi|D1",
         "icon": "storm_ui_icon_lili_fastfeet.png",
         "type": "trait"
       }
@@ -96,9 +96,9 @@
         "icon": "storm_ui_icon_lili_healingbrew.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "Li Li|Q1",
+        "abilityId": "LiLi|Q1",
         "abilityLinks": [
-          "Li Li|Q1"
+          "LiLi|Q1"
         ]
       },
       {
@@ -109,9 +109,9 @@
         "icon": "storm_ui_icon_lili_cloudserpent.png",
         "type": "W",
         "sort": 2,
-        "abilityId": "Li Li|W1",
+        "abilityId": "LiLi|W1",
         "abilityLinks": [
-          "Li Li|W1"
+          "LiLi|W1"
         ]
       },
       {
@@ -122,9 +122,10 @@
         "icon": "storm_ui_icon_lili_fastfeet.png",
         "type": "Trait",
         "sort": 3,
-        "abilityId": "Li Li|D1",
+        "abilityId": "LiLi|D2",
         "abilityLinks": [
-          "Li Li|D1"
+          "LiLi|D2",
+          "LiLi|D1"
         ]
       }
     ],
@@ -137,22 +138,22 @@
         "icon": "storm_ui_icon_lili_cloudserpent.png",
         "type": "W",
         "sort": 1,
-        "abilityId": "Li Li|W1",
+        "abilityId": "LiLi|W1",
         "abilityLinks": [
-          "Li Li|W1"
+          "LiLi|W1"
         ]
       },
       {
-        "tooltipId": "LiLiHinderingWinds",
-        "talentTreeId": "LiLiHinderingWinds",
-        "name": "Hindering Winds",
-        "description": "Blinding Wind Slows enemy Hero Movement Speed by 25% for 1.5 seconds.",
+        "tooltipId": "LiLiSurgingWindsTalent",
+        "talentTreeId": "LiLiMasteryBlindingWindSurgingWinds",
+        "name": "Surging Winds",
+        "description": "If Blinding Wind hits 2 Heroes, its cooldown is reduced by 2 seconds and Li Li gains 10% Spell Power for 10 seconds.",
         "icon": "storm_ui_icon_lili_blindingwind.png",
         "type": "E",
         "sort": 2,
-        "abilityId": "Li Li|E1",
+        "abilityId": "LiLi|E1",
         "abilityLinks": [
-          "Li Li|E1"
+          "LiLi|E1"
         ]
       },
       {
@@ -164,9 +165,10 @@
         "type": "Trait",
         "sort": 3,
         "cooldown": 25,
-        "abilityId": "Li Li|D1",
+        "abilityId": "LiLi|D2",
         "abilityLinks": [
-          "Li Li|D1"
+          "LiLi|D2",
+          "LiLi|D1"
         ]
       }
     ],
@@ -179,9 +181,9 @@
         "icon": "storm_ui_icon_lili_healingbrew.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "Li Li|Q1",
+        "abilityId": "LiLi|Q1",
         "abilityLinks": [
-          "Li Li|Q1"
+          "LiLi|Q1"
         ]
       },
       {
@@ -192,9 +194,9 @@
         "icon": "storm_ui_icon_lili_cloudserpent.png",
         "type": "W",
         "sort": 2,
-        "abilityId": "Li Li|W1",
+        "abilityId": "LiLi|W1",
         "abilityLinks": [
-          "Li Li|W1"
+          "LiLi|W1"
         ]
       },
       {
@@ -206,7 +208,7 @@
         "type": "Active",
         "sort": 3,
         "cooldown": 40,
-        "abilityId": "Li Li|Active"
+        "abilityId": "LiLi|Active"
       }
     ],
     "10": [
@@ -219,9 +221,9 @@
         "type": "Heroic",
         "sort": 1,
         "cooldown": 20,
-        "abilityId": "Li Li|R1",
+        "abilityId": "LiLi|R1",
         "abilityLinks": [
-          "Li Li|R1"
+          "LiLi|R1"
         ]
       },
       {
@@ -233,9 +235,9 @@
         "type": "Heroic",
         "sort": 2,
         "cooldown": 45,
-        "abilityId": "Li Li|R2",
+        "abilityId": "LiLi|R2",
         "abilityLinks": [
-          "Li Li|R2"
+          "LiLi|R2"
         ]
       }
     ],
@@ -248,22 +250,22 @@
         "icon": "storm_ui_icon_lili_blindingwind.png",
         "type": "E",
         "sort": 1,
-        "abilityId": "Li Li|E1",
+        "abilityId": "LiLi|E1",
         "abilityLinks": [
-          "Li Li|E1"
+          "LiLi|E1"
         ]
       },
       {
-        "tooltipId": "LiLiSurgingWindsTalent",
-        "talentTreeId": "LiLiMasteryBlindingWindSurgingWinds",
-        "name": "Surging Winds",
-        "description": "If Blinding Wind hits 2 Heroes, its cooldown is reduced by 3 seconds and Li Li gains 10% Spell Power for 10 seconds.",
+        "tooltipId": "LiLiHinderingWinds",
+        "talentTreeId": "LiLiHinderingWinds",
+        "name": "Hindering Winds",
+        "description": "Blinding Wind Slows enemy Hero Movement Speed by 25% for 2 seconds.",
         "icon": "storm_ui_icon_lili_blindingwind_a.png",
         "type": "E",
         "sort": 2,
-        "abilityId": "Li Li|E1",
+        "abilityId": "LiLi|E1",
         "abilityLinks": [
-          "Li Li|E1"
+          "LiLi|E1"
         ]
       },
       {
@@ -274,9 +276,9 @@
         "icon": "storm_ui_icon_lili_blindingwind_b.png",
         "type": "E",
         "sort": 3,
-        "abilityId": "Li Li|E1",
+        "abilityId": "LiLi|E1",
         "abilityLinks": [
-          "Li Li|E1"
+          "LiLi|E1"
         ]
       }
     ],
@@ -289,9 +291,9 @@
         "icon": "storm_ui_icon_lili_healingbrew.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "Li Li|Q1",
+        "abilityId": "LiLi|Q1",
         "abilityLinks": [
-          "Li Li|Q1"
+          "LiLi|Q1"
         ]
       },
       {
@@ -302,22 +304,22 @@
         "icon": "storm_ui_icon_lili_healingbrew_a.png",
         "type": "Q",
         "sort": 2,
-        "abilityId": "Li Li|Q1",
+        "abilityId": "LiLi|Q1",
         "abilityLinks": [
-          "Li Li|Q1"
+          "LiLi|Q1"
         ]
       },
       {
         "tooltipId": "LiLiBlessingsOfYulon",
         "talentTreeId": "LiLiBlessingsOfYulon",
-        "name": "Blessings Of Yu'lon",
+        "name": "Blessings Of Yu’lon",
         "description": "Cloud Serpent heals its bearer for an additional 1% of their maximum Health each time it attacks.",
         "icon": "storm_ui_icon_lili_cloudserpent.png",
         "type": "W",
         "sort": 3,
-        "abilityId": "Li Li|W1",
+        "abilityId": "LiLi|W1",
         "abilityLinks": [
-          "Li Li|W1"
+          "LiLi|W1"
         ]
       }
     ],
@@ -330,9 +332,9 @@
         "icon": "storm_ui_icon_lili_jugofathousandcups.png",
         "type": "Heroic",
         "sort": 1,
-        "abilityId": "Li Li|R1",
+        "abilityId": "LiLi|R1",
         "abilityLinks": [
-          "Li Li|R1"
+          "LiLi|R1"
         ]
       },
       {
@@ -343,9 +345,9 @@
         "icon": "storm_ui_icon_lili_waterdragon.png",
         "type": "Heroic",
         "sort": 2,
-        "abilityId": "Li Li|R2",
+        "abilityId": "LiLi|R2",
         "abilityLinks": [
-          "Li Li|R2"
+          "LiLi|R2"
         ]
       },
       {
@@ -357,7 +359,7 @@
         "type": "Active",
         "sort": 3,
         "cooldown": 30,
-        "abilityId": "Li Li|Active"
+        "abilityId": "LiLi|Active"
       },
       {
         "tooltipId": "LiLiShakeItOffTalent",
@@ -367,9 +369,10 @@
         "icon": "storm_ui_icon_lili_fastfeet.png",
         "type": "Trait",
         "sort": 4,
-        "abilityId": "Li Li|D1",
+        "abilityId": "LiLi|D2",
         "abilityLinks": [
-          "Li Li|D1"
+          "LiLi|D2",
+          "LiLi|D1"
         ]
       }
     ]

--- a/hero/lili.json
+++ b/hero/lili.json
@@ -122,9 +122,8 @@
         "icon": "storm_ui_icon_lili_fastfeet.png",
         "type": "Trait",
         "sort": 3,
-        "abilityId": "LiLi|D2",
+        "abilityId": "LiLi|D1",
         "abilityLinks": [
-          "LiLi|D2",
           "LiLi|D1"
         ]
       }
@@ -165,9 +164,8 @@
         "type": "Trait",
         "sort": 3,
         "cooldown": 25,
-        "abilityId": "LiLi|D2",
+        "abilityId": "LiLi|D1",
         "abilityLinks": [
-          "LiLi|D2",
           "LiLi|D1"
         ]
       }
@@ -369,9 +367,8 @@
         "icon": "storm_ui_icon_lili_fastfeet.png",
         "type": "Trait",
         "sort": 4,
-        "abilityId": "LiLi|D2",
+        "abilityId": "LiLi|D1",
         "abilityLinks": [
-          "LiLi|D2",
           "LiLi|D1"
         ]
       }

--- a/hero/liming.json
+++ b/hero/liming.json
@@ -1,5 +1,5 @@
 {
-  "id": "48",
+  "id": 48,
   "shortName": "liming",
   "attributeId": "Wiza",
   "cHeroId": "Wizard",
@@ -18,68 +18,68 @@
     "TowerPusher"
   ],
   "abilities": {
-    "Li-Ming": [
+    "LiMing": [
       {
-        "uid": "7efb099",
+        "uid": "e87a11",
         "name": "Magic Missiles",
         "description": "Fire three missiles toward an area, each dealing 147 (+3.5% per level) damage to the first enemy hit. These missiles do 50% damage to Structures.",
         "hotkey": "Q",
-        "abilityId": "Li-Ming|Q1",
+        "abilityId": "LiMing|Q1",
         "cooldown": 3,
         "manaCost": 20,
         "icon": "storm_ui_icon_wizard_magicmissiles.png",
         "type": "basic"
       },
       {
-        "uid": "10b62b5",
+        "uid": "e035bf",
         "name": "Arcane Orb",
         "description": "Fire an Orb that powers up as it travels, dealing 135 (+3% per level) damage to the first enemy hit. Damage is increased the further it travels, up to 270 (+3% per level) more damage.",
         "hotkey": "W",
-        "abilityId": "Li-Ming|W1",
+        "abilityId": "LiMing|W1",
         "cooldown": 8,
         "manaCost": 40,
         "icon": "storm_ui_icon_wizard_arcaneorb.png",
         "type": "basic"
       },
       {
-        "uid": "5ec61d9",
+        "uid": "618a6b",
         "name": "Teleport",
         "description": "Teleport a short distance instantly.",
         "hotkey": "E",
-        "abilityId": "Li-Ming|E1",
+        "abilityId": "LiMing|E1",
         "cooldown": 5,
         "manaCost": 30,
         "icon": "storm_ui_icon_wizard_teleport.png",
         "type": "basic"
       },
       {
-        "uid": "5769b45",
+        "uid": "4d7d28",
         "name": "Disintegrate",
         "description": "Channel a powerful beam, dealing 480 (+5% per level) damage over 2.6 seconds to enemies while they are in it. The direction of the beam changes with your mouse cursor position.",
         "hotkey": "R",
-        "abilityId": "Li-Ming|R1",
+        "abilityId": "LiMing|R1",
         "cooldown": 30,
         "manaCost": 80,
         "icon": "storm_ui_icon_wizard_disintegrate.png",
         "type": "heroic"
       },
       {
-        "uid": "4bdc74f",
+        "uid": "4b23e9",
         "name": "Wave of Force",
         "description": "Knock away all enemies from an area and deal 160 (+5% per level) damage.",
         "hotkey": "R",
-        "abilityId": "Li-Ming|R2",
+        "abilityId": "LiMing|R2",
         "cooldown": 20,
         "manaCost": 80,
         "icon": "storm_ui_icon_wizard_waveofforce.png",
         "type": "heroic"
       },
       {
-        "uid": "75eaa4c",
+        "uid": "eb733b",
         "name": "Critical Mass",
         "description": "Getting a Takedown will refresh the cooldown on all of Li-Ming's Abilities.",
         "trait": true,
-        "abilityId": "Li-Ming|D1",
+        "abilityId": "LiMing|D1",
         "icon": "storm_ui_icon_wizard_criticalmass.png",
         "type": "trait"
       }
@@ -91,13 +91,13 @@
         "tooltipId": "WizardForceArmorTalent",
         "talentTreeId": "WizardForceArmor",
         "name": "Force Armor",
-        "description": "When Magic Missiles damages an enemy Hero, gain 50 Spell Armor against the next enemy Ability, reducing the damage taken by 50%. Gain 1 charge per cast.  Stores up to 4 charges.",
+        "description": "When Magic Missiles damages an enemy Hero, gain 50 Spell Armor, reducing the damage taken by the next Ability by 50%. Gain 1 charge per cast and store up to 4 charges.  Passive: Li-Ming's Mana regeneration is increased by 100% while below 35% Mana.",
         "icon": "storm_ui_icon_wizard_magicmissiles.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "Li-Ming|Q1",
+        "abilityId": "LiMing|Q1",
         "abilityLinks": [
-          "Li-Ming|Q1"
+          "LiMing|Q1"
         ]
       },
       {
@@ -108,22 +108,9 @@
         "icon": "storm_ui_icon_wizard_teleport.png",
         "type": "E",
         "sort": 2,
-        "abilityId": "Li-Ming|E1",
+        "abilityId": "LiMing|E1",
         "abilityLinks": [
-          "Li-Ming|E1"
-        ]
-      },
-      {
-        "tooltipId": "WizardAstralPresence",
-        "talentTreeId": "WizardAstralPresence",
-        "name": "Astral Presence",
-        "description": "Li-Ming's Mana regeneration is increased by 100% while below 35% Mana.",
-        "icon": "storm_btn_d3_traits_wizard_astralpresence.png",
-        "type": "Passive",
-        "sort": 3,
-        "abilityId": "Li-Ming|Passive",
-        "abilityLinks": [
-          "Li-Ming|D1"
+          "LiMing|E1"
         ]
       },
       {
@@ -133,10 +120,10 @@
         "description": "Regeneration Globes restore 100% more Mana and grant 10% Spell Power for 20 seconds.",
         "icon": "storm_ui_icon_talent_powerhungry.png",
         "type": "Passive",
-        "sort": 4,
-        "abilityId": "Li-Ming|Passive",
+        "sort": 3,
+        "abilityId": "LiMing|Passive",
         "abilityLinks": [
-          "Li-Ming|D1"
+          "LiMing|D1"
         ]
       }
     ],
@@ -149,22 +136,22 @@
         "icon": "storm_ui_icon_wizard_magicmissiles.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "Li-Ming|Q1",
+        "abilityId": "LiMing|Q1",
         "abilityLinks": [
-          "Li-Ming|Q1"
+          "LiMing|Q1"
         ]
       },
       {
         "tooltipId": "WizardArcaneOrbTriumvirateTalent",
         "talentTreeId": "WizardArcaneOrbTriumvirate",
         "name": "Triumvirate",
-        "description": "If Arcane Orb hits an enemy Hero after traveling at least 50% of its base range, the cooldown is reduced by 5 seconds.",
+        "description": "If Arcane Orb hits an enemy Hero after traveling at least 50% of its base range, the cooldown is reduced by 5 seconds and 40 Mana is refunded.",
         "icon": "storm_ui_icon_wizard_arcaneorb.png",
         "type": "W",
         "sort": 2,
-        "abilityId": "Li-Ming|W1",
+        "abilityId": "LiMing|W1",
         "abilityLinks": [
-          "Li-Ming|W1"
+          "LiMing|W1"
         ]
       },
       {
@@ -175,9 +162,9 @@
         "icon": "storm_ui_icon_wizard_criticalmass.png",
         "type": "Trait",
         "sort": 3,
-        "abilityId": "Li-Ming|D1",
+        "abilityId": "LiMing|D1",
         "abilityLinks": [
-          "Li-Ming|D1"
+          "LiMing|D1"
         ]
       }
     ],
@@ -190,9 +177,9 @@
         "icon": "storm_ui_icon_wizard_magicmissiles.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "Li-Ming|Q1",
+        "abilityId": "LiMing|Q1",
         "abilityLinks": [
-          "Li-Ming|Q1"
+          "LiMing|Q1"
         ]
       },
       {
@@ -203,9 +190,9 @@
         "icon": "storm_ui_icon_wizard_arcaneorb.png",
         "type": "W",
         "sort": 2,
-        "abilityId": "Li-Ming|W1",
+        "abilityId": "LiMing|W1",
         "abilityLinks": [
-          "Li-Ming|W1"
+          "LiMing|W1"
         ]
       },
       {
@@ -216,9 +203,9 @@
         "icon": "storm_ui_icon_wizard_teleport.png",
         "type": "E",
         "sort": 3,
-        "abilityId": "Li-Ming|E1",
+        "abilityId": "LiMing|E1",
         "abilityLinks": [
-          "Li-Ming|E1"
+          "LiMing|E1"
         ]
       }
     ],
@@ -232,9 +219,9 @@
         "type": "Heroic",
         "sort": 1,
         "cooldown": 30,
-        "abilityId": "Li-Ming|R1",
+        "abilityId": "LiMing|R1",
         "abilityLinks": [
-          "Li-Ming|R1"
+          "LiMing|R1"
         ]
       },
       {
@@ -246,9 +233,9 @@
         "type": "Heroic",
         "sort": 2,
         "cooldown": 20,
-        "abilityId": "Li-Ming|R2",
+        "abilityId": "LiMing|R2",
         "abilityLinks": [
-          "Li-Ming|R2"
+          "LiMing|R2"
         ]
       }
     ],
@@ -261,9 +248,9 @@
         "icon": "storm_ui_icon_wizard_teleport.png",
         "type": "E",
         "sort": 1,
-        "abilityId": "Li-Ming|E1",
+        "abilityId": "LiMing|E1",
         "abilityLinks": [
-          "Li-Ming|E1"
+          "LiMing|E1"
         ]
       },
       {
@@ -274,9 +261,9 @@
         "icon": "storm_ui_icon_talent_autoattack_damage.png",
         "type": "Passive",
         "sort": 2,
-        "abilityId": "Li-Ming|Passive",
+        "abilityId": "LiMing|Passive",
         "abilityLinks": [
-          "Li-Ming|D1"
+          "LiMing|D1"
         ]
       },
       {
@@ -287,9 +274,9 @@
         "icon": "storm_btn_d3_traits_wizard_glasscannon.png",
         "type": "Passive",
         "sort": 3,
-        "abilityId": "Li-Ming|Passive",
+        "abilityId": "LiMing|Passive",
         "abilityLinks": [
-          "Li-Ming|D1"
+          "LiMing|D1"
         ]
       }
     ],
@@ -302,9 +289,9 @@
         "icon": "storm_ui_icon_wizard_magicmissiles.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "Li-Ming|Q1",
+        "abilityId": "LiMing|Q1",
         "abilityLinks": [
-          "Li-Ming|Q1"
+          "LiMing|Q1"
         ]
       },
       {
@@ -315,9 +302,9 @@
         "icon": "storm_ui_icon_wizard_magicmissiles_b.png",
         "type": "Q",
         "sort": 2,
-        "abilityId": "Li-Ming|Q1",
+        "abilityId": "LiMing|Q1",
         "abilityLinks": [
-          "Li-Ming|Q1"
+          "LiMing|Q1"
         ]
       },
       {
@@ -328,9 +315,9 @@
         "icon": "storm_ui_icon_wizard_arcaneorb.png",
         "type": "W",
         "sort": 3,
-        "abilityId": "Li-Ming|W1",
+        "abilityId": "LiMing|W1",
         "abilityLinks": [
-          "Li-Ming|W1"
+          "LiMing|W1"
         ]
       },
       {
@@ -341,9 +328,9 @@
         "icon": "storm_ui_icon_wizard_teleport.png",
         "type": "E",
         "sort": 4,
-        "abilityId": "Li-Ming|E1",
+        "abilityId": "LiMing|E1",
         "abilityLinks": [
-          "Li-Ming|E1"
+          "LiMing|E1"
         ]
       }
     ],
@@ -356,9 +343,9 @@
         "icon": "storm_ui_icon_wizard_disintegrate.png",
         "type": "Heroic",
         "sort": 1,
-        "abilityId": "Li-Ming|R1",
+        "abilityId": "LiMing|R1",
         "abilityLinks": [
-          "Li-Ming|R1"
+          "LiMing|R1"
         ]
       },
       {
@@ -369,9 +356,9 @@
         "icon": "storm_ui_icon_wizard_waveofforce.png",
         "type": "Heroic",
         "sort": 2,
-        "abilityId": "Li-Ming|R2",
+        "abilityId": "LiMing|R2",
         "abilityLinks": [
-          "Li-Ming|R2"
+          "LiMing|R2"
         ]
       },
       {
@@ -382,9 +369,9 @@
         "icon": "storm_btn_d3_traits_wizard_elementalexposure.png",
         "type": "Passive",
         "sort": 3,
-        "abilityId": "Li-Ming|Passive",
+        "abilityId": "LiMing|Passive",
         "abilityLinks": [
-          "Li-Ming|D1"
+          "LiMing|D1"
         ]
       },
       {
@@ -395,7 +382,7 @@
         "icon": "storm_ui_icon_wizard_archon.png",
         "type": "Active",
         "sort": 4,
-        "abilityId": "Li-Ming|Active"
+        "abilityId": "LiMing|Active"
       }
     ]
   }

--- a/hero/lostvikings.json
+++ b/hero/lostvikings.json
@@ -11,7 +11,14 @@
   "type": "Melee",
   "releaseDate": "2015-02-10",
   "releasePatch": "0.9.0.34053",
-  "tags": [],
+  "tags": [
+    "Escaper",
+    "Helper",
+    "Overconfident",
+    "RoleAutoAttacker",
+    "RoleTank",
+    "WaveClearer"
+  ],
   "abilities": {
     "LostVikings": [
       {

--- a/hero/lostvikings.json
+++ b/hero/lostvikings.json
@@ -1,5 +1,5 @@
 {
-  "id": "34",
+  "id": 34,
   "shortName": "lostvikings",
   "attributeId": "Lost",
   "cHeroId": "LostVikings",
@@ -11,160 +11,482 @@
   "type": "Melee",
   "releaseDate": "2015-02-10",
   "releasePatch": "0.9.0.34053",
-  "tags": [
-    "Escaper",
-    "Helper",
-    "Overconfident",
-    "RoleAutoAttacker",
-    "RoleTank",
-    "WaveClearer"
-  ],
+  "tags": [],
   "abilities": {
-    "The Lost Vikings": [
+    "LostVikings": [
       {
-        "uid": "1d72f5a",
+        "uid": "39ea12",
         "name": "Spin To Win!",
         "description": "Activate to have each Viking deal 101 (+4% per level) damage to nearby enemies.",
         "hotkey": "Q",
-        "abilityId": "The Lost Vikings|Q1",
+        "abilityId": "LostVikings|Q1",
         "cooldown": 10,
         "icon": "storm_ui_icon_lostvikings_spintowin.png",
         "type": "basic"
       },
       {
-        "uid": "c3cd717",
-        "name": "Nordic Attack Squad",
-        "description": "Activate to have all Viking Basic Attacks deal bonus damage equal to 1.25% of a Hero's maximum Health for 5 seconds.",
-        "hotkey": "W",
-        "abilityId": "The Lost Vikings|W2",
-        "cooldown": 20,
-        "icon": "storm_ui_icon_talent_autoattack_damage.png",
-        "type": "basic"
-      },
-      {
-        "uid": "616f88a",
-        "name": "Viking Bribery",
-        "description": "Enemy Minions or captured Mercenaries killed near The Lost Vikings grant stacks of Bribe. Use 40 stacks to bribe target Mercenary, instantly defeating them. Does not work on Elite Mercenaries. Maximum stacks available: 200. If a camp is defeated entirely with Bribe, the camp respawns 50% faster.  Current number of Bribe stacks: 0",
-        "hotkey": "E",
-        "abilityId": "The Lost Vikings|E1",
-        "icon": "storm_ui_icon_talent_bribe.png",
-        "type": "basic"
-      },
-      {
-        "uid": "85d6161",
-        "name": "Play Again!",
-        "description": "Summon, fully heal, and revive all Lost Vikings at target location after a Viking channels for 2 seconds.  Only one Viking may attempt to summon at a time.",
-        "hotkey": "R",
-        "abilityId": "The Lost Vikings|R2",
-        "cooldown": 80,
-        "icon": "storm_ui_icon_lostvikings_playagain.png",
-        "type": "heroic"
-      },
-      {
-        "uid": "32e8c00",
-        "name": "Longboat Raid!",
-        "description": "Hop into an Unstoppable Longboat that fires at nearby enemies for 112 (+4% per level) damage per second and can fire a mortar that deals 205 (+4% per level) damage in an area.  The boat has increased Health for each Viking inside. If the boat is destroyed by enemies, all Vikings are stunned for 1.5 seconds. Lasts 15 seconds.  Requires all surviving Vikings to be nearby.",
-        "hotkey": "R",
-        "abilityId": "The Lost Vikings|R1",
-        "cooldown": 90,
-        "icon": "storm_ui_icon_lostvikings_longboatraid.png",
-        "type": "heroic"
-      },
-      {
-        "uid": "6c5bf95",
-        "name": "Go Go Go!",
-        "description": "The Vikings gain 30% increased Movement Speed for 4 seconds.",
-        "hotkey": "Z",
-        "abilityId": "The Lost Vikings|Z1",
-        "cooldown": 30,
-        "icon": "storm_ui_icon_lostvikings_mount.png",
-        "type": "mount"
-      },
-      {
-        "uid": "a07cc19",
-        "name": "Select Olaf",
-        "description": "Olaf can charge enemies and slow their Movement Speed by 30% for 3 seconds by right-clicking on them. 8 second cooldown.  Olaf gains increased Health Regeneration when out of combat for 4 seconds.",
-        "hotkey": "1",
-        "abilityId": "The Lost Vikings|11",
-        "icon": "storm_ui_icon_lostvikings_selectolaf.png",
-        "type": "activable"
-      },
-      {
-        "uid": "9005cd5",
-        "name": "Select Baleog",
-        "description": "Baleog's Basic Attacks deal 50% splash damage to enemies behind his attack target.",
-        "hotkey": "2",
-        "abilityId": "The Lost Vikings|21",
-        "icon": "storm_ui_icon_lostvikings_selectbaleog.png",
-        "type": "activable"
-      },
-      {
-        "uid": "cf27aa9",
-        "name": "Select Erik",
-        "description": "Erik moves faster than the other Vikings and has increased Basic Attack range.",
-        "hotkey": "3",
-        "abilityId": "The Lost Vikings|31",
-        "icon": "storm_ui_icon_lostvikings_selecterik.png",
-        "type": "activable"
-      },
-      {
-        "uid": "29fbe91",
+        "uid": "4fe3b3",
         "name": "Jump!",
         "description": "Makes all Vikings Invulnerable and able to pass over enemies for 1.5 seconds.",
         "hotkey": "W",
-        "abilityId": "The Lost Vikings|W1",
+        "abilityId": "LostVikings|W1",
         "cooldown": 30,
         "icon": "storm_ui_icon_lostvikings_jump.png",
         "type": "basic"
       },
       {
-        "uid": "6bb9a50",
+        "uid": "86ef1a",
+        "name": "Viking Bribery",
+        "description": "Enemy Minions or captured Mercenaries killed near The Lost Vikings grant stacks of Bribe. Use 40 stacks to bribe target Mercenary, instantly defeating them. Does not work on Elite Mercenaries. Maximum stacks available: 200. If a camp is defeated entirely with Bribe, the camp respawns 50% faster.  Current number of Bribe stacks: 0",
+        "hotkey": "E",
+        "abilityId": "LostVikings|E1",
+        "icon": "storm_ui_icon_talent_bribe.png",
+        "type": "basic"
+      },
+      {
+        "uid": "66631d",
+        "name": "Select Olaf",
+        "description": "Olaf can charge enemies and slow their Movement Speed by 30% for 3 seconds by right-clicking on them. 8 second cooldown.  Olaf gains increased Health Regeneration when out of combat for 4 seconds.",
+        "hotkey": 1,
+        "abilityId": "LostVikings|11",
+        "icon": "storm_ui_icon_lostvikings_selectolaf.png",
+        "type": "activable"
+      },
+      {
+        "uid": "f173dc",
+        "name": "Select Baleog",
+        "description": "Baleog's Basic Attacks deal 50% splash damage to enemies behind his attack target.",
+        "hotkey": 2,
+        "abilityId": "LostVikings|21",
+        "icon": "storm_ui_icon_lostvikings_selectbaleog.png",
+        "type": "activable"
+      },
+      {
+        "uid": "f14745",
+        "name": "Select Erik",
+        "description": "Erik moves faster than the other Vikings and has increased Basic Attack range.",
+        "hotkey": 3,
+        "abilityId": "LostVikings|31",
+        "icon": "storm_ui_icon_lostvikings_selecterik.png",
+        "type": "activable"
+      },
+      {
+        "uid": "8da17f",
+        "name": "Select All Vikings",
+        "description": "The Lost Vikings can be controlled individually or as a group. Each Viking has particular strengths.",
+        "hotkey": 4,
+        "abilityId": "LostVikings|41",
+        "icon": "storm_ui_ingame_heroselect_btn_lostvikings.png",
+        "type": "activable"
+      },
+      {
+        "uid": "e9f133",
+        "name": "Longboat Raid!",
+        "description": "Hop into an Unstoppable Longboat that fires at nearby enemies for 112 (+4% per level) damage per second and can fire a mortar that deals 205 (+4% per level) damage in an area.  The boat has increased Health for each Viking inside. If the boat is destroyed by enemies, all Vikings are stunned for 1.5 seconds. Lasts 15 seconds.  Requires all surviving Vikings to be nearby.",
+        "hotkey": "R",
+        "abilityId": "LostVikings|R1",
+        "cooldown": 90,
+        "icon": "storm_ui_icon_lostvikings_longboatraid.png",
+        "type": "heroic"
+      },
+      {
+        "uid": "033e0a",
+        "name": "Play Again!",
+        "description": "Summon, fully heal, and revive all Lost Vikings at target location after a Viking channels for 2 seconds.  Only one Viking may attempt to summon at a time.",
+        "hotkey": "R",
+        "abilityId": "LostVikings|R2",
+        "cooldown": 80,
+        "icon": "storm_ui_icon_lostvikings_playagain.png",
+        "type": "heroic"
+      },
+      {
+        "uid": "23fd3f",
+        "name": "Viking Hoard",
+        "description": "Gathering a Regeneration Globe with a Viking permanently increases all their Health Regeneration by 0.5 per second.  Current Bonus: 0 Regen per second",
+        "trait": true,
+        "abilityId": "LostVikings|D1",
+        "icon": "storm_ui_icon_lostvikings_vikinghoard.png",
+        "type": "trait"
+      },
+      {
+        "uid": "74d859",
+        "name": "Go Go Go!",
+        "description": "The Vikings gain 30% increased Movement Speed for 4 seconds.",
+        "hotkey": "Z",
+        "abilityId": "LostVikings|Z1",
+        "cooldown": 30,
+        "icon": "storm_ui_icon_lostvikings_mount.png",
+        "type": "mount"
+      },
+      {
+        "uid": "c7798d",
         "name": "Norse Force!",
         "description": "All Vikings gain a 130 (+4% per level) to 260 (+4% per level) point Shield, increasing in strength for each Viking alive. Lasts 4 seconds.",
         "hotkey": "Q",
-        "abilityId": "The Lost Vikings|Q2",
+        "abilityId": "LostVikings|Q2",
         "cooldown": 30,
         "icon": "storm_ui_icon_lostvikings_norseforce.png",
         "type": "basic"
       },
       {
-        "uid": "f73377d",
+        "uid": "c2cd44",
+        "name": "Nordic Attack Squad",
+        "description": "Activate to have all Viking Basic Attacks deal bonus damage equal to 1.25% of a Hero's maximum Health for 5 seconds.",
+        "hotkey": "W",
+        "abilityId": "LostVikings|W2",
+        "cooldown": 20,
+        "icon": "storm_ui_icon_talent_autoattack_damage.png",
+        "type": "basic"
+      }
+    ],
+    "LostVikingsLongboatRaidNewer": [
+      {
+        "uid": "033e0a",
+        "name": "Play Again!",
+        "description": "Summon, fully heal, and revive all Lost Vikings at target location after a Viking channels for 2 seconds.  Only one Viking may attempt to summon at a time.",
+        "hotkey": "R",
+        "abilityId": "LostVikings|R3",
+        "cooldown": 80,
+        "icon": "storm_ui_icon_lostvikings_playagain.png",
+        "type": "heroic"
+      },
+      {
+        "uid": "86ef1a",
+        "name": "Viking Bribery",
+        "description": "Enemy Minions or captured Mercenaries killed near The Lost Vikings grant stacks of Bribe. Use 40 stacks to bribe target Mercenary, instantly defeating them. Does not work on Elite Mercenaries. Maximum stacks available: 200. If a camp is defeated entirely with Bribe, the camp respawns 50% faster.  Current number of Bribe stacks: 0",
+        "hotkey": "E",
+        "abilityId": "LostVikings|E2",
+        "icon": "storm_ui_icon_talent_bribe.png",
+        "type": "basic"
+      },
+      {
+        "uid": "23fd3f",
+        "name": "Viking Hoard",
+        "description": "Gathering a Regeneration Globe with a Viking permanently increases all their Health Regeneration by 0.5 per second.  Current Bonus: 0 Regen per second",
+        "trait": true,
+        "abilityId": "LostVikings|D2",
+        "icon": "storm_ui_icon_lostvikings_vikinghoard.png",
+        "type": "trait"
+      },
+      {
+        "uid": "23fd3f",
+        "name": "Viking Hoard",
+        "description": "Gathering a Regeneration Globe with a Viking permanently increases all their Health Regeneration by 0.5 per second.  Current Bonus: 0 Regen per second",
+        "trait": true,
+        "abilityId": "LostVikings|D3",
+        "icon": "storm_ui_icon_lostvikings_vikinghoard.png",
+        "type": "trait"
+      },
+      {
+        "uid": "39ea12",
+        "name": "Spin To Win!",
+        "description": "Activate to have each Viking deal 101 (+4% per level) damage to nearby enemies.",
+        "hotkey": "Q",
+        "abilityId": "LostVikings|Q3",
+        "cooldown": 10,
+        "icon": "storm_ui_icon_lostvikings_spintowin.png",
+        "type": "basic"
+      },
+      {
+        "uid": "c7798d",
+        "name": "Norse Force!",
+        "description": "All Vikings gain a 130 (+4% per level) to 260 (+4% per level) point Shield, increasing in strength for each Viking alive. Lasts 4 seconds.",
+        "hotkey": "Q",
+        "abilityId": "LostVikings|Q4",
+        "cooldown": 30,
+        "icon": "storm_ui_icon_lostvikings_norseforce.png",
+        "type": "basic"
+      },
+      {
+        "uid": "4fe3b3",
+        "name": "Jump!",
+        "description": "Makes all Vikings Invulnerable and able to pass over enemies for 1.5 seconds.",
+        "hotkey": "W",
+        "abilityId": "LostVikings|W3",
+        "cooldown": 30,
+        "icon": "storm_ui_icon_lostvikings_jump.png",
+        "type": "basic"
+      },
+      {
+        "uid": "c2cd44",
+        "name": "Nordic Attack Squad",
+        "description": "Activate to have all Viking Basic Attacks deal bonus damage equal to 1.25% of a Hero's maximum Health for 5 seconds.",
+        "hotkey": "W",
+        "abilityId": "LostVikings|W4",
+        "cooldown": 20,
+        "icon": "storm_ui_icon_talent_autoattack_damage.png",
+        "type": "basic"
+      },
+      {
+        "uid": "e9f133",
+        "name": "Longboat Raid!",
+        "description": "Hop into an Unstoppable Longboat that fires at nearby enemies for 112 (+4% per level) damage per second and can fire a mortar that deals 205 (+4% per level) damage in an area.  The boat has increased Health for each Viking inside. If the boat is destroyed by enemies, all Vikings are stunned for 1.5 seconds. Lasts 15 seconds.  Requires all surviving Vikings to be nearby.",
+        "hotkey": "R",
+        "abilityId": "LostVikings|R4",
+        "cooldown": 90,
+        "icon": "storm_ui_icon_lostvikings_longboatraid.png",
+        "type": "heroic"
+      },
+      {
+        "uid": "74d859",
+        "name": "Go Go Go!",
+        "description": "The Vikings gain 30% increased Movement Speed for 4 seconds.",
+        "hotkey": "Z",
+        "abilityId": "LostVikings|Z2",
+        "cooldown": 30,
+        "icon": "storm_ui_icon_lostvikings_mount.png",
+        "type": "mount"
+      },
+      {
+        "uid": "f173dc",
+        "name": "Select Baleog",
+        "description": "Baleog's Basic Attacks deal 50% splash damage to enemies behind his attack target.",
+        "hotkey": 5,
+        "abilityId": "LostVikings|51",
+        "icon": "storm_ui_icon_lostvikings_selectbaleog.png",
+        "type": "activable"
+      },
+      {
+        "uid": "8da17f",
+        "name": "Select All Vikings",
+        "description": "The Lost Vikings can be controlled individually or as a group. Each Viking has particular strengths.",
+        "hotkey": 6,
+        "abilityId": "LostVikings|61",
+        "icon": "storm_ui_ingame_heroselect_btn_lostvikings.png",
+        "type": "activable"
+      },
+      {
+        "uid": "a40d9c",
         "name": "Mortar",
         "description": "Fires a mortar at the targeted location, dealing 205 (+4% per level) damage in a large area.",
         "hotkey": "Q",
-        "abilityId": "The Lost Vikings|Q3",
+        "abilityId": "LostVikings|Q5",
         "cooldown": 3,
         "icon": "storm_ui_icon_lostvikings_mortar.png",
         "type": "basic"
       },
       {
-        "uid": "4313b63",
+        "uid": "39ea12",
+        "name": "Spin To Win!",
+        "description": "Activate to have each Viking deal 101 (+4% per level) damage to nearby enemies.",
+        "hotkey": "Q",
+        "abilityId": "LostVikings|Q6",
+        "cooldown": 10,
+        "icon": "storm_ui_icon_lostvikings_spintowin.png",
+        "type": "basic"
+      },
+      {
+        "uid": "c7798d",
+        "name": "Norse Force!",
+        "description": "All Vikings gain a 130 (+4% per level) to 260 (+4% per level) point Shield, increasing in strength for each Viking alive. Lasts 4 seconds.",
+        "hotkey": "Q",
+        "abilityId": "LostVikings|Q7",
+        "cooldown": 30,
+        "icon": "storm_ui_icon_lostvikings_norseforce.png",
+        "type": "basic"
+      },
+      {
+        "uid": "4fe3b3",
+        "name": "Jump!",
+        "description": "Makes all Vikings Invulnerable and able to pass over enemies for 1.5 seconds.",
+        "hotkey": "W",
+        "abilityId": "LostVikings|W5",
+        "cooldown": 30,
+        "icon": "storm_ui_icon_lostvikings_jump.png",
+        "type": "basic"
+      },
+      {
+        "uid": "c2cd44",
+        "name": "Nordic Attack Squad",
+        "description": "Activate to have all Viking Basic Attacks deal bonus damage equal to 1.25% of a Hero's maximum Health for 5 seconds.",
+        "hotkey": "W",
+        "abilityId": "LostVikings|W6",
+        "cooldown": 20,
+        "icon": "storm_ui_icon_talent_autoattack_damage.png",
+        "type": "basic"
+      },
+      {
+        "uid": "86ef1a",
+        "name": "Viking Bribery",
+        "description": "Enemy Minions or captured Mercenaries killed near The Lost Vikings grant stacks of Bribe. Use 40 stacks to bribe target Mercenary, instantly defeating them. Does not work on Elite Mercenaries. Maximum stacks available: 200. If a camp is defeated entirely with Bribe, the camp respawns 50% faster.  Current number of Bribe stacks: 0",
+        "hotkey": "E",
+        "abilityId": "LostVikings|E3",
+        "icon": "storm_ui_icon_talent_bribe.png",
+        "type": "basic"
+      },
+      {
+        "uid": "033e0a",
+        "name": "Play Again!",
+        "description": "Summon, fully heal, and revive all Lost Vikings at target location after a Viking channels for 2 seconds.  Only one Viking may attempt to summon at a time.",
+        "hotkey": "R",
+        "abilityId": "LostVikings|R5",
+        "cooldown": 80,
+        "icon": "storm_ui_icon_lostvikings_playagain.png",
+        "type": "heroic"
+      },
+      {
+        "uid": "e9f133",
+        "name": "Longboat Raid!",
+        "description": "Hop into an Unstoppable Longboat that fires at nearby enemies for 112 (+4% per level) damage per second and can fire a mortar that deals 205 (+4% per level) damage in an area.  The boat has increased Health for each Viking inside. If the boat is destroyed by enemies, all Vikings are stunned for 1.5 seconds. Lasts 15 seconds.  Requires all surviving Vikings to be nearby.",
+        "hotkey": "R",
+        "abilityId": "LostVikings|R6",
+        "cooldown": 90,
+        "icon": "storm_ui_icon_lostvikings_longboatraid.png",
+        "type": "heroic"
+      },
+      {
+        "uid": "74d859",
+        "name": "Go Go Go!",
+        "description": "The Vikings gain 30% increased Movement Speed for 4 seconds.",
+        "hotkey": "Z",
+        "abilityId": "LostVikings|Z3",
+        "cooldown": 30,
+        "icon": "storm_ui_icon_lostvikings_mount.png",
+        "type": "mount"
+      },
+      {
+        "uid": "f14745",
+        "name": "Select Erik",
+        "description": "Erik moves faster than the other Vikings and has increased Basic Attack range.",
+        "hotkey": 7,
+        "abilityId": "LostVikings|71",
+        "icon": "storm_ui_icon_lostvikings_selecterik.png",
+        "type": "activable"
+      },
+      {
+        "uid": "8da17f",
+        "name": "Select All Vikings",
+        "description": "The Lost Vikings can be controlled individually or as a group. Each Viking has particular strengths.",
+        "hotkey": 8,
+        "abilityId": "LostVikings|81",
+        "icon": "storm_ui_ingame_heroselect_btn_lostvikings.png",
+        "type": "activable"
+      },
+      {
+        "uid": "a40d9c",
+        "name": "Mortar",
+        "description": "Fires a mortar at the targeted location, dealing 205 (+4% per level) damage in a large area.",
+        "hotkey": "Q",
+        "abilityId": "LostVikings|Q8",
+        "cooldown": 3,
+        "icon": "storm_ui_icon_lostvikings_mortar.png",
+        "type": "basic"
+      },
+      {
+        "uid": "39ea12",
+        "name": "Spin To Win!",
+        "description": "Activate to have each Viking deal 101 (+4% per level) damage to nearby enemies.",
+        "hotkey": "Q",
+        "abilityId": "LostVikings|Q9",
+        "cooldown": 10,
+        "icon": "storm_ui_icon_lostvikings_spintowin.png",
+        "type": "basic"
+      },
+      {
+        "uid": "c7798d",
+        "name": "Norse Force!",
+        "description": "All Vikings gain a 130 (+4% per level) to 260 (+4% per level) point Shield, increasing in strength for each Viking alive. Lasts 4 seconds.",
+        "hotkey": "Q",
+        "abilityId": "LostVikings|Q10",
+        "cooldown": 30,
+        "icon": "storm_ui_icon_lostvikings_norseforce.png",
+        "type": "basic"
+      },
+      {
+        "uid": "4fe3b3",
+        "name": "Jump!",
+        "description": "Makes all Vikings Invulnerable and able to pass over enemies for 1.5 seconds.",
+        "hotkey": "W",
+        "abilityId": "LostVikings|W7",
+        "cooldown": 30,
+        "icon": "storm_ui_icon_lostvikings_jump.png",
+        "type": "basic"
+      },
+      {
+        "uid": "c2cd44",
+        "name": "Nordic Attack Squad",
+        "description": "Activate to have all Viking Basic Attacks deal bonus damage equal to 1.25% of a Hero's maximum Health for 5 seconds.",
+        "hotkey": "W",
+        "abilityId": "LostVikings|W8",
+        "cooldown": 20,
+        "icon": "storm_ui_icon_talent_autoattack_damage.png",
+        "type": "basic"
+      },
+      {
+        "uid": "86ef1a",
+        "name": "Viking Bribery",
+        "description": "Enemy Minions or captured Mercenaries killed near The Lost Vikings grant stacks of Bribe. Use 40 stacks to bribe target Mercenary, instantly defeating them. Does not work on Elite Mercenaries. Maximum stacks available: 200. If a camp is defeated entirely with Bribe, the camp respawns 50% faster.  Current number of Bribe stacks: 0",
+        "hotkey": "E",
+        "abilityId": "LostVikings|E4",
+        "icon": "storm_ui_icon_talent_bribe.png",
+        "type": "basic"
+      },
+      {
+        "uid": "033e0a",
+        "name": "Play Again!",
+        "description": "Summon, fully heal, and revive all Lost Vikings at target location after a Viking channels for 2 seconds.  Only one Viking may attempt to summon at a time.",
+        "hotkey": "R",
+        "abilityId": "LostVikings|R7",
+        "cooldown": 80,
+        "icon": "storm_ui_icon_lostvikings_playagain.png",
+        "type": "heroic"
+      },
+      {
+        "uid": "e9f133",
+        "name": "Longboat Raid!",
+        "description": "Hop into an Unstoppable Longboat that fires at nearby enemies for 112 (+4% per level) damage per second and can fire a mortar that deals 205 (+4% per level) damage in an area.  The boat has increased Health for each Viking inside. If the boat is destroyed by enemies, all Vikings are stunned for 1.5 seconds. Lasts 15 seconds.  Requires all surviving Vikings to be nearby.",
+        "hotkey": "R",
+        "abilityId": "LostVikings|R8",
+        "cooldown": 90,
+        "icon": "storm_ui_icon_lostvikings_longboatraid.png",
+        "type": "heroic"
+      },
+      {
+        "uid": "23fd3f",
         "name": "Viking Hoard",
         "description": "Gathering a Regeneration Globe with a Viking permanently increases all their Health Regeneration by 0.5 per second.  Current Bonus: 0 Regen per second",
         "trait": true,
-        "abilityId": "The Lost Vikings|D2",
+        "abilityId": "LostVikings|D4",
         "icon": "storm_ui_icon_lostvikings_vikinghoard.png",
         "type": "trait"
       },
       {
-        "uid": "f513e42",
-        "name": "Viking Hoard",
-        "description": "Gathering a Regeneration Globe with a Viking permanently increases all their Health Regeneration by 0.5 per second.  Current Bonus: 0 Regen per second",
-        "trait": true,
-        "abilityId": "The Lost Vikings|D1",
-        "icon": "storm_ui_icon_lostvikings_vikinghoard.png",
-        "type": "trait"
-      }
-    ],
-    "LostVikingsLongboatRaidNewer": [
+        "uid": "74d859",
+        "name": "Go Go Go!",
+        "description": "The Vikings gain 30% increased Movement Speed for 4 seconds.",
+        "hotkey": "Z",
+        "abilityId": "LostVikings|Z4",
+        "cooldown": 30,
+        "icon": "storm_ui_icon_lostvikings_mount.png",
+        "type": "mount"
+      },
       {
-        "uid": "8044936",
+        "uid": "66631d",
+        "name": "Select Olaf",
+        "description": "Olaf can charge enemies and slow their Movement Speed by 30% for 3 seconds by right-clicking on them. 8 second cooldown.  Olaf gains increased Health Regeneration when out of combat for 4 seconds.",
+        "hotkey": 9,
+        "abilityId": "LostVikings|91",
+        "icon": "storm_ui_icon_lostvikings_selectolaf.png",
+        "type": "activable"
+      },
+      {
+        "uid": "8da17f",
         "name": "Select All Vikings",
         "description": "The Lost Vikings can be controlled individually or as a group. Each Viking has particular strengths.",
-        "hotkey": "1",
-        "abilityId": "The Lost Vikings|12",
+        "hotkey": 10,
+        "abilityId": "LostVikings|101",
         "icon": "storm_ui_ingame_heroselect_btn_lostvikings.png",
-        "type": "subunit"
+        "type": "activable"
+      },
+      {
+        "uid": "a40d9c",
+        "name": "Mortar",
+        "description": "Fires a mortar at the targeted location, dealing 205 (+4% per level) damage in a large area.",
+        "hotkey": "Q",
+        "abilityId": "LostVikings|Q11",
+        "cooldown": 3,
+        "icon": "storm_ui_icon_lostvikings_mortar.png",
+        "type": "basic"
       }
     ]
   },
@@ -178,9 +500,9 @@
         "icon": "storm_ui_icon_lostvikings_selectolaf.png",
         "type": "Passive",
         "sort": 1,
-        "abilityId": "The Lost Vikings|Passive",
+        "abilityId": "LostVikings|Passive",
         "abilityLinks": [
-          "The Lost Vikings|11"
+          "LostVikings|91"
         ]
       },
       {
@@ -191,9 +513,9 @@
         "icon": "storm_ui_icon_lostvikings_selecterik.png",
         "type": "Passive",
         "sort": 2,
-        "abilityId": "The Lost Vikings|Passive",
+        "abilityId": "LostVikings|Passive",
         "abilityLinks": [
-          "The Lost Vikings|31"
+          "LostVikings|71"
         ]
       },
       {
@@ -204,9 +526,9 @@
         "icon": "storm_ui_icon_lostvikings_selectbaleog.png",
         "type": "Passive",
         "sort": 3,
-        "abilityId": "The Lost Vikings|Passive",
+        "abilityId": "LostVikings|Passive",
         "abilityLinks": [
-          "The Lost Vikings|21"
+          "LostVikings|51"
         ]
       },
       {
@@ -217,7 +539,7 @@
         "icon": "storm_ui_icon_talent_bribe.png",
         "type": "Active",
         "sort": 4,
-        "abilityId": "The Lost Vikings|Active"
+        "abilityId": "LostVikings|Active"
       }
     ],
     "4": [
@@ -229,9 +551,9 @@
         "icon": "storm_ui_icon_lostvikings_selectbaleog.png",
         "type": "Passive",
         "sort": 1,
-        "abilityId": "The Lost Vikings|Passive",
+        "abilityId": "LostVikings|Passive",
         "abilityLinks": [
-          "The Lost Vikings|21"
+          "LostVikings|51"
         ]
       },
       {
@@ -242,9 +564,9 @@
         "icon": "storm_ui_icon_lostvikings_selecterik.png",
         "type": "Passive",
         "sort": 2,
-        "abilityId": "The Lost Vikings|Passive",
+        "abilityId": "LostVikings|Passive",
         "abilityLinks": [
-          "The Lost Vikings|31"
+          "LostVikings|71"
         ]
       },
       {
@@ -255,9 +577,9 @@
         "icon": "storm_ui_icon_lostvikings_selecterik_var1.png",
         "type": "Passive",
         "sort": 3,
-        "abilityId": "The Lost Vikings|Passive",
+        "abilityId": "LostVikings|Passive",
         "abilityLinks": [
-          "The Lost Vikings|31"
+          "LostVikings|71"
         ]
       },
       {
@@ -268,7 +590,7 @@
         "icon": "storm_ui_icon_talent_mercenarylord.png",
         "type": "Passive",
         "sort": 4,
-        "abilityId": "The Lost Vikings|Passive"
+        "abilityId": "LostVikings|Passive"
       }
     ],
     "7": [
@@ -280,9 +602,9 @@
         "icon": "storm_ui_icon_lostvikings_selectbaleog.png",
         "type": "Passive",
         "sort": 1,
-        "abilityId": "The Lost Vikings|Passive",
+        "abilityId": "LostVikings|Passive",
         "abilityLinks": [
-          "The Lost Vikings|21"
+          "LostVikings|51"
         ]
       },
       {
@@ -294,7 +616,7 @@
         "type": "Active",
         "sort": 2,
         "cooldown": 10,
-        "abilityId": "The Lost Vikings|Active"
+        "abilityId": "LostVikings|Active"
       },
       {
         "tooltipId": "LostVikingsNorseForce",
@@ -305,7 +627,7 @@
         "type": "Active",
         "sort": 3,
         "cooldown": 30,
-        "abilityId": "The Lost Vikings|Active"
+        "abilityId": "LostVikings|Active"
       }
     ],
     "10": [
@@ -318,9 +640,9 @@
         "type": "Heroic",
         "sort": 1,
         "cooldown": 90,
-        "abilityId": "The Lost Vikings|R1",
+        "abilityId": "LostVikings|R8",
         "abilityLinks": [
-          "The Lost Vikings|R1"
+          "LostVikings|R8"
         ]
       },
       {
@@ -332,9 +654,9 @@
         "type": "Heroic",
         "sort": 2,
         "cooldown": 80,
-        "abilityId": "The Lost Vikings|R2",
+        "abilityId": "LostVikings|R7",
         "abilityLinks": [
-          "The Lost Vikings|R2"
+          "LostVikings|R7"
         ]
       }
     ],
@@ -347,9 +669,9 @@
         "icon": "storm_ui_icon_lostvikings_selectolaf.png",
         "type": "Passive",
         "sort": 1,
-        "abilityId": "The Lost Vikings|Passive",
+        "abilityId": "LostVikings|Passive",
         "abilityLinks": [
-          "The Lost Vikings|11"
+          "LostVikings|91"
         ]
       },
       {
@@ -361,7 +683,7 @@
         "type": "Active",
         "sort": 2,
         "cooldown": 30,
-        "abilityId": "The Lost Vikings|Active"
+        "abilityId": "LostVikings|Active"
       },
       {
         "tooltipId": "LostVikingsNordicAttackSquad",
@@ -372,7 +694,7 @@
         "type": "Active",
         "sort": 3,
         "cooldown": 20,
-        "abilityId": "The Lost Vikings|Active"
+        "abilityId": "LostVikings|Active"
       }
     ],
     "16": [
@@ -384,9 +706,9 @@
         "icon": "storm_ui_icon_lostvikings_selectolaf.png",
         "type": "Passive",
         "sort": 1,
-        "abilityId": "The Lost Vikings|Passive",
+        "abilityId": "LostVikings|Passive",
         "abilityLinks": [
-          "The Lost Vikings|11"
+          "LostVikings|91"
         ]
       },
       {
@@ -397,7 +719,7 @@
         "icon": "storm_ui_icon_talent_autoattack_cooldown.png",
         "type": "Passive",
         "sort": 2,
-        "abilityId": "The Lost Vikings|Passive"
+        "abilityId": "LostVikings|Passive"
       },
       {
         "tooltipId": "LostVikingsGoGoGo64KBMarathonTalent",
@@ -407,9 +729,9 @@
         "icon": "storm_ui_icon_lostvikings_64kbmarathon.png",
         "type": "Z",
         "sort": 3,
-        "abilityId": "The Lost Vikings|Z1",
+        "abilityId": "LostVikings|Z4",
         "abilityLinks": [
-          "The Lost Vikings|Z1"
+          "LostVikings|Z4"
         ]
       },
       {
@@ -420,7 +742,7 @@
         "icon": "storm_ui_icon_talent_autoattack_damage.png",
         "type": "Passive",
         "sort": 4,
-        "abilityId": "The Lost Vikings|Passive"
+        "abilityId": "LostVikings|Passive"
       }
     ],
     "20": [
@@ -432,9 +754,9 @@
         "icon": "storm_ui_icon_lostvikings_longboatraid.png",
         "type": "Heroic",
         "sort": 1,
-        "abilityId": "The Lost Vikings|R1",
+        "abilityId": "LostVikings|R8",
         "abilityLinks": [
-          "The Lost Vikings|R1"
+          "LostVikings|R8"
         ]
       },
       {
@@ -445,9 +767,9 @@
         "icon": "storm_ui_icon_lostvikings_playagain.png",
         "type": "Heroic",
         "sort": 2,
-        "abilityId": "The Lost Vikings|R2",
+        "abilityId": "LostVikings|R7",
         "abilityLinks": [
-          "The Lost Vikings|R2"
+          "LostVikings|R7"
         ]
       },
       {
@@ -458,9 +780,9 @@
         "icon": "storm_ui_icon_lostvikings_fastrestart.png",
         "type": "Trait",
         "sort": 3,
-        "abilityId": "The Lost Vikings|D2",
+        "abilityId": "LostVikings|D4",
         "abilityLinks": [
-          "The Lost Vikings|D2"
+          "LostVikings|D4"
         ]
       },
       {
@@ -471,7 +793,7 @@
         "icon": "storm_ui_icon_talent_autoattack_damage.png",
         "type": "Passive",
         "sort": 4,
-        "abilityId": "The Lost Vikings|Passive"
+        "abilityId": "LostVikings|Passive"
       }
     ]
   }

--- a/hero/ltmorales.json
+++ b/hero/ltmorales.json
@@ -113,9 +113,8 @@
         "type": "E",
         "sort": 3,
         "isQuest": true,
-        "abilityId": "LtMorales|E2",
+        "abilityId": "LtMorales|E1",
         "abilityLinks": [
-          "LtMorales|E2",
           "LtMorales|E1"
         ]
       }
@@ -249,9 +248,8 @@
         "icon": "storm_ui_icon_medic_displacementgrenade_b.png",
         "type": "E",
         "sort": 2,
-        "abilityId": "LtMorales|E2",
+        "abilityId": "LtMorales|E1",
         "abilityLinks": [
-          "LtMorales|E2",
           "LtMorales|E1"
         ]
       },
@@ -278,9 +276,8 @@
         "icon": "storm_ui_icon_medic_healingbeam.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "LtMorales|Q2",
+        "abilityId": "LtMorales|Q1",
         "abilityLinks": [
-          "LtMorales|Q2",
           "LtMorales|Q1"
         ]
       },
@@ -292,9 +289,8 @@
         "icon": "storm_ui_icon_medic_healingbeam_c.png",
         "type": "Q",
         "sort": 2,
-        "abilityId": "LtMorales|Q2",
+        "abilityId": "LtMorales|Q1",
         "abilityLinks": [
-          "LtMorales|Q2",
           "LtMorales|Q1"
         ]
       },

--- a/hero/ltmorales.json
+++ b/hero/ltmorales.json
@@ -1,5 +1,5 @@
 {
-  "id": "42",
+  "id": 42,
   "shortName": "ltmorales",
   "attributeId": "Medi",
   "cHeroId": "Medic",
@@ -17,65 +17,63 @@
     "RoleSupport"
   ],
   "abilities": {
-    "Lt. Morales": [
+    "LtMorales": [
       {
-        "uid": "b8ecaa3",
+        "uid": "cd68c0",
         "name": "Healing Beam",
         "description": "Heal target allied Hero or Minion for 172 (+4% per level) Health per second as long as they are in range. After not channeling Healing Beam for 2 seconds, regenerate 6 Energy per second.  Reactivate to switch targets, or self-cast to cancel channeling.",
         "hotkey": "Q",
-        "abilityId": "Lt. Morales|Q1",
-        "cooldown": 1,
-        "manaCost": 6,
-        "manaPerSecond": true,
+        "abilityId": "LtMorales|Q1",
+        "manaCost": "second",
         "icon": "storm_ui_icon_medic_healingbeam.png",
         "type": "basic"
       },
       {
-        "uid": "b4c083c",
+        "uid": "ed0253",
         "name": "Safeguard",
         "description": "Grant target ally Hero 30 Armor for 3 seconds.",
         "hotkey": "W",
-        "abilityId": "Lt. Morales|W1",
+        "abilityId": "LtMorales|W1",
         "cooldown": 11,
         "icon": "storm_ui_icon_medic_deployshield.png",
         "type": "basic"
       },
       {
-        "uid": "4969c58",
+        "uid": "d95f16",
         "name": "Displacement Grenade",
         "description": "Fire a grenade that can be manually detonated, dealing 208 (+4% per level) to nearby enemies and knocking them away.",
         "hotkey": "E",
-        "abilityId": "Lt. Morales|E1",
+        "abilityId": "LtMorales|E1",
         "cooldown": 12,
         "icon": "storm_ui_icon_medic_displacementgrenade.png",
         "type": "basic"
       },
       {
-        "uid": "0506b6d",
+        "uid": "85f242",
         "name": "Stim Drone",
         "description": "Grant an allied Hero 75% Attack Speed and 25% Movement Speed for 10 seconds.",
         "hotkey": "R",
-        "abilityId": "Lt. Morales|R1",
+        "abilityId": "LtMorales|R1",
         "cooldown": 90,
         "icon": "storm_ui_icon_medic_stim.png",
         "type": "heroic"
       },
       {
-        "uid": "5afa053",
+        "uid": "7ecd6d",
         "name": "Medivac Dropship",
         "description": "Target a location for a Medivac transport. For up to 10 seconds before takeoff, allies can right-click to enter the Medivac.",
         "hotkey": "R",
-        "abilityId": "Lt. Morales|R2",
+        "abilityId": "LtMorales|R2",
         "cooldown": 60,
         "icon": "storm_ui_icon_medic_medivacdropship.png",
         "type": "heroic"
       },
       {
-        "uid": "3274517",
+        "uid": "a1038e",
         "name": "Caduceus Reactor",
         "description": "While channeling Healing Beam, Lt. Morales regenerates 2% of her maximum Health per second.",
         "trait": true,
-        "abilityId": "Lt. Morales|D1",
+        "abilityId": "LtMorales|D1",
         "icon": "storm_ui_icon_medic_caduceusreactor.png",
         "type": "trait"
       }
@@ -91,7 +89,7 @@
         "icon": "storm_ui_icon_talent_autoattack_mana.png",
         "type": "Passive",
         "sort": 1,
-        "abilityId": "Lt. Morales|Passive"
+        "abilityId": "LtMorales|Passive"
       },
       {
         "tooltipId": "MedicLifeSupport",
@@ -101,9 +99,9 @@
         "icon": "storm_ui_icon_medic_deployshield.png",
         "type": "W",
         "sort": 2,
-        "abilityId": "Lt. Morales|W1",
+        "abilityId": "LtMorales|W1",
         "abilityLinks": [
-          "Lt. Morales|W1"
+          "LtMorales|W1"
         ]
       },
       {
@@ -115,9 +113,10 @@
         "type": "E",
         "sort": 3,
         "isQuest": true,
-        "abilityId": "Lt. Morales|E1",
+        "abilityId": "LtMorales|E2",
         "abilityLinks": [
-          "Lt. Morales|E1"
+          "LtMorales|E2",
+          "LtMorales|E1"
         ]
       }
     ],
@@ -131,7 +130,7 @@
         "type": "Active",
         "sort": 1,
         "cooldown": 45,
-        "abilityId": "Lt. Morales|Active"
+        "abilityId": "LtMorales|Active"
       },
       {
         "tooltipId": "MedicTraumaTriggerTalent",
@@ -141,7 +140,7 @@
         "icon": "storm_ui_icon_medic_advancedblock.png",
         "type": "Passive",
         "sort": 2,
-        "abilityId": "Lt. Morales|Passive"
+        "abilityId": "LtMorales|Passive"
       },
       {
         "tooltipId": "MedicBlastShield",
@@ -151,9 +150,9 @@
         "icon": "storm_ui_icon_medic_displacementgrenade.png",
         "type": "E",
         "sort": 3,
-        "abilityId": "Lt. Morales|E1",
+        "abilityId": "LtMorales|E1",
         "abilityLinks": [
-          "Lt. Morales|E1"
+          "LtMorales|E1"
         ]
       }
     ],
@@ -166,35 +165,35 @@
         "icon": "storm_ui_icon_medic_deployshield.png",
         "type": "W",
         "sort": 1,
-        "abilityId": "Lt. Morales|W1",
+        "abilityId": "LtMorales|W1",
         "abilityLinks": [
-          "Lt. Morales|W1"
+          "LtMorales|W1"
         ]
       },
       {
         "tooltipId": "MedicVanadiumPlating",
         "talentTreeId": "MedicVanadiumPlating",
         "name": "Vanadium Plating",
-        "description": "While an ally affected by Safeguard is Stunned or Rooted, Safeguard grants an additional 25 Armor and its duration is paused.",
-        "icon": "storm_ui_icon_medic_deployshield_b.png",
+        "description": "Passive: Increase the duration of Safeguard by 1 second.  While an ally affected by Safeguard is Stunned or Rooted, Safeguard grants an additional 20 Armor.",
+        "icon": "storm_ui_icon_medic_deployshield_c.png",
         "type": "W",
         "sort": 2,
-        "abilityId": "Lt. Morales|W1",
+        "abilityId": "LtMorales|W1",
         "abilityLinks": [
-          "Lt. Morales|W1"
+          "LtMorales|W1"
         ]
       },
       {
-        "tooltipId": "MedicProlongedSafeguard",
-        "talentTreeId": "MedicProlongedSafeguard",
-        "name": "Prolonged Safeguard",
-        "description": "Increase Safeguard's duration by 50%.",
-        "icon": "storm_ui_icon_medic_deployshield_c.png",
+        "tooltipId": "MedicMediDrone",
+        "talentTreeId": "MedicMediDrone",
+        "name": "Medi-Drone",
+        "description": "Allies with Safeguard receive 50% of the healing done by Healing Beam on another ally.",
+        "icon": "storm_ui_icon_medic_deployshield_b.png",
         "type": "W",
         "sort": 3,
-        "abilityId": "Lt. Morales|W1",
+        "abilityId": "LtMorales|W1",
         "abilityLinks": [
-          "Lt. Morales|W1"
+          "LtMorales|W1"
         ]
       }
     ],
@@ -208,9 +207,9 @@
         "type": "Heroic",
         "sort": 1,
         "cooldown": 90,
-        "abilityId": "Lt. Morales|R1",
+        "abilityId": "LtMorales|R1",
         "abilityLinks": [
-          "Lt. Morales|R1"
+          "LtMorales|R1"
         ]
       },
       {
@@ -222,9 +221,9 @@
         "type": "Heroic",
         "sort": 2,
         "cooldown": 60,
-        "abilityId": "Lt. Morales|R2",
+        "abilityId": "LtMorales|R2",
         "abilityLinks": [
-          "Lt. Morales|R2"
+          "LtMorales|R2"
         ]
       }
     ],
@@ -237,9 +236,9 @@
         "icon": "storm_ui_icon_medic_displacementgrenade.png",
         "type": "E",
         "sort": 1,
-        "abilityId": "Lt. Morales|E1",
+        "abilityId": "LtMorales|E1",
         "abilityLinks": [
-          "Lt. Morales|E1"
+          "LtMorales|E1"
         ]
       },
       {
@@ -250,9 +249,10 @@
         "icon": "storm_ui_icon_medic_displacementgrenade_b.png",
         "type": "E",
         "sort": 2,
-        "abilityId": "Lt. Morales|E1",
+        "abilityId": "LtMorales|E2",
         "abilityLinks": [
-          "Lt. Morales|E1"
+          "LtMorales|E2",
+          "LtMorales|E1"
         ]
       },
       {
@@ -263,9 +263,9 @@
         "icon": "storm_ui_icon_medic_displacementgrenade_c.png",
         "type": "E",
         "sort": 3,
-        "abilityId": "Lt. Morales|E1",
+        "abilityId": "LtMorales|E1",
         "abilityLinks": [
-          "Lt. Morales|E1"
+          "LtMorales|E1"
         ]
       }
     ],
@@ -278,9 +278,10 @@
         "icon": "storm_ui_icon_medic_healingbeam.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "Lt. Morales|Q1",
+        "abilityId": "LtMorales|Q2",
         "abilityLinks": [
-          "Lt. Morales|Q1"
+          "LtMorales|Q2",
+          "LtMorales|Q1"
         ]
       },
       {
@@ -291,9 +292,10 @@
         "icon": "storm_ui_icon_medic_healingbeam_c.png",
         "type": "Q",
         "sort": 2,
-        "abilityId": "Lt. Morales|Q1",
+        "abilityId": "LtMorales|Q2",
         "abilityLinks": [
-          "Lt. Morales|Q1"
+          "LtMorales|Q2",
+          "LtMorales|Q1"
         ]
       },
       {
@@ -304,9 +306,9 @@
         "icon": "storm_ui_icon_medic_deployshield.png",
         "type": "W",
         "sort": 3,
-        "abilityId": "Lt. Morales|W1",
+        "abilityId": "LtMorales|W1",
         "abilityLinks": [
-          "Lt. Morales|W1"
+          "LtMorales|W1"
         ]
       }
     ],
@@ -319,9 +321,9 @@
         "icon": "storm_ui_icon_medic_stim.png",
         "type": "Heroic",
         "sort": 1,
-        "abilityId": "Lt. Morales|R1",
+        "abilityId": "LtMorales|R1",
         "abilityLinks": [
-          "Lt. Morales|R1"
+          "LtMorales|R1"
         ]
       },
       {
@@ -332,9 +334,9 @@
         "icon": "storm_ui_icon_medic_medivacdropship.png",
         "type": "Heroic",
         "sort": 2,
-        "abilityId": "Lt. Morales|R2",
+        "abilityId": "LtMorales|R2",
         "abilityLinks": [
-          "Lt. Morales|R2"
+          "LtMorales|R2"
         ]
       },
       {
@@ -346,9 +348,9 @@
         "type": "Active",
         "sort": 3,
         "cooldown": 30,
-        "abilityId": "Lt. Morales|R2",
+        "abilityId": "LtMorales|Active",
         "abilityLinks": [
-          "Lt. Morales|R2"
+          "LtMorales|R2"
         ]
       },
       {
@@ -359,9 +361,9 @@
         "icon": "storm_ui_icon_medic_caduceusreactor.png",
         "type": "Trait",
         "sort": 4,
-        "abilityId": "Lt. Morales|D1",
+        "abilityId": "LtMorales|D1",
         "abilityLinks": [
-          "Lt. Morales|D1"
+          "LtMorales|D1"
         ]
       }
     ]

--- a/hero/lucio.json
+++ b/hero/lucio.json
@@ -1,5 +1,5 @@
 {
-  "id": "63",
+  "id": 63,
   "shortName": "lucio",
   "attributeId": "Luci",
   "cHeroId": "Lucio",
@@ -20,88 +20,89 @@
     "SelfHealer"
   ],
   "abilities": {
-    "Lúcio": [
+    "Lucio": [
       {
-        "uid": "44ed254",
+        "uid": "d9b44f",
         "name": "Soundwave",
         "description": "Deal 105 (+4% per level) damage to enemies in an area and knock them back.",
         "hotkey": "Q",
-        "abilityId": "Lúcio|Q1",
+        "abilityId": "Lucio|Q1",
         "cooldown": 7,
         "manaCost": 30,
         "icon": "storm_ui_icon_lucio_soundwave.png",
         "type": "basic"
       },
       {
-        "uid": "3a4b93e",
+        "uid": "219d28",
+        "name": "Crossfade",
+        "description": "Currently playing Speed Boost, increasing the Movement Speed of Lúcio and nearby allied Heroes by 10%.  Toggle to play Healing Boost instead.",
+        "hotkey": "W",
+        "abilityId": "Lucio|W1",
+        "icon": "storm_ui_icon_lucio_crossfadehealing.png",
+        "type": "basic"
+      },
+      {
+        "uid": "bb4eb8",
         "name": "Amp It Up",
         "description": "Raise Lúcio's Crossfade track volume for 3 seconds, amping Healing Boost to 112 (+4% per level) Health per second and Speed Boost to 30% increased Movement Speed.",
         "hotkey": "E",
-        "abilityId": "Lúcio|E1",
+        "abilityId": "Lucio|E1",
         "cooldown": 13,
         "manaCost": 90,
         "icon": "storm_ui_icon_lucio_ampitup.png",
         "type": "basic"
       },
       {
-        "uid": "11a3cf4",
+        "uid": "4d5292",
         "name": "Sound Barrier",
         "description": "After 1 second, Lúcio and nearby allied Heroes gain a 1296 (+4% per level) point Shield that rapidly decays over 6 seconds.",
         "hotkey": "R",
-        "abilityId": "Lúcio|R1",
+        "abilityId": "Lucio|R1",
         "cooldown": 80,
         "manaCost": 100,
         "icon": "storm_ui_icon_lucio_soundbarrier.png",
         "type": "heroic"
       },
       {
-        "uid": "4584f34",
-        "name": "Wall Ride",
-        "description": "When moving alongside terrain, Lúcio begins to Wall Ride for 2 seconds. While Wall Ride is active, Lúcio can walk through units and gains 20% Movement Speed that stacks with other bonuses.",
-        "abilityId": "Lúcio|Z1",
-        "icon": "storm_ui_icon_lucio_mount.png",
-        "type": "mount"
-      },
-      {
-        "uid": "0b5cf08",
+        "uid": "fb6e89",
         "name": "High Five",
         "description": "Quickly skate to an allied Hero. Upon arrival, the ally is granted Unstoppable for 1 second and is healed for 250 (+4% per level).",
         "hotkey": "R",
-        "abilityId": "Lúcio|R2",
+        "abilityId": "Lucio|R2",
         "cooldown": 15,
         "manaCost": 35,
         "icon": "storm_ui_icon_lucio_highfive.png",
         "type": "heroic"
       },
       {
-        "uid": "4a6faa2",
+        "uid": "65fa01",
         "name": "Push Off",
         "description": "While moving alongside terrain, activate to slide towards a targeted location. Enemies hit take 100 (+4% per level) damage and are Slowed by 75% for 1 second.",
         "trait": true,
-        "abilityId": "Lúcio|D1",
+        "abilityId": "Lucio|D1",
         "cooldown": 20,
         "icon": "storm_ui_icon_lucio_accelerando.png",
         "type": "trait"
       },
       {
-        "uid": "c891e16",
-        "name": "Crossfade",
-        "description": "Currently playing Speed Boost, increasing the Movement Speed of Lúcio and nearby allied Heroes by 10%.  Toggle to play Healing Boost instead.",
-        "hotkey": "W",
-        "abilityId": "Lúcio|W1",
-        "icon": "storm_ui_icon_lucio_crossfadehealing.png",
-        "type": "basic"
+        "uid": "169f23",
+        "name": "Wall Ride",
+        "description": "When moving alongside terrain, Lúcio begins to Wall Ride for 2 seconds. While Wall Ride is active, Lúcio can walk through units and gains 20% Movement Speed that stacks with other bonuses.",
+        "hotkey": "Z",
+        "abilityId": "Lucio|Z1",
+        "icon": "storm_ui_icon_lucio_mount.png",
+        "type": "mount"
       }
     ],
     "LucioCrossfade": [
       {
-        "uid": "bede789",
+        "uid": "07a7bb",
         "name": "Crossfade",
         "description": "Currently playing Healing Boost, passively healing Lúcio and nearby allied Heroes for 15 (+4% per level) Health per second.  Toggle to play Speed Boost instead.",
         "hotkey": "W",
-        "abilityId": "Lúcio|W2",
+        "abilityId": "Lucio|W2",
         "icon": "storm_ui_icon_lucio_crossfadespeed.png",
-        "type": "subunit"
+        "type": "basic"
       }
     ]
   },
@@ -116,9 +117,9 @@
         "type": "W",
         "sort": 1,
         "isQuest": true,
-        "abilityId": "Lúcio|W2",
+        "abilityId": "Lucio|W2",
         "abilityLinks": [
-          "Lúcio|W2"
+          "Lucio|W2"
         ]
       },
       {
@@ -129,9 +130,9 @@
         "icon": "storm_ui_icon_lucio_wallride.png",
         "type": "Z",
         "sort": 2,
-        "abilityId": "Lúcio|Z1",
+        "abilityId": "Lucio|Z1",
         "abilityLinks": [
-          "Lúcio|Z1"
+          "Lucio|Z1"
         ]
       },
       {
@@ -142,9 +143,9 @@
         "icon": "storm_ui_icon_lucio_wallride_a.png",
         "type": "Z",
         "sort": 3,
-        "abilityId": "Lúcio|Z1",
+        "abilityId": "Lucio|Z1",
         "abilityLinks": [
-          "Lúcio|Z1"
+          "Lucio|Z1"
         ]
       }
     ],
@@ -158,9 +159,9 @@
         "type": "Q",
         "sort": 1,
         "isQuest": true,
-        "abilityId": "Lúcio|Q1",
+        "abilityId": "Lucio|Q1",
         "abilityLinks": [
-          "Lúcio|Q1"
+          "Lucio|Q1"
         ]
       },
       {
@@ -171,9 +172,9 @@
         "icon": "storm_ui_icon_lucio_soundwave_a.png",
         "type": "Q",
         "sort": 2,
-        "abilityId": "Lúcio|Q1",
+        "abilityId": "Lucio|Q1",
         "abilityLinks": [
-          "Lúcio|Q1"
+          "Lucio|Q1"
         ]
       },
       {
@@ -184,9 +185,9 @@
         "icon": "storm_ui_icon_lucio_accelerando.png",
         "type": "Trait",
         "sort": 3,
-        "abilityId": "Lúcio|D1",
+        "abilityId": "Lucio|D1",
         "abilityLinks": [
-          "Lúcio|D1"
+          "Lucio|D1"
         ]
       }
     ],
@@ -199,9 +200,9 @@
         "icon": "storm_ui_icon_lucio_soundwave_a.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "Lúcio|Q1",
+        "abilityId": "Lucio|Q1",
         "abilityLinks": [
-          "Lúcio|Q1"
+          "Lucio|Q1"
         ]
       },
       {
@@ -212,10 +213,9 @@
         "icon": "storm_ui_icon_lucio_crossfade_all.png",
         "type": "W",
         "sort": 2,
-        "cooldown": 45,
-        "abilityId": "Lúcio|W2",
+        "abilityId": "Lucio|W2",
         "abilityLinks": [
-          "Lúcio|W2"
+          "Lucio|W2"
         ]
       },
       {
@@ -227,7 +227,7 @@
         "type": "Active",
         "sort": 3,
         "cooldown": 20,
-        "abilityId": "Lúcio|Active"
+        "abilityId": "Lucio|Active"
       }
     ],
     "10": [
@@ -240,9 +240,9 @@
         "type": "Heroic",
         "sort": 1,
         "cooldown": 80,
-        "abilityId": "Lúcio|R1",
+        "abilityId": "Lucio|R1",
         "abilityLinks": [
-          "Lúcio|R1"
+          "Lucio|R1"
         ]
       },
       {
@@ -254,9 +254,9 @@
         "type": "Heroic",
         "sort": 2,
         "cooldown": 15,
-        "abilityId": "Lúcio|R2",
+        "abilityId": "Lucio|R2",
         "abilityLinks": [
-          "Lúcio|R2"
+          "Lucio|R2"
         ]
       }
     ],
@@ -269,9 +269,9 @@
         "icon": "storm_ui_icon_lucio_crossfade_all.png",
         "type": "W",
         "sort": 1,
-        "abilityId": "Lúcio|W2",
+        "abilityId": "Lucio|W2",
         "abilityLinks": [
-          "Lúcio|W2"
+          "Lucio|W2"
         ]
       },
       {
@@ -282,9 +282,9 @@
         "icon": "storm_ui_icon_lucio_accelerando.png",
         "type": "Trait",
         "sort": 2,
-        "abilityId": "Lúcio|D1",
+        "abilityId": "Lucio|D1",
         "abilityLinks": [
-          "Lúcio|D1"
+          "Lucio|D1"
         ]
       },
       {
@@ -295,9 +295,9 @@
         "icon": "storm_ui_icon_lucio_wallride.png",
         "type": "Z",
         "sort": 3,
-        "abilityId": "Lúcio|Z1",
+        "abilityId": "Lucio|Z1",
         "abilityLinks": [
-          "Lúcio|Z1"
+          "Lucio|Z1"
         ]
       }
     ],
@@ -310,9 +310,9 @@
         "icon": "storm_ui_icon_lucio_ampitup.png",
         "type": "E",
         "sort": 1,
-        "abilityId": "Lúcio|E1",
+        "abilityId": "Lucio|E1",
         "abilityLinks": [
-          "Lúcio|E1"
+          "Lucio|E1"
         ]
       },
       {
@@ -323,9 +323,9 @@
         "icon": "storm_ui_icon_lucio_ampitup_b.png",
         "type": "E",
         "sort": 2,
-        "abilityId": "Lúcio|E1",
+        "abilityId": "Lucio|E1",
         "abilityLinks": [
-          "Lúcio|E1"
+          "Lucio|E1"
         ]
       },
       {
@@ -337,7 +337,7 @@
         "type": "Active",
         "sort": 3,
         "cooldown": 60,
-        "abilityId": "Lúcio|Active"
+        "abilityId": "Lucio|Active"
       }
     ],
     "20": [
@@ -349,9 +349,9 @@
         "icon": "storm_ui_icon_lucio_soundbarrier.png",
         "type": "Heroic",
         "sort": 1,
-        "abilityId": "Lúcio|R1",
+        "abilityId": "Lucio|R1",
         "abilityLinks": [
-          "Lúcio|R1"
+          "Lucio|R1"
         ]
       },
       {
@@ -362,9 +362,9 @@
         "icon": "storm_ui_icon_lucio_highfive.png",
         "type": "Heroic",
         "sort": 2,
-        "abilityId": "Lúcio|R2",
+        "abilityId": "Lucio|R2",
         "abilityLinks": [
-          "Lúcio|R2"
+          "Lucio|R2"
         ]
       },
       {
@@ -375,9 +375,9 @@
         "icon": "storm_ui_icon_lucio_crossfade_all.png",
         "type": "W",
         "sort": 3,
-        "abilityId": "Lúcio|W2",
+        "abilityId": "Lucio|W2",
         "abilityLinks": [
-          "Lúcio|W2"
+          "Lucio|W2"
         ]
       },
       {
@@ -389,9 +389,9 @@
         "type": "Active",
         "sort": 4,
         "cooldown": 75,
-        "abilityId": "Lúcio|W2",
+        "abilityId": "Lucio|Active",
         "abilityLinks": [
-          "Lúcio|W2"
+          "Lucio|W2"
         ]
       }
     ]

--- a/hero/lunara.json
+++ b/hero/lunara.json
@@ -104,9 +104,8 @@
         "icon": "storm_ui_icon_lunara_wisp.png",
         "type": "E",
         "sort": 1,
-        "abilityId": "Lunara|E2",
+        "abilityId": "Lunara|E1",
         "abilityLinks": [
-          "Lunara|E2",
           "Lunara|E1"
         ]
       },
@@ -131,9 +130,8 @@
         "icon": "storm_ui_icon_lunara_boundlessstride_a.png",
         "type": "Z",
         "sort": 3,
-        "abilityId": "Lunara|Z2",
+        "abilityId": "Lunara|Z1",
         "abilityLinks": [
-          "Lunara|Z2",
           "Lunara|Z1"
         ]
       }

--- a/hero/lunara.json
+++ b/hero/lunara.json
@@ -1,5 +1,5 @@
 {
-  "id": "46",
+  "id": 46,
   "shortName": "lunara",
   "attributeId": "Drya",
   "cHeroId": "Dryad",
@@ -21,7 +21,7 @@
   "abilities": {
     "Lunara": [
       {
-        "uid": "e709daa",
+        "uid": "333ffe",
         "name": "Noxious Blossom",
         "description": "After 0.5 seconds, cause an area to explode with pollen dealing 160 (+4% per level) damage.",
         "hotkey": "Q",
@@ -32,7 +32,7 @@
         "type": "basic"
       },
       {
-        "uid": "9eebbfb",
+        "uid": "03ec56",
         "name": "Crippling Spores",
         "description": "Enemies currently afflicted by Nature's Toxin have its duration increased by 3 seconds and are Slowed by 40% decaying over 3 seconds.",
         "hotkey": "W",
@@ -43,7 +43,7 @@
         "type": "basic"
       },
       {
-        "uid": "4c69179",
+        "uid": "0b8564",
         "name": "Wisp",
         "description": "Spawn a Wisp to scout an area. Can be redirected once active. When the Wisp is in a bush for more 2 seconds, its vision radius is increased by 75%.  Lasts 45 seconds.",
         "hotkey": "E",
@@ -53,7 +53,7 @@
         "type": "basic"
       },
       {
-        "uid": "75a8b15",
+        "uid": "e13b16",
         "name": "Thornwood Vine",
         "description": "Send forth vines that deal 176 (+4% per level) damage to all enemies in a line.  Stores up to 3 charges.",
         "hotkey": "R",
@@ -64,7 +64,7 @@
         "type": "heroic"
       },
       {
-        "uid": "7d220f7",
+        "uid": "4fb100",
         "name": "Leaping Strike",
         "description": "Leap over an enemy, Slowing them by 80% for 0.35 seconds and dealing 271 (+4% per level) damage.  Stores up to 2 charges.",
         "hotkey": "R",
@@ -75,7 +75,7 @@
         "type": "heroic"
       },
       {
-        "uid": "45d35fe",
+        "uid": "18d607",
         "name": "Nature's Toxin",
         "description": "Lunara's Basic Attacks and damaging Abilities poison their target, dealing 30 (+5% per level) damage a second for 3 seconds. Every additional application increases the duration by 3 seconds, up to a maximum of 9 seconds.",
         "trait": true,
@@ -84,9 +84,10 @@
         "type": "trait"
       },
       {
-        "uid": "56ea45f",
+        "uid": "a41cea",
         "name": "Dryad's Swiftness",
         "description": "Lunara moves 20% faster by leaping short distances.",
+        "hotkey": "Z",
         "abilityId": "Lunara|Z1",
         "icon": "storm_ui_icon_lunara_mount.png",
         "type": "mount"
@@ -103,10 +104,10 @@
         "icon": "storm_ui_icon_lunara_wisp.png",
         "type": "E",
         "sort": 1,
-        "abilityId": "Lunara|E1",
+        "abilityId": "Lunara|E2",
         "abilityLinks": [
-          "Lunara|E1",
-          "Lunara|E2"
+          "Lunara|E2",
+          "Lunara|E1"
         ]
       },
       {
@@ -387,10 +388,10 @@
         "icon": "storm_ui_icon_lunara_stiflingblossom.png",
         "type": "Trait",
         "sort": 3,
-        "abilityId": "Lunara|Q1",
+        "abilityId": "Lunara|D1",
         "abilityLinks": [
-          "Lunara|Q1",
-          "Lunara|D1"
+          "Lunara|D1",
+          "Lunara|Q1"
         ]
       },
       {

--- a/hero/maiev.json
+++ b/hero/maiev.json
@@ -160,9 +160,8 @@
         "icon": "storm_ui_icon_maiev_rush_2.png",
         "type": "E",
         "sort": 3,
-        "abilityId": "Maiev|E2",
+        "abilityId": "Maiev|E1",
         "abilityLinks": [
-          "Maiev|E2",
           "Maiev|E1"
         ]
       }
@@ -202,9 +201,8 @@
         "icon": "storm_ui_icon_maiev_rush_1.png",
         "type": "E",
         "sort": 3,
-        "abilityId": "Maiev|E2",
+        "abilityId": "Maiev|E1",
         "abilityLinks": [
-          "Maiev|E2",
           "Maiev|E1"
         ]
       }
@@ -274,9 +272,8 @@
         "icon": "storm_ui_icon_maiev_rush_2.png",
         "type": "E",
         "sort": 3,
-        "abilityId": "Maiev|E2",
+        "abilityId": "Maiev|E1",
         "abilityLinks": [
-          "Maiev|E2",
           "Maiev|E1"
         ]
       }
@@ -303,9 +300,8 @@
         "icon": "storm_ui_icon_maiev_vengeful_knives.png",
         "type": "E",
         "sort": 2,
-        "abilityId": "Maiev|E2",
+        "abilityId": "Maiev|E1",
         "abilityLinks": [
-          "Maiev|E2",
           "Maiev|E1"
         ]
       },

--- a/hero/maiev.json
+++ b/hero/maiev.json
@@ -1,5 +1,5 @@
 {
-  "id": "77",
+  "id": 77,
   "shortName": "maiev",
   "attributeId": "Maie",
   "cHeroId": "Maiev",
@@ -15,7 +15,7 @@
   "abilities": {
     "Maiev": [
       {
-        "uid": "feb394a",
+        "uid": "4922f9",
         "name": "Fan of Knives",
         "description": "Deal 152 (+4% per level) damage to enemies in a crescent area.  Hitting at least 2 enemy Heroes with Fan of Knives reduces its cooldown to 0.5 seconds, and refunds its Mana cost.",
         "hotkey": "Q",
@@ -26,7 +26,7 @@
         "type": "basic"
       },
       {
-        "uid": "bc98674",
+        "uid": "9efd23",
         "name": "Umbral Bind",
         "description": "Maiev's next Basic Attack cleaves and applies a tether to enemy Heroes hit for 2.5 seconds. If a tethered Hero moves too far from Maiev, they are pulled toward her, dealing 110 (+4% per level) damage and breaking the tether.",
         "hotkey": "W",
@@ -37,7 +37,7 @@
         "type": "basic"
       },
       {
-        "uid": "88093b9",
+        "uid": "69d506",
         "name": "Spirit of Vengeance",
         "description": "Send a shadow of Maiev outward that will return to its cast location, dealing 150 (+4% per level) damage to enemies along both paths. If an enemy Hero is hit, reduce the cooldown by 4 seconds.",
         "hotkey": "E",
@@ -48,7 +48,7 @@
         "type": "basic"
       },
       {
-        "uid": "1ecc6bb",
+        "uid": "60fa79",
         "name": "Containment Disc",
         "description": "Throw a glaive in the target direction. If an enemy Hero is hit, Containment Disc can be reactivated to remove their vision and Time Stop them for 4 seconds.  Containment Disc automatically activates 6 seconds after hitting a Hero.",
         "hotkey": "R",
@@ -59,7 +59,7 @@
         "type": "heroic"
       },
       {
-        "uid": "3e124e6",
+        "uid": "2e14da",
         "name": "Warden's Cage",
         "description": "Summon 8 Warden Avatars as a cage around Maiev. After 1.5 seconds, enemy Heroes that come in contact with an Avatar consume it and are knocked to the center of the cage. Warden Avatars last 5 seconds.",
         "hotkey": "R",
@@ -70,10 +70,9 @@
         "type": "heroic"
       },
       {
-        "uid": "74d33e4",
+        "uid": "40402f",
         "name": "Vault of the Wardens",
         "description": "Leap into the air, becoming Immune to all hostile effects for 0.75 seconds.",
-        "hotkey": "D",
         "trait": true,
         "abilityId": "Maiev|D1",
         "cooldown": 13,
@@ -119,7 +118,7 @@
         "icon": "storm_ui_icon_maiev_memento.png",
         "type": "Active",
         "sort": 3,
-        "abilityId": "Maiev|Q1",
+        "abilityId": "Maiev|Active",
         "abilityLinks": [
           "Maiev|Q1"
         ]
@@ -161,8 +160,9 @@
         "icon": "storm_ui_icon_maiev_rush_2.png",
         "type": "E",
         "sort": 3,
-        "abilityId": "Maiev|E1",
+        "abilityId": "Maiev|E2",
         "abilityLinks": [
+          "Maiev|E2",
           "Maiev|E1"
         ]
       }
@@ -202,8 +202,9 @@
         "icon": "storm_ui_icon_maiev_rush_1.png",
         "type": "E",
         "sort": 3,
-        "abilityId": "Maiev|E1",
+        "abilityId": "Maiev|E2",
         "abilityLinks": [
+          "Maiev|E2",
           "Maiev|E1"
         ]
       }
@@ -273,8 +274,9 @@
         "icon": "storm_ui_icon_maiev_rush_2.png",
         "type": "E",
         "sort": 3,
-        "abilityId": "Maiev|E1",
+        "abilityId": "Maiev|E2",
         "abilityLinks": [
+          "Maiev|E2",
           "Maiev|E1"
         ]
       }
@@ -301,8 +303,9 @@
         "icon": "storm_ui_icon_maiev_vengeful_knives.png",
         "type": "E",
         "sort": 2,
-        "abilityId": "Maiev|E1",
+        "abilityId": "Maiev|E2",
         "abilityLinks": [
+          "Maiev|E2",
           "Maiev|E1"
         ]
       },

--- a/hero/malfurion.json
+++ b/hero/malfurion.json
@@ -1,5 +1,5 @@
 {
-  "id": "9",
+  "id": 9,
   "shortName": "malfurion",
   "attributeId": "Malf",
   "cHeroId": "Malfurion",
@@ -21,7 +21,7 @@
   "abilities": {
     "Malfurion": [
       {
-        "uid": "5a3ef22",
+        "uid": "ff74fd",
         "name": "Regrowth",
         "description": "Heal an allied Hero for 380 (+4% per level) Health over 20 seconds.",
         "hotkey": "Q",
@@ -32,7 +32,7 @@
         "type": "basic"
       },
       {
-        "uid": "56a5964",
+        "uid": "895dcf",
         "name": "Moonfire",
         "description": "Deal 90 (+4% per level) damage to enemies in an area and reveal them for 2 seconds.  Allies with an active Regrowth are healed for 130 (+4% per level) Health for each enemy Hero hit by Moonfire.",
         "hotkey": "W",
@@ -43,18 +43,18 @@
         "type": "basic"
       },
       {
-        "uid": "6e2caa2",
+        "uid": "699cfb",
         "name": "Entangling Roots",
         "description": "Root enemy Heroes in an area for 1.25 seconds, and deal 117 (+4% per level) damage over the duration. Affected area grows over 3 seconds.",
         "hotkey": "E",
         "abilityId": "Malfurion|E1",
-        "cooldown": 14,
-        "manaCost": 75,
+        "cooldown": 12,
+        "manaCost": 65,
         "icon": "storm_ui_icon_malfurion_entanglingroots.png",
         "type": "basic"
       },
       {
-        "uid": "7ab654c",
+        "uid": "c1042b",
         "name": "Tranquility",
         "description": "Heal nearby allied Heroes for 80 (+4% per level) Health per second for 8 seconds. Allies affected by Regrowth within Tranquility's area gain 10 Armor.",
         "hotkey": "R",
@@ -65,7 +65,7 @@
         "type": "heroic"
       },
       {
-        "uid": "39f1e67",
+        "uid": "d55c5b",
         "name": "Twilight Dream",
         "description": "After 0.5 seconds, deal 310 (+4% per level) damage in a large area around Malfurion, Silencing enemies making them unable to use Abilities for 3 seconds.",
         "hotkey": "R",
@@ -76,13 +76,12 @@
         "type": "heroic"
       },
       {
-        "uid": "2f181bf",
+        "uid": "e7b6e6",
         "name": "Innervate",
         "description": "Grant an allied Hero 20% of their maximum Mana over 5 seconds. While affected by Innervate, their Basic Ability cooldowns recharge 50% faster.  Cannot be used on Heroes that do not use Mana.",
-        "hotkey": "D",
         "trait": true,
         "abilityId": "Malfurion|D1",
-        "cooldown": 30,
+        "cooldown": 25,
         "icon": "storm_ui_icon_malfurion_innerrvate.png",
         "type": "trait"
       }
@@ -209,7 +208,7 @@
         "type": "Active",
         "sort": 3,
         "cooldown": 45,
-        "abilityId": "Malfurion|Q1",
+        "abilityId": "Malfurion|Active",
         "abilityLinks": [
           "Malfurion|Q1"
         ]

--- a/hero/malganis.json
+++ b/hero/malganis.json
@@ -1,5 +1,5 @@
 {
-  "id": "83",
+  "id": 83,
   "shortName": "malganis",
   "attributeId": "MalG",
   "cHeroId": "MalGanis",
@@ -19,68 +19,68 @@
     "SelfHealer"
   ],
   "abilities": {
-    "Mal'Ganis": [
+    "MalGanis": [
       {
-        "uid": "7599439",
+        "uid": "22d1ec",
         "name": "Fel Claws",
         "description": "Violently slash in the chosen direction, dealing 69 (+4% per level) damage to enemies.  Reactivate to slash up to 2 more times. The third slash Stuns enemies for 0.75 seconds.",
         "hotkey": "Q",
-        "abilityId": "Mal'Ganis|Q1",
+        "abilityId": "MalGanis|Q1",
         "cooldown": 8,
         "manaCost": 45,
         "icon": "storm_ui_icon_malganis_fel_1.png",
         "type": "basic"
       },
       {
-        "uid": "de3ae62",
+        "uid": "ed88e2",
         "name": "Necrotic Embrace",
         "description": "Desecrate the air, dealing 110 (+4% per level) damage to nearby enemies and gaining 25 Armor for 3 seconds.",
         "hotkey": "W",
-        "abilityId": "Mal'Ganis|W1",
+        "abilityId": "MalGanis|W1",
         "cooldown": 8,
         "manaCost": 35,
         "icon": "storm_ui_icon_malganis_necrotic.png",
         "type": "basic"
       },
       {
-        "uid": "6203e91",
+        "uid": "140052",
         "name": "Night Rush",
         "description": "After 0.75 seconds, gain 50% Movement Speed for 2 seconds. While active, Mal'Ganis can move through enemy Heroes and put them to Sleep for 2.5 seconds.",
         "hotkey": "E",
-        "abilityId": "Mal'Ganis|E1",
+        "abilityId": "MalGanis|E1",
         "cooldown": 16,
         "manaCost": 70,
         "icon": "storm_ui_icon_malganis_nightrush.png",
         "type": "basic"
       },
       {
-        "uid": "69d57a2",
-        "name": "Carrion Swarm",
-        "description": "After 1 second, disperse into an Invulnerable swarm of bats for 3 seconds, dealing 126 (+4% per level) damage per second to enemies.  Vampiric Touch heals for 75% of Carrion Swarm's damage to Heroes.",
-        "hotkey": "R",
-        "abilityId": "Mal'Ganis|R2",
-        "cooldown": 80,
-        "manaCost": 70,
-        "icon": "storm_ui_icon_malganis_ult_swarm.png",
-        "type": "heroic"
-      },
-      {
-        "uid": "a2cbffd",
+        "uid": "d0fed8",
         "name": "Dark Conversion",
         "description": "Channel on an enemy Hero for 0.75 seconds, then swap Health percentages with the target over 3 seconds.",
         "hotkey": "R",
-        "abilityId": "Mal'Ganis|R1",
+        "abilityId": "MalGanis|R1",
         "cooldown": 80,
         "manaCost": 70,
         "icon": "storm_ui_icon_malganis_ult_conversion.png",
         "type": "heroic"
       },
       {
-        "uid": "3504360",
+        "uid": "5c68a5",
+        "name": "Carrion Swarm",
+        "description": "After 1 second, disperse into an Invulnerable swarm of bats for 3 seconds, dealing 126 (+4% per level) damage per second to enemies.  Vampiric Touch heals for 75% of Carrion Swarm's damage to Heroes.",
+        "hotkey": "R",
+        "abilityId": "MalGanis|R2",
+        "cooldown": 80,
+        "manaCost": 70,
+        "icon": "storm_ui_icon_malganis_ult_swarm.png",
+        "type": "heroic"
+      },
+      {
+        "uid": "e08563",
         "name": "Vampiric Touch",
         "description": "Mal'Ganis heals for 45% of damage dealt to enemy Heroes and 10% of damage dealt to non-Heroes.",
         "trait": true,
-        "abilityId": "Mal'Ganis|D1",
+        "abilityId": "MalGanis|D1",
         "icon": "storm_ui_icon_malganis_trait.png",
         "type": "trait"
       }
@@ -96,9 +96,9 @@
         "icon": "storm_ui_icon_malganis_necrotic.png",
         "type": "W",
         "sort": 1,
-        "abilityId": "Mal'Ganis|W1",
+        "abilityId": "MalGanis|W1",
         "abilityLinks": [
-          "Mal'Ganis|W1"
+          "MalGanis|W1"
         ]
       },
       {
@@ -109,9 +109,9 @@
         "icon": "storm_ui_icon_malganis_trait.png",
         "type": "Trait",
         "sort": 2,
-        "abilityId": "Mal'Ganis|D1",
+        "abilityId": "MalGanis|D1",
         "abilityLinks": [
-          "Mal'Ganis|D1"
+          "MalGanis|D1"
         ]
       },
       {
@@ -122,9 +122,9 @@
         "icon": "storm_ui_icon_malganis_trait_b.png",
         "type": "Passive",
         "sort": 3,
-        "abilityId": "Mal'Ganis|Passive",
+        "abilityId": "MalGanis|Passive",
         "abilityLinks": [
-          "Mal'Ganis|D1"
+          "MalGanis|D1"
         ]
       }
     ],
@@ -137,9 +137,9 @@
         "icon": "storm_ui_icon_malganis_necrotic.png",
         "type": "W",
         "sort": 1,
-        "abilityId": "Mal'Ganis|W1",
+        "abilityId": "MalGanis|W1",
         "abilityLinks": [
-          "Mal'Ganis|W1"
+          "MalGanis|W1"
         ]
       },
       {
@@ -150,9 +150,9 @@
         "icon": "storm_ui_icon_malganis_necrotic_b.png",
         "type": "W",
         "sort": 2,
-        "abilityId": "Mal'Ganis|W1",
+        "abilityId": "MalGanis|W1",
         "abilityLinks": [
-          "Mal'Ganis|W1"
+          "MalGanis|W1"
         ]
       },
       {
@@ -163,9 +163,9 @@
         "icon": "storm_ui_icon_malganis_necrotic_c.png",
         "type": "W",
         "sort": 3,
-        "abilityId": "Mal'Ganis|W1",
+        "abilityId": "MalGanis|W1",
         "abilityLinks": [
-          "Mal'Ganis|W1"
+          "MalGanis|W1"
         ]
       }
     ],
@@ -178,9 +178,11 @@
         "icon": "storm_ui_icon_malganis_fel_1.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "Mal'Ganis|Q1",
+        "abilityId": "MalGanis|Q2",
         "abilityLinks": [
-          "Mal'Ganis|Q1"
+          "MalGanis|Q2",
+          "MalGanis|Q3",
+          "MalGanis|Q1"
         ]
       },
       {
@@ -191,9 +193,11 @@
         "icon": "storm_ui_icon_malganis_fel_1_b.png",
         "type": "Q",
         "sort": 2,
-        "abilityId": "Mal'Ganis|Q1",
+        "abilityId": "MalGanis|Q2",
         "abilityLinks": [
-          "Mal'Ganis|Q1"
+          "MalGanis|Q2",
+          "MalGanis|Q3",
+          "MalGanis|Q1"
         ]
       },
       {
@@ -204,9 +208,9 @@
         "icon": "storm_ui_icon_malganis_nightrush.png",
         "type": "E",
         "sort": 3,
-        "abilityId": "Mal'Ganis|E1",
+        "abilityId": "MalGanis|E1",
         "abilityLinks": [
-          "Mal'Ganis|E1"
+          "MalGanis|E1"
         ]
       },
       {
@@ -217,10 +221,10 @@
         "icon": "storm_ui_icon_malganis_nightrush_b.png",
         "type": "E",
         "sort": 4,
-        "abilityId": "Mal'Ganis|E1",
+        "abilityId": "MalGanis|E1",
         "abilityLinks": [
-          "Mal'Ganis|E1",
-          "Mal'Ganis|D1"
+          "MalGanis|E1",
+          "MalGanis|D1"
         ]
       }
     ],
@@ -234,9 +238,9 @@
         "type": "Heroic",
         "sort": 1,
         "cooldown": 80,
-        "abilityId": "Mal'Ganis|R2",
+        "abilityId": "MalGanis|R2",
         "abilityLinks": [
-          "Mal'Ganis|R2"
+          "MalGanis|R2"
         ]
       },
       {
@@ -248,9 +252,9 @@
         "type": "Heroic",
         "sort": 2,
         "cooldown": 80,
-        "abilityId": "Mal'Ganis|R1",
+        "abilityId": "MalGanis|R1",
         "abilityLinks": [
-          "Mal'Ganis|R1"
+          "MalGanis|R1"
         ]
       }
     ],
@@ -263,9 +267,9 @@
         "icon": "storm_ui_icon_malganis_nightrush.png",
         "type": "E",
         "sort": 1,
-        "abilityId": "Mal'Ganis|E1",
+        "abilityId": "MalGanis|E1",
         "abilityLinks": [
-          "Mal'Ganis|E1"
+          "MalGanis|E1"
         ]
       },
       {
@@ -276,9 +280,9 @@
         "icon": "storm_ui_icon_malganis_nightrush_b.png",
         "type": "E",
         "sort": 2,
-        "abilityId": "Mal'Ganis|E1",
+        "abilityId": "MalGanis|E1",
         "abilityLinks": [
-          "Mal'Ganis|E1"
+          "MalGanis|E1"
         ]
       },
       {
@@ -289,9 +293,9 @@
         "icon": "storm_ui_icon_malganis_trait.png",
         "type": "Trait",
         "sort": 3,
-        "abilityId": "Mal'Ganis|D1",
+        "abilityId": "MalGanis|D1",
         "abilityLinks": [
-          "Mal'Ganis|D1"
+          "MalGanis|D1"
         ]
       }
     ],
@@ -304,9 +308,9 @@
         "icon": "storm_ui_icon_malganis_necrotic.png",
         "type": "W",
         "sort": 1,
-        "abilityId": "Mal'Ganis|W1",
+        "abilityId": "MalGanis|W1",
         "abilityLinks": [
-          "Mal'Ganis|W1"
+          "MalGanis|W1"
         ]
       },
       {
@@ -317,9 +321,9 @@
         "icon": "storm_ui_icon_malganis_trait.png",
         "type": "Passive",
         "sort": 2,
-        "abilityId": "Mal'Ganis|Passive",
+        "abilityId": "MalGanis|Passive",
         "abilityLinks": [
-          "Mal'Ganis|D1"
+          "MalGanis|D1"
         ]
       },
       {
@@ -331,7 +335,7 @@
         "type": "Active",
         "sort": 3,
         "cooldown": 80,
-        "abilityId": "Mal'Ganis|Active"
+        "abilityId": "MalGanis|Active"
       }
     ],
     "20": [
@@ -343,9 +347,9 @@
         "icon": "storm_ui_icon_malganis_ult_swarm.png",
         "type": "Heroic",
         "sort": 1,
-        "abilityId": "Mal'Ganis|R2",
+        "abilityId": "MalGanis|R2",
         "abilityLinks": [
-          "Mal'Ganis|R2"
+          "MalGanis|R2"
         ]
       },
       {
@@ -356,9 +360,9 @@
         "icon": "storm_ui_icon_malganis_ult_conversion.png",
         "type": "Heroic",
         "sort": 2,
-        "abilityId": "Mal'Ganis|R1",
+        "abilityId": "MalGanis|R1",
         "abilityLinks": [
-          "Mal'Ganis|R1"
+          "MalGanis|R1"
         ]
       },
       {
@@ -369,9 +373,11 @@
         "icon": "storm_ui_icon_malganis_fel_1.png",
         "type": "Q",
         "sort": 3,
-        "abilityId": "Mal'Ganis|Q1",
+        "abilityId": "MalGanis|Q2",
         "abilityLinks": [
-          "Mal'Ganis|Q1"
+          "MalGanis|Q2",
+          "MalGanis|Q3",
+          "MalGanis|Q1"
         ]
       },
       {
@@ -382,9 +388,9 @@
         "icon": "storm_ui_icon_malganis_nightrush.png",
         "type": "E",
         "sort": 4,
-        "abilityId": "Mal'Ganis|E1",
+        "abilityId": "MalGanis|E1",
         "abilityLinks": [
-          "Mal'Ganis|E1"
+          "MalGanis|E1"
         ]
       }
     ]

--- a/hero/malganis.json
+++ b/hero/malganis.json
@@ -178,10 +178,8 @@
         "icon": "storm_ui_icon_malganis_fel_1.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "MalGanis|Q2",
+        "abilityId": "MalGanis|Q1",
         "abilityLinks": [
-          "MalGanis|Q2",
-          "MalGanis|Q3",
           "MalGanis|Q1"
         ]
       },
@@ -193,10 +191,8 @@
         "icon": "storm_ui_icon_malganis_fel_1_b.png",
         "type": "Q",
         "sort": 2,
-        "abilityId": "MalGanis|Q2",
+        "abilityId": "MalGanis|Q1",
         "abilityLinks": [
-          "MalGanis|Q2",
-          "MalGanis|Q3",
           "MalGanis|Q1"
         ]
       },
@@ -373,10 +369,8 @@
         "icon": "storm_ui_icon_malganis_fel_1.png",
         "type": "Q",
         "sort": 3,
-        "abilityId": "MalGanis|Q2",
+        "abilityId": "MalGanis|Q1",
         "abilityLinks": [
-          "MalGanis|Q2",
-          "MalGanis|Q3",
           "MalGanis|Q1"
         ]
       },

--- a/hero/malthael.json
+++ b/hero/malthael.json
@@ -1,5 +1,5 @@
 {
-  "id": "68",
+  "id": 68,
   "shortName": "malthael",
   "attributeId": "MALT",
   "cHeroId": "Malthael",
@@ -23,7 +23,7 @@
   "abilities": {
     "Malthael": [
       {
-        "uid": "b2fd2a8",
+        "uid": "88afa6",
         "name": "Soul Rip",
         "description": "Extract the souls of nearby enemies afflicted by Reaper's Mark, dealing 100 (+4% per level) damage and healing Malthael for 25 (+4% per level) per target hit. Heroic targets heal Malthael for an additional 4% of the Hero's maximum Health.",
         "hotkey": "Q",
@@ -34,7 +34,7 @@
         "type": "basic"
       },
       {
-        "uid": "625e9e1",
+        "uid": "d3e2e8",
         "name": "Wraith Strike",
         "description": "Instantly teleport through an enemy afflicted by Reaper's Mark, dealing 59 (+4% per level) damage and refreshing Reaper's Mark.",
         "hotkey": "W",
@@ -45,7 +45,7 @@
         "type": "basic"
       },
       {
-        "uid": "bdec408",
+        "uid": "fd6b05",
         "name": "Death Shroud",
         "description": "After 0.25 seconds, unleash a wave of dark mist that applies Reaper's Mark to enemies it hits.",
         "hotkey": "E",
@@ -56,7 +56,7 @@
         "type": "basic"
       },
       {
-        "uid": "3f08ef9",
+        "uid": "d173a6",
         "name": "Tormented Souls",
         "description": "Unleash a torrent of souls, continually applying Reaper's Mark to nearby enemies for 4 seconds.  When Tormented Souls is cast and when it expires, reset the cooldown of Wraith Strike.",
         "hotkey": "R",
@@ -67,7 +67,7 @@
         "type": "heroic"
       },
       {
-        "uid": "78d285c",
+        "uid": "39397d",
         "name": "Last Rites",
         "description": "Apply a death sentence to an enemy Hero that, after 2 seconds, deals damage equal to 50% of their missing Health.  Quest: Enemies killed between the application of Last Rites and within 1.5 seconds of it dealing damage permanently reduce its cooldown by 5 seconds, to a minimum of 15 seconds.",
         "hotkey": "R",
@@ -78,7 +78,7 @@
         "type": "heroic"
       },
       {
-        "uid": "dfc12ce",
+        "uid": "041ae8",
         "name": "Reaper's Mark",
         "description": "Basic Attacks cleave in an area in front of Malthael and afflict non-Structure targets with Reaper's Mark for 4 seconds.  Marked enemies are revealed and take damage equal to 1.75% of their maximum Health every 1 second.",
         "trait": true,
@@ -113,7 +113,7 @@
         "sort": 2,
         "abilityId": "Malthael|Passive",
         "abilityLinks": [
-          "Z1"
+          "Greymane|Z1"
         ]
       },
       {

--- a/hero/medivh.json
+++ b/hero/medivh.json
@@ -1,5 +1,5 @@
 {
-  "id": "53",
+  "id": 53,
   "shortName": "medivh",
   "attributeId": "Mdvh",
   "cHeroId": "Medivh",
@@ -21,7 +21,7 @@
   "abilities": {
     "Medivh": [
       {
-        "uid": "0650274",
+        "uid": "9aaf79",
         "name": "Arcane Rift",
         "description": "Launch a rift that deals 170 (+4% per level) damage to enemies in its path. If an enemy Hero is hit, reduce its cooldown by 5 seconds and refund 50 Mana.  Quest: Hit 40 enemy Heroes with Arcane Rift without dying.  Reward: Permanently increase the damage dealt by 75 and cooldown reduction for hitting a Hero by 1 second.",
         "hotkey": "Q",
@@ -32,7 +32,7 @@
         "type": "basic"
       },
       {
-        "uid": "0511489",
+        "uid": "20c9af",
         "name": "Force of Will",
         "description": "Protect an allied Hero from all damage for 1.5 seconds.  Upon expiration, Force of Will heals the target for 20% of the damage it absorbed.",
         "hotkey": "W",
@@ -43,7 +43,7 @@
         "type": "basic"
       },
       {
-        "uid": "3cc3d97",
+        "uid": "735d73",
         "name": "Portal",
         "description": "Create a set of portals between Medivh and the target location, allowing allies to teleport between both. The portals last 6 seconds.",
         "hotkey": "E",
@@ -54,7 +54,7 @@
         "type": "basic"
       },
       {
-        "uid": "be3e2ba",
+        "uid": "fd63c3",
         "name": "Poly Bomb",
         "description": "Polymorph an enemy Hero for 2 seconds, Silencing them and making them unable to attack. On expiration, Poly Bomb spreads to other nearby enemy Heroes.",
         "hotkey": "R",
@@ -65,7 +65,7 @@
         "type": "heroic"
       },
       {
-        "uid": "6abc78a",
+        "uid": "3df0f5",
         "name": "Ley Line Seal",
         "description": "After 0.5 seconds, unleash a wave of energy that places enemy Heroes in Time Stop for 3 seconds.",
         "hotkey": "R",
@@ -76,7 +76,16 @@
         "type": "heroic"
       },
       {
-        "uid": "e7871e3",
+        "uid": "d8c432",
+        "name": "Raven Form",
+        "description": "Instead of mounting, Medivh can transform into a raven, increasing Movement Speed by 20%. While transformed, Medivh can see and fly over all terrain and is immune to all effects.",
+        "trait": true,
+        "abilityId": "Medivh|D1",
+        "icon": "storm_ui_icon_medivh_ravenform.png",
+        "type": "trait"
+      },
+      {
+        "uid": "2fb729",
         "name": "Raven Form",
         "description": "Transform into a raven, increasing Movement Speed by 20%. While transformed, Medivh can see and fly over terrain and is immune to all effects.",
         "hotkey": "Z",
@@ -84,15 +93,6 @@
         "cooldown": 4,
         "icon": "storm_ui_icon_medivh_mount.png",
         "type": "mount"
-      },
-      {
-        "uid": "6a0dd6b",
-        "name": "Raven Form",
-        "description": "Instead of mounting, Medivh can transform into a raven, increasing Movement Speed by 20%. While transformed, Medivh can see and fly over all terrain and is immune to all effects.",
-        "trait": true,
-        "abilityId": "Medivh|D1",
-        "icon": "storm_ui_icon_medivh_ravenform.png",
-        "type": "trait"
       }
     ]
   },
@@ -114,7 +114,7 @@
       {
         "tooltipId": "MedivhTransformRavenRavensIntellect",
         "talentTreeId": "MedivhTransformRavenRavensIntellect",
-        "name": "Raven's Intellect",
+        "name": "Raven’s Intellect",
         "description": "Raven Form increases Medivh's Mana and Health Regeneration by 75%.",
         "icon": "storm_ui_icon_medivh_ravenform_b.png",
         "type": "Z",
@@ -133,7 +133,7 @@
         "type": "Active",
         "sort": 3,
         "cooldown": 16,
-        "abilityId": "Medivh|E1",
+        "abilityId": "Medivh|Active",
         "abilityLinks": [
           "Medivh|E1"
         ]

--- a/hero/mephisto.json
+++ b/hero/mephisto.json
@@ -1,5 +1,5 @@
 {
-  "id": "82",
+  "id": 82,
   "shortName": "mephisto",
   "attributeId": "MEPH",
   "cHeroId": "Mephisto",
@@ -20,7 +20,7 @@
   "abilities": {
     "Mephisto": [
       {
-        "uid": "92822f3",
+        "uid": "837523",
         "name": "Skull Missile",
         "description": "Conjure a skull that travels in the target direction after 0.75 seconds, dealing 127 (+4% per level) damage to enemies hit and Slowing Heroes hit by 25% for 2 seconds.",
         "hotkey": "Q",
@@ -31,7 +31,7 @@
         "type": "basic"
       },
       {
-        "uid": "10efb19",
+        "uid": "0a9c37",
         "name": "Lightning Nova",
         "description": "A ring of lightning appears around Mephisto for 2.5 seconds. Enemies within the ring take 45 (+4% per level) damage every 0.25 seconds.  Each time a cast of Lightning Nova hits a Hero, its damage is increased by 3%, up to 30%.",
         "hotkey": "W",
@@ -42,7 +42,7 @@
         "type": "basic"
       },
       {
-        "uid": "4442d5a",
+        "uid": "672f52",
         "name": "Shade of Mephisto",
         "description": "Teleport to a location, dealing 78 (+4% per level) damage to nearby enemies and leaving behind a Shade of Mephisto at Mephisto's original location.  After 2.5 seconds, Mephisto is teleported back to the Shade's location.",
         "hotkey": "E",
@@ -53,7 +53,7 @@
         "type": "basic"
       },
       {
-        "uid": "812dcd5",
+        "uid": "45ce26",
         "name": "Consume Souls",
         "description": "Channel for 2.5 seconds, revealing all enemy Heroes. After the Channel completes, all enemy Heroes take 357 (+4% per level) damage and are Slowed by 25% for 2.5 seconds.",
         "hotkey": "R",
@@ -64,7 +64,7 @@
         "type": "heroic"
       },
       {
-        "uid": "9334fe2",
+        "uid": "e6ac94",
         "name": "Durance of Hate",
         "description": "After 1 second, unleash a wave of evil spirits that Root the first enemy Hero hit for 2.5 seconds and deal 250 (+4% per level) damage to them over the same duration.  Durance of Hate spreads outwards from its initial target, Rooting and damaging additional nearby enemy Heroes.",
         "hotkey": "R",
@@ -75,7 +75,7 @@
         "type": "heroic"
       },
       {
-        "uid": "dcbb866",
+        "uid": "2dee4c",
         "name": "Lord Of Hatred",
         "description": "Hitting enemy Heroes with Basic Abilities reduces Mephisto's Basic Ability cooldowns.  Skull Missile and Shade of Mephisto grant 1.5 seconds of cooldown reduction per Hero hit, and Lightning Nova grants 0.3 seconds per Hero hit.",
         "trait": true,
@@ -366,7 +366,7 @@
         "type": "Active",
         "sort": 4,
         "cooldown": 40,
-        "abilityId": "Mephisto|E1",
+        "abilityId": "Mephisto|Active",
         "abilityLinks": [
           "Mephisto|E1"
         ]

--- a/hero/muradin.json
+++ b/hero/muradin.json
@@ -311,9 +311,8 @@
         "type": "Trait",
         "sort": 3,
         "cooldown": 60,
-        "abilityId": "Muradin|D2",
+        "abilityId": "Muradin|D1",
         "abilityLinks": [
-          "Muradin|D2",
           "Muradin|D1"
         ]
       }

--- a/hero/muradin.json
+++ b/hero/muradin.json
@@ -1,5 +1,5 @@
 {
-  "id": "10",
+  "id": 10,
   "shortName": "muradin",
   "attributeId": "Mura",
   "cHeroId": "Muradin",
@@ -22,7 +22,7 @@
   "abilities": {
     "Muradin": [
       {
-        "uid": "e76a512",
+        "uid": "0dce1c",
         "name": "Storm Bolt",
         "description": "Throw a hammer, dealing 110 (+4% per level) damage to the first enemy hit and Stunning them for 1.25 seconds.  Quest: Hit 25 Heroes with Storm Bolt. Heroes who die within 2.5 seconds of being hit by Storm Bolt count as hitting 3 additional Heroes.  Reward: Storm Bolt pierces to hit an additional target, and Muradin's Basic Attacks reduce the cooldown of Storm Bolt by 1 second.",
         "hotkey": "Q",
@@ -33,7 +33,7 @@
         "type": "basic"
       },
       {
-        "uid": "abf1ff1",
+        "uid": "c201dc",
         "name": "Thunder Clap",
         "description": "Blast nearby enemies for 96 (+4% per level) damage and Slow them by 25% for 2.5 seconds. Heroes hit also have their Attack Speed reduced by 25% for the duration.",
         "hotkey": "W",
@@ -44,7 +44,7 @@
         "type": "basic"
       },
       {
-        "uid": "ba49cdf",
+        "uid": "ad5596",
         "name": "Dwarf Toss",
         "description": "Leap to target location, dealing 59 (+4% per level) damage to enemies on landing. Upon leaping, gain 25 Armor for 2 seconds, reducing damage taken by 25%.",
         "hotkey": "E",
@@ -55,7 +55,7 @@
         "type": "basic"
       },
       {
-        "uid": "b465bcf",
+        "uid": "2cd7aa",
         "name": "Avatar",
         "description": "Transform for 20 seconds, gaining 1053 (+4% per level) Health.",
         "hotkey": "R",
@@ -66,7 +66,7 @@
         "type": "heroic"
       },
       {
-        "uid": "5251783",
+        "uid": "7958d3",
         "name": "Haymaker",
         "description": "Stun target enemy Hero, and wind up a punch dealing 319 (+4% per level) damage and knocking the target back, hitting enemies in the way for 319 (+4% per level) damage and knocking them aside.",
         "hotkey": "R",
@@ -77,7 +77,7 @@
         "type": "heroic"
       },
       {
-        "uid": "7fad63a",
+        "uid": "1e593b",
         "name": "Second Wind",
         "description": "Muradin restores 55 (+4% per level) Health per second when he has not taken damage for 4 seconds. When below 40% Health, increased to 111 (+4% per level) Health per second.",
         "trait": true,
@@ -311,8 +311,9 @@
         "type": "Trait",
         "sort": 3,
         "cooldown": 60,
-        "abilityId": "Muradin|D1",
+        "abilityId": "Muradin|D2",
         "abilityLinks": [
+          "Muradin|D2",
           "Muradin|D1"
         ]
       }

--- a/hero/murky.json
+++ b/hero/murky.json
@@ -1,5 +1,5 @@
 {
-  "id": "26",
+  "id": 26,
   "shortName": "murky",
   "attributeId": "Murk",
   "cHeroId": "Murky",
@@ -25,7 +25,7 @@
   "abilities": {
     "Murky": [
       {
-        "uid": "5dc2e3f",
+        "uid": "e3adb7",
         "name": "Slime",
         "description": "Deal 86 (+4% per level) damage and apply Slime on nearby enemies for 6 seconds, slowing them by 20%.  Deal 210 (+4% per level) damage to enemies who are already Slimed.",
         "hotkey": "Q",
@@ -35,7 +35,7 @@
         "type": "basic"
       },
       {
-        "uid": "d011dac",
+        "uid": "9152c7",
         "name": "Pufferfish",
         "description": "Spit out a Pufferfish with 225 (+5.5% per level) health at the target point. After 3 seconds, the fish will blow up for 410 (+4% per level) damage. Deals 50% less damage to Structures.",
         "hotkey": "W",
@@ -45,7 +45,7 @@
         "type": "basic"
       },
       {
-        "uid": "17ceb60",
+        "uid": "f1e080",
         "name": "Safety Bubble",
         "description": "Becomes Invulnerable for 2 seconds. While active, Murky cannot attack or use abilities.",
         "hotkey": "E",
@@ -55,7 +55,7 @@
         "type": "basic"
       },
       {
-        "uid": "1f121b8",
+        "uid": "b50a9e",
         "name": "March of the Murlocs",
         "description": "After 0.75 seconds, Murky commands a legion of Murlocs to march in a target direction, each one leaping onto the first enemy Hero or Structure they find. Each Murloc deals 125 (+4% per level) damage and slows its target by 15% for 5 seconds. Murlocs deal 50% damage to Structures.",
         "hotkey": "R",
@@ -65,7 +65,7 @@
         "type": "heroic"
       },
       {
-        "uid": "65800fe",
+        "uid": "d802c4",
         "name": "Octo-Grab",
         "description": "Murky becomes Unstoppable and Stuns target enemy Hero for 3 seconds while he hits them for 1 damage a second.",
         "hotkey": "R",
@@ -75,10 +75,9 @@
         "type": "heroic"
       },
       {
-        "uid": "c2d8cd4",
+        "uid": "c618ef",
         "name": "Spawn Egg",
         "description": "Place an Egg at target location, revealing the nearby area. Upon dying, Murky respawns at the Egg after 8 seconds. Murky only grants 25% of a real Hero's experience upon dying.  If Murky's Egg is killed, he is revealed to enemies for 15 seconds, and Spawn Egg is placed on cooldown.",
-        "hotkey": "D",
         "trait": true,
         "abilityId": "Murky|D1",
         "cooldown": 15,

--- a/hero/nazeebo.json
+++ b/hero/nazeebo.json
@@ -1,5 +1,5 @@
 {
-  "id": "11",
+  "id": 11,
   "shortName": "nazeebo",
   "attributeId": "Witc",
   "cHeroId": "WitchDoctor",
@@ -21,7 +21,7 @@
   "abilities": {
     "Nazeebo": [
       {
-        "uid": "4d96a1a",
+        "uid": "d2b362",
         "name": "Corpse Spiders",
         "description": "Hurl a jar of spiders that deals 50 (+4% per level) damage. If it hits at least one enemy, create 3 Corpse Spiders that attack for 38 (+4% per level) damage. Spiders last for 4 seconds.",
         "hotkey": "Q",
@@ -32,7 +32,7 @@
         "type": "basic"
       },
       {
-        "uid": "92e3716",
+        "uid": "59a96a",
         "name": "Zombie Wall",
         "description": "After 1 second, create a ring of Zombies surrounding the target area that deal 28 (+4% per level) damage and last for 3 seconds.",
         "hotkey": "W",
@@ -43,7 +43,7 @@
         "type": "basic"
       },
       {
-        "uid": "5d86b28",
+        "uid": "c41a44",
         "name": "Plague of Toads",
         "description": "Create a wave of 3 Toads that explode on contact, dealing 119 (+4% per level) damage over 6 seconds. This effect stacks.  Stores up to 2 charges.",
         "hotkey": "E",
@@ -54,7 +54,7 @@
         "type": "basic"
       },
       {
-        "uid": "26a4060",
+        "uid": "e78c10",
         "name": "Gargantuan",
         "description": "Summon a Gargantuan to guard an area for 20 seconds. Deals 100 (+4% per level) damage when summoned, attacks for 140 (+4% per level) damage, and can be ordered to stomp nearby enemies.",
         "hotkey": "R",
@@ -65,7 +65,7 @@
         "type": "heroic"
       },
       {
-        "uid": "8162ee9",
+        "uid": "52f290",
         "name": "Ravenous Spirit",
         "description": "Channel a Ravenous Spirit that deals 216 (+4% per level) damage per second. Cannot move while channeling. Lasts for 8 seconds.",
         "hotkey": "R",
@@ -76,7 +76,7 @@
         "type": "heroic"
       },
       {
-        "uid": "ef9b6a8",
+        "uid": "9addd5",
         "name": "Voodoo Ritual",
         "description": "Nazeebo's Basic Attacks and Abilities poison Non-Heroic enemies, causing them to take 67 (+4% per level) additional damage over 6 seconds.  Quest: If a Minion dies while poisoned by Voodoo Ritual, Nazeebo permanently gains 6 Health and 1 Mana.",
         "trait": true,
@@ -87,24 +87,23 @@
     ],
     "WitchDoctorGargantuan": [
       {
-        "uid": "8b3e463",
+        "uid": "f2827a",
         "name": "Gargantuan Stomp",
         "description": "Order the Gargantuan to stomp, dealing 240 (+4% per level) damage to nearby enemies and slowing them by 30% for 2 seconds.",
         "hotkey": "R",
         "abilityId": "Nazeebo|R3",
-        "cooldown": 5,
         "icon": "storm_ui_icon_nazeebo_gargantuanstomp.png",
-        "type": "subunit"
+        "type": "heroic"
       },
       {
-        "uid": "fb7b2bc",
+        "uid": "fd5603",
         "name": "Gargantuan Stomp",
         "description": "Order the Gargantuan to stomp, dealing 240 (+4% per level) damage to nearby enemies and slowing them by 30% for 2 seconds.",
         "hotkey": "R",
         "abilityId": "Nazeebo|R4",
         "cooldown": 5,
         "icon": "storm_ui_icon_nazeebo_gargantuanstomp.png",
-        "type": "subunit"
+        "type": "heroic"
       }
     ]
   },

--- a/hero/nova.json
+++ b/hero/nova.json
@@ -1,5 +1,5 @@
 {
-  "id": "12",
+  "id": 12,
   "shortName": "nova",
   "attributeId": "Nova",
   "cHeroId": "Nova",
@@ -20,7 +20,7 @@
   "abilities": {
     "Nova": [
       {
-        "uid": "4d1365a",
+        "uid": "431e00",
         "name": "Snipe",
         "description": "Deal 230 (+4% per level) damage to the first enemy hit.  Passive: Hitting an enemy Hero with Snipe permanently increases the damage of Snipe by 6%, stacking up to 30%. Gain an additional 25% damage bonus at maximum stacks. All stacks are lost if Snipe fails to hit an enemy.",
         "hotkey": "Q",
@@ -31,7 +31,7 @@
         "type": "basic"
       },
       {
-        "uid": "7e7e227",
+        "uid": "ffa782",
         "name": "Pinning Shot",
         "description": "Deal 100 (+4% per level) damage to an enemy and Slow them by 40% for 2.25 seconds.",
         "hotkey": "W",
@@ -42,7 +42,7 @@
         "type": "basic"
       },
       {
-        "uid": "e99ae67",
+        "uid": "9a5566",
         "name": "Holo Decoy",
         "description": "Create a Decoy for 5 seconds with 100% of Nova's current Health that attacks enemies, dealing 10% of Nova's base damage. Whenever a Decoy takes damage, it deals that amount of damage to itself, effectively doubling the damage it takes.  Using this Ability does not break Stealth.",
         "hotkey": "E",
@@ -53,7 +53,17 @@
         "type": "basic"
       },
       {
-        "uid": "d043b6e",
+        "uid": "7294e0",
+        "name": "Ghost Protocol",
+        "description": "Activate to instantly grant Stealth to Nova and spawn a Holo Decoy at her location. Nova is Unrevealable for the first 0.5 seconds when Stealthed by Ghost Protocol.",
+        "hotkey": 1,
+        "abilityId": "Nova|11",
+        "cooldown": 60,
+        "icon": "storm_ui_icon_nova_personalcloaking.png",
+        "type": "activable"
+      },
+      {
+        "uid": "b7a5b6",
         "name": "Triple Tap",
         "description": "Locks in on the target Hero, then fires 3 shots that hit the first Hero or Structure they come in contact with for 372 (+4% per level) damage each.",
         "hotkey": "R",
@@ -64,7 +74,7 @@
         "type": "heroic"
       },
       {
-        "uid": "1b5dbc0",
+        "uid": "c6dbe1",
         "name": "Precision Strike",
         "description": "After a 1.5 second delay, deals 435 (+4% per level) damage to enemies within an area. Unlimited range.",
         "hotkey": "R",
@@ -75,23 +85,13 @@
         "type": "heroic"
       },
       {
-        "uid": "56e3463",
+        "uid": "02797c",
         "name": "Permanent Cloak",
         "description": "Gain Stealth when out of combat for 3 seconds. Taking damage, attacking, using Abilities, or Channeling ends Stealth. Remaining stationary for at least 1.5 seconds while Stealthed grants Invisible.  Passive: Gain 15% Movement Speed while Stealthed.",
         "trait": true,
         "abilityId": "Nova|D1",
         "icon": "storm_ui_icon_nova_personalcloaking.png",
         "type": "trait"
-      },
-      {
-        "uid": "d36cf3d",
-        "name": "Ghost Protocol",
-        "description": "Activate to instantly grant Stealth to Nova and spawn a Holo Decoy at her location. Nova is Unrevealable for the first 0.5 seconds when Stealthed by Ghost Protocol.",
-        "hotkey": "1",
-        "abilityId": "Nova|11",
-        "cooldown": 60,
-        "icon": "storm_ui_icon_nova_personalcloaking.png",
-        "type": "activable"
       }
     ]
   },

--- a/hero/orphea.json
+++ b/hero/orphea.json
@@ -1,5 +1,5 @@
 {
-  "id": "84",
+  "id": 84,
   "shortName": "orphea",
   "attributeId": "ORPH",
   "cHeroId": "Orphea",
@@ -23,7 +23,7 @@
   "abilities": {
     "Orphea": [
       {
-        "uid": "67b9e5d",
+        "uid": "88e5d4",
         "name": "Shadow Waltz",
         "description": "After 0.5 seconds, deal 165 (+4% per level) damage to enemies in a line.  Hitting a Hero with Shadow Waltz sets its cooldown to 2 seconds, refunds 40 Mana, and causes Orphea to dash a short distance upon moving.",
         "hotkey": "Q",
@@ -34,7 +34,7 @@
         "type": "basic"
       },
       {
-        "uid": "b534c77",
+        "uid": "e09b54",
         "name": "Chomp",
         "description": "After 0.625 seconds, deal 285 (+4% per level) damage to nearby enemies in front of Orphea.",
         "hotkey": "W",
@@ -45,7 +45,7 @@
         "type": "basic"
       },
       {
-        "uid": "c2e0ba6",
+        "uid": "63f43d",
         "name": "Dread",
         "description": "Release a wave of dread that deals 85 (+4% per level) damage to enemies hit. Dread erupts 0.75 seconds after reaching the end of its path, dealing 175 (+4% per level) damage and Slowing enemies in the area by 25% for 2 seconds.",
         "hotkey": "E",
@@ -56,18 +56,7 @@
         "type": "basic"
       },
       {
-        "uid": "a2a6a43",
-        "name": "Eternal Feast",
-        "description": "After 1.5 seconds, deal 210 (+4% per level) damage in an area. Eternal Feast repeats every 1 second as long as it hits an enemy Hero.",
-        "hotkey": "R",
-        "abilityId": "Orphea|R2",
-        "cooldown": 50,
-        "manaCost": 75,
-        "icon": "storm_ui_icon_orphea_ult_darkfall.png",
-        "type": "heroic"
-      },
-      {
-        "uid": "13f8182",
+        "uid": "db0324",
         "name": "Crushing Jaws",
         "description": "After 1.25 seconds, pull enemies in an area towards the center, dealing 250 (+4% per level) damage and Stunning them for 0.5 seconds.",
         "hotkey": "R",
@@ -78,7 +67,18 @@
         "type": "heroic"
       },
       {
-        "uid": "0acb8cb",
+        "uid": "6001f6",
+        "name": "Eternal Feast",
+        "description": "After 1.5 seconds, deal 210 (+4% per level) damage in an area. Eternal Feast repeats every 1 second as long as it hits an enemy Hero.",
+        "hotkey": "R",
+        "abilityId": "Orphea|R2",
+        "cooldown": 50,
+        "manaCost": 75,
+        "icon": "storm_ui_icon_orphea_ult_darkfall.png",
+        "type": "heroic"
+      },
+      {
+        "uid": "37e632",
         "name": "Overflowing Chaos",
         "description": "Hitting an enemy Hero with a Basic Ability grants 1 Chaos. Chaos can stack up to 3 times.  While Orphea has Chaos, her Basic Attacks against Heroes consume all Chaos, dealing 50% increased damage per stack, and healing for 100% of the damage dealt.",
         "trait": true,
@@ -124,8 +124,9 @@
         "icon": "storm_ui_icon_orphea_trait.png",
         "type": "Trait",
         "sort": 3,
-        "abilityId": "Orphea|D1",
+        "abilityId": "Orphea|D2",
         "abilityLinks": [
+          "Orphea|D2",
           "Orphea|D1"
         ]
       }
@@ -280,7 +281,10 @@
         "type": "Trait",
         "sort": 3,
         "cooldown": 10,
-        "abilityId": "Orphea|Trait"
+        "abilityId": "Orphea|D2",
+        "abilityLinks": [
+          "Orphea|D2"
+        ]
       }
     ],
     "16": [
@@ -305,8 +309,9 @@
         "icon": "storm_ui_icon_orphea_trait.png",
         "type": "Trait",
         "sort": 2,
-        "abilityId": "Orphea|D1",
+        "abilityId": "Orphea|D2",
         "abilityLinks": [
+          "Orphea|D2",
           "Orphea|D1"
         ]
       },
@@ -319,7 +324,7 @@
         "type": "Active",
         "sort": 3,
         "cooldown": 10,
-        "abilityId": "Orphea|E1",
+        "abilityId": "Orphea|Active",
         "abilityLinks": [
           "Orphea|E1"
         ]
@@ -360,8 +365,9 @@
         "icon": "storm_ui_icon_orphea_trait.png",
         "type": "Trait",
         "sort": 3,
-        "abilityId": "Orphea|D1",
+        "abilityId": "Orphea|D2",
         "abilityLinks": [
+          "Orphea|D2",
           "Orphea|D1"
         ]
       },
@@ -374,7 +380,7 @@
         "type": "Active",
         "sort": 4,
         "cooldown": 30,
-        "abilityId": "Orphea|Q1",
+        "abilityId": "Orphea|Active",
         "abilityLinks": [
           "Orphea|Q1"
         ]

--- a/hero/orphea.json
+++ b/hero/orphea.json
@@ -124,9 +124,8 @@
         "icon": "storm_ui_icon_orphea_trait.png",
         "type": "Trait",
         "sort": 3,
-        "abilityId": "Orphea|D2",
+        "abilityId": "Orphea|D1",
         "abilityLinks": [
-          "Orphea|D2",
           "Orphea|D1"
         ]
       }
@@ -281,10 +280,7 @@
         "type": "Trait",
         "sort": 3,
         "cooldown": 10,
-        "abilityId": "Orphea|D2",
-        "abilityLinks": [
-          "Orphea|D2"
-        ]
+        "abilityLinks": []
       }
     ],
     "16": [
@@ -309,9 +305,8 @@
         "icon": "storm_ui_icon_orphea_trait.png",
         "type": "Trait",
         "sort": 2,
-        "abilityId": "Orphea|D2",
+        "abilityId": "Orphea|D1",
         "abilityLinks": [
-          "Orphea|D2",
           "Orphea|D1"
         ]
       },
@@ -365,9 +360,8 @@
         "icon": "storm_ui_icon_orphea_trait.png",
         "type": "Trait",
         "sort": 3,
-        "abilityId": "Orphea|D2",
+        "abilityId": "Orphea|D1",
         "abilityLinks": [
-          "Orphea|D2",
           "Orphea|D1"
         ]
       },

--- a/hero/probius.json
+++ b/hero/probius.json
@@ -1,5 +1,5 @@
 {
-  "id": "64",
+  "id": 64,
   "shortName": "probius",
   "attributeId": "Prob",
   "cHeroId": "Probius",
@@ -20,7 +20,7 @@
   "abilities": {
     "Probius": [
       {
-        "uid": "0d2670d",
+        "uid": "9a1d2a",
         "name": "Disruption Pulse",
         "description": "Fire a burst of energy forward, dealing 142 (+5% per level) damage to all enemies it passes through.  Hitting the center of a Warp Rift will cause it to explode, dealing additional damage.",
         "hotkey": "Q",
@@ -31,7 +31,7 @@
         "type": "basic"
       },
       {
-        "uid": "543ed1c",
+        "uid": "a02798",
         "name": "Warp Rift",
         "description": "Open an unstable Warp Rift at a location that takes 1.25 seconds to arm, which then slows nearby enemies by 25% lasting 9 seconds.  Armed Warp Rifts explode when hit by Disruption Pulse, dealing 261 (+5% per level) damage to nearby enemies.  Stores up to 2 charges.",
         "hotkey": "W",
@@ -42,7 +42,7 @@
         "type": "basic"
       },
       {
-        "uid": "3119fc6",
+        "uid": "f93316",
         "name": "Photon Cannon",
         "description": "Warp in a Photon Cannon that deals 105 (+4% per level) damage per second. Lasts for 13 seconds.  Must be placed within a Pylon's Power Field.  Deactivates if it doesn't have a Pylon powering it.",
         "hotkey": "E",
@@ -52,7 +52,7 @@
         "type": "basic"
       },
       {
-        "uid": "c8b8812",
+        "uid": "cc6c2f",
         "name": "Pylon Overcharge",
         "description": "Increase the size of Pylon power fields and allow them to attack enemies within it for 96 (+4% per level) damage per second. Lasts 10 seconds.",
         "hotkey": "R",
@@ -63,7 +63,7 @@
         "type": "heroic"
       },
       {
-        "uid": "b43b831",
+        "uid": "53b44e",
         "name": "Null Gate",
         "description": "Vector Targeting Project a barrier of negative energy in the target direction that lasts 4 seconds. Enemies who touch the barrier take 68 (+4% per level) damage per second and are Slowed by 80% for as long as they remain in contact with it.",
         "hotkey": "R",
@@ -74,10 +74,9 @@
         "type": "heroic"
       },
       {
-        "uid": "ac0b052",
+        "uid": "57d91f",
         "name": "Warp In Pylon",
         "description": "Warp in a Pylon that generates a Power Field and grants vision of the surrounding area. Probius only regenerates mana while inside a Power Field.  Up to 2 Pylons can be active at a time.",
-        "hotkey": "D",
         "trait": true,
         "abilityId": "Probius|D1",
         "cooldown": 12,
@@ -85,7 +84,7 @@
         "type": "trait"
       },
       {
-        "uid": "e6b08e2",
+        "uid": "3e8f42",
         "name": "Worker Rush",
         "description": "Activate to gain an additional 60% Movement Speed for 5 seconds. Taking damage ends this effect early.  Worker Rush is always active while at the Hall of Storms.  Passive: Probius moves 10% faster by hovering over the ground.",
         "hotkey": "Z",

--- a/hero/qhira.json
+++ b/hero/qhira.json
@@ -1,5 +1,5 @@
 {
-  "id": "87",
+  "id": 87,
   "shortName": "qhira",
   "attributeId": "NXHU",
   "cHeroId": "NexusHunter",
@@ -23,7 +23,7 @@
   "abilities": {
     "Qhira": [
       {
-        "uid": "f2a96ea",
+        "uid": "c8c352",
         "name": "Carnage",
         "description": "Unleash your sword in the target direction, continuously dealing 30 (+4% per level) damage to enemies caught in its path.",
         "hotkey": "Q",
@@ -34,7 +34,7 @@
         "type": "basic"
       },
       {
-        "uid": "ca2dc4e",
+        "uid": "da6cb3",
         "name": "Blood Rage",
         "description": "Passive: Basic Attack and Ability damage cause enemies to bleed for 44 (+4% per level) damage over 4 seconds. Stacks 5 times.  Active: Qhira deals 32 (+4% per level) damage and heals for 85 (+4% per level) Health per enemy Hero affected. Damage and healing is increased by 50% per each additional stack on that Hero.",
         "hotkey": "W",
@@ -45,7 +45,7 @@
         "type": "basic"
       },
       {
-        "uid": "8a2e369",
+        "uid": "0df908",
         "name": "Revolving Sweep",
         "description": "Attach your sword on the first enemy Hero hit, dealing 96 (+4% per level) damage and Stunning them for 0.25 seconds. Once attached, Qhira becomes Immune to all effects, swinging around the target for 2.75 seconds and dealing 105 (+4% per level) damage to enemies between you and the target.  Re-activate to send you to the target's location knocking them away, dealing 108 (+4% per level) damage and Stunning them for 0.75 seconds.",
         "hotkey": "E",
@@ -56,7 +56,7 @@
         "type": "basic"
       },
       {
-        "uid": "cb30177",
+        "uid": "67c4cc",
         "name": "Unrelenting Strikes",
         "description": "Deal 44 (+4% per level) damage to nearby enemies every 0.5 seconds for 2.5 seconds as your sword grows outward. Upon expiring, deal 160 (+4% per level) damage to nearby enemy Heroes and Stun them for 1 second.",
         "hotkey": "R",
@@ -67,7 +67,7 @@
         "type": "heroic"
       },
       {
-        "uid": "6609292",
+        "uid": "9b6fac",
         "name": "Final Strike",
         "description": "After 1 second, deal 395 (+4% per level) damage to enemies in a line. This damage is increased by 25% against enemy Heroes who are below 50% Health.",
         "hotkey": "R",
@@ -78,7 +78,7 @@
         "type": "heroic"
       },
       {
-        "uid": "509bbba",
+        "uid": "23b034",
         "name": "Grappling Hook",
         "description": "Qhira fires a grappling hook that pulls her to terrain it contacts. If an enemy Hero is hit, they take 35 (+4% per level) damage and Qhira launches at them, kicking them for an additional 108 (+4% per level) damage.  Can be used while Revolving Sweep is active.",
         "trait": true,
@@ -122,7 +122,7 @@
         "tooltipId": "NexusHunterFinishingTouch",
         "talentTreeId": "NexusHunterFinishingTouch",
         "name": "Finishing Touch",
-        "description": "When Qhira Basic Attacks an enemy Hero below 50% Health it deals 30% additional damage, and she gains 35% Attack Speed for 3 seconds.",
+        "description": "Gain 15%  Basic Attack damage. When Qhira Basic Attacks an enemy Hero below 50% Health it deals 15% additional damage, and she gains 35% Attack Speed for 3 seconds.",
         "icon": "storm_ui_icon_nexushunter_passive.png",
         "type": "Passive",
         "sort": 3,
@@ -154,8 +154,9 @@
         "icon": "storm_ui_icon_nexushunter_e.png",
         "type": "E",
         "sort": 2,
-        "abilityId": "Qhira|E1",
+        "abilityId": "Qhira|E2",
         "abilityLinks": [
+          "Qhira|E2",
           "Qhira|E1"
         ]
       },
@@ -208,8 +209,9 @@
         "icon": "storm_ui_icon_nexushunter_e.png",
         "type": "E",
         "sort": 3,
-        "abilityId": "Qhira|E1",
+        "abilityId": "Qhira|E2",
         "abilityLinks": [
+          "Qhira|E2",
           "Qhira|E1"
         ]
       }
@@ -266,8 +268,9 @@
         "icon": "storm_ui_icon_nexushunter_e.png",
         "type": "E",
         "sort": 2,
-        "abilityId": "Qhira|E1",
+        "abilityId": "Qhira|E2",
         "abilityLinks": [
+          "Qhira|E2",
           "Qhira|E1"
         ]
       },
@@ -294,8 +297,9 @@
         "icon": "storm_ui_icon_nexushunter_e.png",
         "type": "E",
         "sort": 1,
-        "abilityId": "Qhira|E1",
+        "abilityId": "Qhira|E2",
         "abilityLinks": [
+          "Qhira|E2",
           "Qhira|E1"
         ]
       },
@@ -307,8 +311,9 @@
         "icon": "storm_ui_icon_nexushunter_e_alt_1.png",
         "type": "E",
         "sort": 2,
-        "abilityId": "Qhira|E1",
+        "abilityId": "Qhira|E2",
         "abilityLinks": [
+          "Qhira|E2",
           "Qhira|E1"
         ]
       },
@@ -320,8 +325,9 @@
         "icon": "storm_ui_icon_nexushunter_e_alt_2.png",
         "type": "E",
         "sort": 3,
-        "abilityId": "Qhira|E1",
+        "abilityId": "Qhira|E2",
         "abilityLinks": [
+          "Qhira|E2",
           "Qhira|E1"
         ]
       }

--- a/hero/qhira.json
+++ b/hero/qhira.json
@@ -154,9 +154,8 @@
         "icon": "storm_ui_icon_nexushunter_e.png",
         "type": "E",
         "sort": 2,
-        "abilityId": "Qhira|E2",
+        "abilityId": "Qhira|E1",
         "abilityLinks": [
-          "Qhira|E2",
           "Qhira|E1"
         ]
       },
@@ -209,9 +208,8 @@
         "icon": "storm_ui_icon_nexushunter_e.png",
         "type": "E",
         "sort": 3,
-        "abilityId": "Qhira|E2",
+        "abilityId": "Qhira|E1",
         "abilityLinks": [
-          "Qhira|E2",
           "Qhira|E1"
         ]
       }
@@ -268,9 +266,8 @@
         "icon": "storm_ui_icon_nexushunter_e.png",
         "type": "E",
         "sort": 2,
-        "abilityId": "Qhira|E2",
+        "abilityId": "Qhira|E1",
         "abilityLinks": [
-          "Qhira|E2",
           "Qhira|E1"
         ]
       },
@@ -297,9 +294,8 @@
         "icon": "storm_ui_icon_nexushunter_e.png",
         "type": "E",
         "sort": 1,
-        "abilityId": "Qhira|E2",
+        "abilityId": "Qhira|E1",
         "abilityLinks": [
-          "Qhira|E2",
           "Qhira|E1"
         ]
       },
@@ -311,9 +307,8 @@
         "icon": "storm_ui_icon_nexushunter_e_alt_1.png",
         "type": "E",
         "sort": 2,
-        "abilityId": "Qhira|E2",
+        "abilityId": "Qhira|E1",
         "abilityLinks": [
-          "Qhira|E2",
           "Qhira|E1"
         ]
       },
@@ -325,9 +320,8 @@
         "icon": "storm_ui_icon_nexushunter_e_alt_2.png",
         "type": "E",
         "sort": 3,
-        "abilityId": "Qhira|E2",
+        "abilityId": "Qhira|E1",
         "abilityLinks": [
-          "Qhira|E2",
           "Qhira|E1"
         ]
       }

--- a/hero/ragnaros.json
+++ b/hero/ragnaros.json
@@ -1,5 +1,5 @@
 {
-  "id": "60",
+  "id": 60,
   "shortName": "ragnaros",
   "attributeId": "Ragn",
   "cHeroId": "Ragnaros",
@@ -21,7 +21,7 @@
   "abilities": {
     "Ragnaros": [
       {
-        "uid": "cd59533",
+        "uid": "b666f7",
         "name": "Empower Sulfuras",
         "description": "Ragnaros's next Basic Attack is instant, dealing 191 (+4% per level) Ability damage in an area, and heals for 20% of the damage dealt. Healing doubled versus Heroes.  Molten Core: Molten Swing Stun and damage nearby enemies.",
         "hotkey": "Q",
@@ -32,7 +32,7 @@
         "type": "basic"
       },
       {
-        "uid": "2f35dd0",
+        "uid": "f29115",
         "name": "Living Meteor",
         "description": "Vector Targeting Summon a meteor at the target point that deals 68 (+4% per level) damage, then rolls in the target direction dealing 272 (+4% per level) damage per second for 1.75 seconds.  Molten Core: Meteor Shower Drop a line of meteor impacts.",
         "hotkey": "W",
@@ -43,7 +43,7 @@
         "type": "basic"
       },
       {
-        "uid": "b34d04d",
+        "uid": "64c349",
         "name": "Blast Wave",
         "description": "Ignite Ragnaros or an ally, granting 25% Movement Speed for 1.5 seconds before exploding dealing 104 (+4% per level) damage to nearby enemies.  Molten Core: Explosive Rune Cause a delayed explosion in a large area.",
         "hotkey": "E",
@@ -54,7 +54,7 @@
         "type": "basic"
       },
       {
-        "uid": "9b8215f",
+        "uid": "a636e9",
         "name": "Sulfuras Smash",
         "description": "Hurl Sulfuras at the target area, landing after 0.75 seconds, dealing 198 (+4% per level) damage. Enemies in the center take 594 (+4% per level) damage instead and are Stunned for 0.5 seconds.",
         "hotkey": "R",
@@ -65,7 +65,7 @@
         "type": "heroic"
       },
       {
-        "uid": "cb554cf",
+        "uid": "355e2d",
         "name": "Lava Wave",
         "description": "Release a wave of lava from Ragnaros's Core that travels down the targeted lane, dealing 240 (+4% per level) damage per second to non-Structure enemies in its path and instantly killing enemy Minions. Damage increased by 100% versus Heroes.",
         "hotkey": "R",
@@ -76,10 +76,9 @@
         "type": "heroic"
       },
       {
-        "uid": "9f58180",
+        "uid": "cbaafa",
         "name": "Molten Core",
         "description": "Channel on an allied or destroyed Fort or Keep to replace it with Ragnaros's ultimate form, temporarily gaining new Abilities, having 3996 (+4% per level) Health that burns away over 18 seconds.  Ragnaros returns to his normal form upon losing all Health in Molten Core.",
-        "hotkey": "D",
         "trait": true,
         "abilityId": "Ragnaros|D1",
         "cooldown": 120,
@@ -89,44 +88,92 @@
     ],
     "RagnarosBigRag": [
       {
-        "uid": "1553849",
-        "name": "Molten Swing",
-        "description": "Swing Sulfuras in a wide arc, dealing 161 (+4% per level) damage and Stunning enemies for 1 second.  Damage increased by 25% versus Minions, Mercenaries, and Monsters.",
-        "hotkey": "Q",
-        "abilityId": "Ragnaros|Q2",
-        "cooldown": 6,
-        "icon": "storm_ui_icon_ragnaros_moltenswing.png",
-        "type": "subunit"
-      },
-      {
-        "uid": "d5c7b3c",
-        "name": "Meteor Shower",
-        "description": "Vector Targeting Summon 3 meteors at the target point that fall in the target direction. Each meteor deals 151 (+4% per level) damage and slows enemies by 25% for 2 seconds.  Damage increased by 25% versus Minions, Mercenaries, and Monsters.",
-        "hotkey": "W",
-        "abilityId": "Ragnaros|W2",
-        "cooldown": 2.5,
-        "icon": "storm_ui_icon_ragnaros_meteorshower.png",
-        "type": "subunit"
-      },
-      {
-        "uid": "974f66b",
-        "name": "Explosive Rune",
-        "description": "Create a rune that deals 285 (+4% per level) damage to non-Structure enemies after 1.5 seconds.  Damage increased by 25% versus Minions, Mercenaries, and Monsters.",
-        "hotkey": "E",
-        "abilityId": "Ragnaros|E2",
-        "cooldown": 4,
-        "icon": "storm_ui_icon_ragnaros_explosiverune.png",
-        "type": "subunit"
-      },
-      {
-        "uid": "93601b9",
+        "uid": "2a388b",
         "name": "Sulfuras Smash",
         "description": "Hurl Sulfuras at the target area, landing after 0.75 seconds, dealing 198 (+4% per level) damage. Enemies in the center take 594 (+4% per level) damage instead and are Stunned for 0.5 seconds.",
         "hotkey": "R",
         "abilityId": "Ragnaros|R3",
         "cooldown": 80,
         "icon": "storm_ui_icon_ragnaros_sulfurassmash.png",
-        "type": "subunit"
+        "type": "heroic"
+      },
+      {
+        "uid": "3ce02a",
+        "name": "Empower Sulfuras",
+        "description": "Ragnaros's next Basic Attack is instant, dealing 191 (+4% per level) Ability damage in an area, and heals for 20% of the damage dealt. Healing doubled versus Heroes.  Molten Core: Molten Swing Stun and damage nearby enemies.",
+        "hotkey": "Q",
+        "abilityId": "Ragnaros|Q2",
+        "icon": "storm_ui_icon_ragnaros_empowersulfuras_active.png",
+        "type": "basic"
+      },
+      {
+        "uid": "0479e0",
+        "name": "Shifting Meteor",
+        "description": "Change the direction of Living Meteor.",
+        "hotkey": "W",
+        "abilityId": "Ragnaros|W2",
+        "cooldown": 3,
+        "icon": "storm_ui_icon_ragnaros_shiftingmeteor.png",
+        "type": "basic"
+      },
+      {
+        "uid": "b06941",
+        "name": "Explosive Rune",
+        "description": "Create a rune that deals 285 (+4% per level) damage to non-Structure enemies after 1.5 seconds.  Damage increased by 25% versus Minions, Mercenaries, and Monsters.",
+        "hotkey": "E",
+        "abilityId": "Ragnaros|E2",
+        "cooldown": 4,
+        "icon": "storm_ui_icon_ragnaros_explosiverune.png",
+        "type": "basic"
+      },
+      {
+        "uid": "285893",
+        "name": "Return",
+        "description": "Return to original form.",
+        "trait": true,
+        "abilityId": "Ragnaros|D2",
+        "icon": "storm_ui_icon_ragnaros_return.png",
+        "type": "trait"
+      },
+      {
+        "uid": "a7507f",
+        "name": "Cancel Return",
+        "description": "Cancel returning to original form.",
+        "trait": true,
+        "abilityId": "Ragnaros|D3",
+        "icon": "hud_btn_bg_ability_cancel.png",
+        "type": "trait"
+      },
+      {
+        "uid": "2539b7",
+        "name": "Molten Swing",
+        "description": "Swing Sulfuras in a wide arc, dealing 161 (+4% per level) damage and Stunning enemies for 1 second.  Damage increased by 25% versus Minions, Mercenaries, and Monsters.",
+        "hotkey": "Q",
+        "abilityId": "Ragnaros|Q3",
+        "cooldown": 6,
+        "icon": "storm_ui_icon_ragnaros_moltenswing.png",
+        "type": "basic"
+      },
+      {
+        "uid": "145ab3",
+        "name": "Meteor Shower",
+        "description": "Vector Targeting Summon 3 meteors at the target point that fall in the target direction. Each meteor deals 151 (+4% per level) damage and slows enemies by 25% for 2 seconds.  Damage increased by 25% versus Minions, Mercenaries, and Monsters.",
+        "hotkey": "W",
+        "abilityId": "Ragnaros|W3",
+        "cooldown": 25,
+        "icon": "storm_ui_icon_ragnaros_meteorshower.png",
+        "type": "basic"
+      },
+      {
+        "uid": "355e2d",
+        "name": "Lava Wave",
+        "description": "Release a wave of lava from Ragnaros's Core that travels down the targeted lane, dealing 240 (+4% per level) damage per second to non-Structure enemies in its path and instantly killing enemy Minions. Damage increased by 100% versus Heroes.",
+        "hotkey": "R",
+        "abilityId": "Ragnaros|R4",
+        "cooldown": 120,
+        "manaCost": 80,
+        "icon": "storm_ui_icon_ragnaros_lavawave.png",
+        "type": "heroic"
       }
     ]
   },
@@ -141,10 +188,10 @@
         "type": "Q",
         "sort": 1,
         "isQuest": true,
-        "abilityId": "Ragnaros|Q1",
+        "abilityId": "Ragnaros|Q2",
         "abilityLinks": [
-          "Ragnaros|Q1",
-          "Ragnaros|Q2"
+          "Ragnaros|Q2",
+          "Ragnaros|Q1"
         ]
       },
       {
@@ -224,10 +271,10 @@
         "icon": "storm_ui_icon_ragnaros_empowersulfuras.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "Ragnaros|Q1",
+        "abilityId": "Ragnaros|Q2",
         "abilityLinks": [
-          "Ragnaros|Q1",
-          "Ragnaros|Q2"
+          "Ragnaros|Q2",
+          "Ragnaros|Q1"
         ]
       },
       {
@@ -278,9 +325,9 @@
         "type": "Heroic",
         "sort": 2,
         "cooldown": 120,
-        "abilityId": "Ragnaros|R2",
+        "abilityId": "Ragnaros|R4",
         "abilityLinks": [
-          "Ragnaros|R2"
+          "Ragnaros|R4"
         ]
       }
     ],
@@ -293,10 +340,10 @@
         "icon": "storm_ui_icon_ragnaros_empowersulfuras.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "Ragnaros|Q1",
+        "abilityId": "Ragnaros|Q2",
         "abilityLinks": [
-          "Ragnaros|Q1",
-          "Ragnaros|Q2"
+          "Ragnaros|Q2",
+          "Ragnaros|Q1"
         ]
       },
       {
@@ -332,10 +379,10 @@
         "icon": "storm_ui_icon_ragnaros_empowersulfuras.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "Ragnaros|Q1",
+        "abilityId": "Ragnaros|Q2",
         "abilityLinks": [
-          "Ragnaros|Q1",
-          "Ragnaros|Q2"
+          "Ragnaros|Q2",
+          "Ragnaros|Q1"
         ]
       },
       {
@@ -388,9 +435,9 @@
         "icon": "storm_ui_icon_ragnaros_lavawave.png",
         "type": "Heroic",
         "sort": 2,
-        "abilityId": "Ragnaros|R2",
+        "abilityId": "Ragnaros|R4",
         "abilityLinks": [
-          "Ragnaros|R2"
+          "Ragnaros|R4"
         ]
       },
       {

--- a/hero/raynor.json
+++ b/hero/raynor.json
@@ -94,9 +94,8 @@
         "type": "Trait",
         "sort": 1,
         "isQuest": true,
-        "abilityId": "Raynor|D2",
+        "abilityId": "Raynor|D1",
         "abilityLinks": [
-          "Raynor|D2",
           "Raynor|D1"
         ]
       },
@@ -110,7 +109,6 @@
         "sort": 2,
         "abilityId": "Raynor|Passive",
         "abilityLinks": [
-          "Raynor|D2",
           "Raynor|D1"
         ]
       },
@@ -124,7 +122,6 @@
         "sort": 3,
         "abilityId": "Raynor|Passive",
         "abilityLinks": [
-          "Raynor|D2",
           "Raynor|D1"
         ]
       }
@@ -151,9 +148,8 @@
         "icon": "storm_ui_icon_raynor_acquireweakspot.png",
         "type": "Trait",
         "sort": 2,
-        "abilityId": "Raynor|D2",
+        "abilityId": "Raynor|D1",
         "abilityLinks": [
-          "Raynor|D2",
           "Raynor|D1"
         ]
       },
@@ -168,7 +164,6 @@
         "isQuest": true,
         "abilityId": "Raynor|Passive",
         "abilityLinks": [
-          "Raynor|D2",
           "Raynor|D1"
         ]
       }
@@ -196,9 +191,8 @@
         "icon": "storm_ui_icon_raynor_acquireweakspot.png",
         "type": "Trait",
         "sort": 2,
-        "abilityId": "Raynor|D2",
+        "abilityId": "Raynor|D1",
         "abilityLinks": [
-          "Raynor|D2",
           "Raynor|D1"
         ]
       },
@@ -356,8 +350,7 @@
         "sort": 2,
         "abilityId": "Raynor|R2",
         "abilityLinks": [
-          "Raynor|R2",
-          "Raynor|R3"
+          "Raynor|R2"
         ]
       },
       {
@@ -368,9 +361,8 @@
         "icon": "storm_ui_icon_raynor_acquireweakspot.png",
         "type": "Trait",
         "sort": 3,
-        "abilityId": "Raynor|D2",
+        "abilityId": "Raynor|D1",
         "abilityLinks": [
-          "Raynor|D2",
           "Raynor|D1"
         ]
       },
@@ -384,7 +376,6 @@
         "sort": 4,
         "abilityId": "Raynor|Passive",
         "abilityLinks": [
-          "Raynor|D2",
           "Raynor|D1"
         ]
       }

--- a/hero/raynor.json
+++ b/hero/raynor.json
@@ -1,5 +1,5 @@
 {
-  "id": "13",
+  "id": 13,
   "shortName": "raynor",
   "attributeId": "Rayn",
   "cHeroId": "Raynor",
@@ -19,7 +19,7 @@
   "abilities": {
     "Raynor": [
       {
-        "uid": "d135872",
+        "uid": "40a0cc",
         "name": "Penetrating Round",
         "description": "Deal 220 (+4% per level) damage, knock back, and Slow enemies in a line by 20% for 2 seconds. Enemies close to Raynor are knocked back further.",
         "hotkey": "Q",
@@ -30,7 +30,7 @@
         "type": "basic"
       },
       {
-        "uid": "7f67c07",
+        "uid": "3a4b44",
         "name": "Inspire",
         "description": "Raynor and all nearby allied Minions and Mercenaries gain 30% Attack Speed and 10% Movement Speed for 4 seconds.  Casting Inspire resets Raynor's Basic Attack cooldown.",
         "hotkey": "W",
@@ -41,7 +41,7 @@
         "type": "basic"
       },
       {
-        "uid": "c6fbec0",
+        "uid": "01991c",
         "name": "Adrenaline Rush",
         "description": "Heal Raynor for 25% of his maximum Health over 1 second. Raynor's Basic Attacks lower the cooldown of this by 0.5 seconds, doubled against Heroes.",
         "hotkey": "E",
@@ -52,7 +52,7 @@
         "type": "basic"
       },
       {
-        "uid": "7847316",
+        "uid": "9b4247",
         "name": "Hyperion",
         "description": "Order the Hyperion to make a strafing run for 12 seconds, hitting up to 4 enemies for 66 (+4% per level) damage every second. Every 4 seconds, it can fire its Yamato Cannon at a Structure, dealing 794 (+4% per level) damage.",
         "hotkey": "R",
@@ -63,7 +63,7 @@
         "type": "heroic"
       },
       {
-        "uid": "900f6e7",
+        "uid": "5e6187",
         "name": "Raynor's Raider",
         "description": "Summon a Banshee that assists Raynor. The Banshee deals 84 (+4% per level) damage per second and regenerates 75 (+4% per level) Health per second if it hasn't taken damage in the last 4 seconds. Can reactivate to retarget or move the Banshee.  The Banshee respawns automatically after 45 seconds.",
         "hotkey": "R",
@@ -73,7 +73,7 @@
         "type": "heroic"
       },
       {
-        "uid": "f17494f",
+        "uid": "9b3918",
         "name": "Give 'Em Some Pepper",
         "description": "Every 4th Basic Attack splashes in a small area and deals 125% more damage to the main target.",
         "trait": true,
@@ -94,8 +94,9 @@
         "type": "Trait",
         "sort": 1,
         "isQuest": true,
-        "abilityId": "Raynor|D1",
+        "abilityId": "Raynor|D2",
         "abilityLinks": [
+          "Raynor|D2",
           "Raynor|D1"
         ]
       },
@@ -109,6 +110,7 @@
         "sort": 2,
         "abilityId": "Raynor|Passive",
         "abilityLinks": [
+          "Raynor|D2",
           "Raynor|D1"
         ]
       },
@@ -122,6 +124,7 @@
         "sort": 3,
         "abilityId": "Raynor|Passive",
         "abilityLinks": [
+          "Raynor|D2",
           "Raynor|D1"
         ]
       }
@@ -148,8 +151,9 @@
         "icon": "storm_ui_icon_raynor_acquireweakspot.png",
         "type": "Trait",
         "sort": 2,
-        "abilityId": "Raynor|D1",
+        "abilityId": "Raynor|D2",
         "abilityLinks": [
+          "Raynor|D2",
           "Raynor|D1"
         ]
       },
@@ -164,6 +168,7 @@
         "isQuest": true,
         "abilityId": "Raynor|Passive",
         "abilityLinks": [
+          "Raynor|D2",
           "Raynor|D1"
         ]
       }
@@ -191,8 +196,9 @@
         "icon": "storm_ui_icon_raynor_acquireweakspot.png",
         "type": "Trait",
         "sort": 2,
-        "abilityId": "Raynor|D1",
+        "abilityId": "Raynor|D2",
         "abilityLinks": [
+          "Raynor|D2",
           "Raynor|D1"
         ]
       },
@@ -205,7 +211,7 @@
         "type": "Active",
         "sort": 3,
         "cooldown": 30,
-        "abilityId": "Raynor|Q1",
+        "abilityId": "Raynor|Active",
         "abilityLinks": [
           "Raynor|Q1"
         ]
@@ -350,7 +356,8 @@
         "sort": 2,
         "abilityId": "Raynor|R2",
         "abilityLinks": [
-          "Raynor|R2"
+          "Raynor|R2",
+          "Raynor|R3"
         ]
       },
       {
@@ -361,8 +368,9 @@
         "icon": "storm_ui_icon_raynor_acquireweakspot.png",
         "type": "Trait",
         "sort": 3,
-        "abilityId": "Raynor|D1",
+        "abilityId": "Raynor|D2",
         "abilityLinks": [
+          "Raynor|D2",
           "Raynor|D1"
         ]
       },
@@ -376,6 +384,7 @@
         "sort": 4,
         "abilityId": "Raynor|Passive",
         "abilityLinks": [
+          "Raynor|D2",
           "Raynor|D1"
         ]
       }

--- a/hero/rehgar.json
+++ b/hero/rehgar.json
@@ -136,8 +136,7 @@
         "sort": 3,
         "abilityId": "Rehgar|D1",
         "abilityLinks": [
-          "Rehgar|D1",
-          "Rehgar|D2"
+          "Rehgar|D1"
         ]
       }
     ],
@@ -165,8 +164,7 @@
         "sort": 2,
         "abilityId": "Rehgar|D1",
         "abilityLinks": [
-          "Rehgar|D1",
-          "Rehgar|D2"
+          "Rehgar|D1"
         ]
       },
       {
@@ -201,8 +199,7 @@
         "sort": 2,
         "abilityId": "Rehgar|D1",
         "abilityLinks": [
-          "Rehgar|D1",
-          "Rehgar|D2"
+          "Rehgar|D1"
         ]
       },
       {
@@ -325,8 +322,7 @@
         "sort": 3,
         "abilityId": "Rehgar|D1",
         "abilityLinks": [
-          "Rehgar|D1",
-          "Rehgar|D2"
+          "Rehgar|D1"
         ]
       }
     ],

--- a/hero/rehgar.json
+++ b/hero/rehgar.json
@@ -1,5 +1,5 @@
 {
-  "id": "28",
+  "id": 28,
   "shortName": "rehgar",
   "attributeId": "Rehg",
   "cHeroId": "Rehgar",
@@ -23,7 +23,7 @@
   "abilities": {
     "Rehgar": [
       {
-        "uid": "eba8e87",
+        "uid": "773536",
         "name": "Chain Heal",
         "description": "Heal an ally with a wave of healing for 260 (+4% per level) Health. The wave then bounces 2 times to nearby allies within 7 range, restoring 260 (+4% per level) Health to them.",
         "hotkey": "Q",
@@ -34,7 +34,7 @@
         "type": "basic"
       },
       {
-        "uid": "718299c",
+        "uid": "659151",
         "name": "Lightning Shield",
         "description": "Imbue an ally with lightning dealing 64 (+4% per level) damage a second to nearby enemies. Lasts 5 seconds.",
         "hotkey": "W",
@@ -45,7 +45,7 @@
         "type": "basic"
       },
       {
-        "uid": "5aa4eaf",
+        "uid": "dac29d",
         "name": "Earthbind Totem",
         "description": "Create a totem that slows nearby enemies by 35%. The totem has 217 (+4% per level) Health and lasts for 8 seconds.",
         "hotkey": "E",
@@ -56,7 +56,7 @@
         "type": "basic"
       },
       {
-        "uid": "9216183",
+        "uid": "0e1193",
         "name": "Bloodlust",
         "description": "Grant nearby allied Heroes 40% Attack Speed and 35% Movement Speed and causes them to heal for 30% of the Basic Attack damage to their primary target. Lasts for 8 seconds.",
         "hotkey": "R",
@@ -67,7 +67,7 @@
         "type": "heroic"
       },
       {
-        "uid": "14acc53",
+        "uid": "bd69ac",
         "name": "Ancestral Healing",
         "description": "After 1 second, heal an allied Hero for 1180 (+4% per level) Health.",
         "hotkey": "R",
@@ -78,7 +78,16 @@
         "type": "heroic"
       },
       {
-        "uid": "8734a0b",
+        "uid": "4a70e4",
+        "name": "Ghost Wolf",
+        "description": "Instead of using a mount, Rehgar transforms into a Ghost Wolf with 20% increased Movement Speed. Basic Attacks in Ghost Wolf form cause him to lunge at his target and deal 75% bonus damage. Dealing damage, using Abilities, and channeling cancels Ghost Wolf form.",
+        "trait": true,
+        "abilityId": "Rehgar|D1",
+        "icon": "storm_ui_icon_rehgar_ghostwolf.png",
+        "type": "trait"
+      },
+      {
+        "uid": "f6d67e",
         "name": "Ghost Wolf",
         "description": "Increases Movement Speed by 20%.",
         "hotkey": "Z",
@@ -86,15 +95,6 @@
         "cooldown": 4,
         "icon": "storm_ui_icon_rehgar_mount.png",
         "type": "mount"
-      },
-      {
-        "uid": "2bf11d7",
-        "name": "Ghost Wolf",
-        "description": "Instead of using a mount, Rehgar transforms into a Ghost Wolf with 20% increased Movement Speed. Basic Attacks in Ghost Wolf form cause him to lunge at his target and deal 75% bonus damage. Dealing damage, using Abilities, and channeling cancels Ghost Wolf form.",
-        "trait": true,
-        "abilityId": "Rehgar|D1",
-        "icon": "storm_ui_icon_rehgar_ghostwolf.png",
-        "type": "trait"
       }
     ]
   },
@@ -136,7 +136,8 @@
         "sort": 3,
         "abilityId": "Rehgar|D1",
         "abilityLinks": [
-          "Rehgar|D1"
+          "Rehgar|D1",
+          "Rehgar|D2"
         ]
       }
     ],
@@ -164,7 +165,8 @@
         "sort": 2,
         "abilityId": "Rehgar|D1",
         "abilityLinks": [
-          "Rehgar|D1"
+          "Rehgar|D1",
+          "Rehgar|D2"
         ]
       },
       {
@@ -184,11 +186,10 @@
         "tooltipId": "RehgarEarthbindTotemGroundedTotem",
         "talentTreeId": "RehgarEarthbindTotemGroundedTotem",
         "name": "Grounded Totem",
-        "description": "Increase the Health of Earthbind Totem by 100%.  Enemy Heroes who are Slowed by Earthbind Totem also have their Attack Speed Slowed by 40%.",
+        "description": "Increase the Health of Earthbind Totem by 100%.  Enemy Heroes who are Slowed by Earthbind Totem also have their Attack Speed Slowed by 40%. ",
         "icon": "storm_ui_icon_rehgar_earthbindtotem.png",
         "type": "E",
-        "sort": 1,
-        "abilityId": "Rehgar|E"
+        "sort": 1
       },
       {
         "tooltipId": "RehgarBloodAndThunder",
@@ -200,7 +201,8 @@
         "sort": 2,
         "abilityId": "Rehgar|D1",
         "abilityLinks": [
-          "Rehgar|D1"
+          "Rehgar|D1",
+          "Rehgar|D2"
         ]
       },
       {
@@ -323,7 +325,8 @@
         "sort": 3,
         "abilityId": "Rehgar|D1",
         "abilityLinks": [
-          "Rehgar|D1"
+          "Rehgar|D1",
+          "Rehgar|D2"
         ]
       }
     ],

--- a/hero/rexxar.json
+++ b/hero/rexxar.json
@@ -203,8 +203,7 @@
         "sort": 3,
         "abilityId": "Rexxar|W1",
         "abilityLinks": [
-          "Rexxar|W1",
-          "Rexxar|W2"
+          "Rexxar|W1"
         ]
       }
     ],
@@ -262,8 +261,7 @@
         "sort": 2,
         "abilityId": "Rexxar|W1",
         "abilityLinks": [
-          "Rexxar|W1",
-          "Rexxar|W2"
+          "Rexxar|W1"
         ]
       },
       {

--- a/hero/rexxar.json
+++ b/hero/rexxar.json
@@ -1,5 +1,5 @@
 {
-  "id": "41",
+  "id": 41,
   "shortName": "rexxar",
   "attributeId": "Rexx",
   "cHeroId": "Rexxar",
@@ -21,7 +21,7 @@
   "abilities": {
     "Rexxar": [
       {
-        "uid": "75987bf",
+        "uid": "911dc8",
         "name": "Spirit Swoop",
         "description": "Deal 141 (+4% per level) damage to enemies in a line, slowing them by 30% for 2 seconds.",
         "hotkey": "Q",
@@ -32,7 +32,7 @@
         "type": "basic"
       },
       {
-        "uid": "5f656bf",
+        "uid": "3a5c78",
         "name": "Misha, Charge!",
         "description": "Misha charges in a line, dealing 150 (+4% per level) damage and stunning enemies for 1.25 seconds.",
         "hotkey": "W",
@@ -43,18 +43,18 @@
         "type": "basic"
       },
       {
-        "uid": "01525a6",
+        "uid": "dc4fef",
         "name": "Mend Pet",
         "description": "Heal Misha for 714 (+4% per level) Health over 5 seconds.",
         "hotkey": "E",
         "abilityId": "Rexxar|E1",
         "cooldown": 10,
-        "manaCost": 55,
+        "manaCost": 60,
         "icon": "storm_ui_icon_rexxar_mendpet.png",
         "type": "basic"
       },
       {
-        "uid": "58265ee",
+        "uid": "d6d53c",
         "name": "Unleash the Boars",
         "description": "Release a herd of boars that track down all enemy Heroes in a direction, dealing 110 (+4% per level) damage, revealing, and slowing enemies by 40% for 5 seconds.",
         "hotkey": "R",
@@ -65,7 +65,7 @@
         "type": "heroic"
       },
       {
-        "uid": "1bbda6e",
+        "uid": "876546",
         "name": "Bestial Wrath",
         "description": "Increases Misha's Basic Attack damage by 200% for 12 seconds.",
         "hotkey": "R",
@@ -76,10 +76,9 @@
         "type": "heroic"
       },
       {
-        "uid": "9273f1a",
+        "uid": "3e1bbf",
         "name": "Misha, Focus!",
         "description": "Passive: Misha gains 15% move speed.  Command Misha to attack a specific enemy or move to a point and wait.  Targeting Rexxar commands Misha to retreat to his position, gaining 30% move speed until she reaches Rexxar.  Targeting Misha commands her to hold her current position.",
-        "hotkey": "D",
         "trait": true,
         "abilityId": "Rexxar|D1",
         "icon": "storm_ui_icon_rexxar_mishafixate.png",
@@ -106,7 +105,7 @@
         "tooltipId": "RexxarSpiritBondEasyPreyTalent",
         "talentTreeId": "RexxarSpiritBondEasyPrey",
         "name": "Easy Prey",
-        "description": "Increases Misha's basic attack damage to Minions and Mercenaries by 200%, and Misha gains 50 Armor against Minions and Mercenaries, reducing damage taken by 50%.",
+        "description": "Increases Misha's basic attack damage to Minions and Mercenaries by 150%, and Misha gains 50 Armor against Minions and Mercenaries, reducing damage taken by 50%.",
         "icon": "storm_ui_icon_rexxar_heremishaactive.png",
         "type": "Passive",
         "sort": 2,
@@ -139,7 +138,7 @@
         "tooltipId": "RexxarHunterGathererTalent",
         "talentTreeId": "RexxarHunterGatherer",
         "name": "Hunter-Gatherer",
-        "description": "Quest: Gathering a Regeneration Globe increases Rexxar's Health Regeneration by 1.25 per second, up to 25 per second.  Reward: After gathering 20 Globes, Rexxar and Misha gain 15 Armor.",
+        "description": "Quest: Gathering a Regeneration Globe increases Rexxar's Health Regeneration by 1 per second, up to 25 per second.  Reward: After gathering 25 Globes, Rexxar and Misha gain 15 Armor.",
         "icon": "storm_ui_icon_talent_regenerationmaster.png",
         "type": "Passive",
         "sort": 2,

--- a/hero/samuro.json
+++ b/hero/samuro.json
@@ -1,5 +1,5 @@
 {
-  "id": "58",
+  "id": 58,
   "shortName": "samuro",
   "attributeId": "Samu",
   "cHeroId": "Samuro",
@@ -21,7 +21,7 @@
   "abilities": {
     "Samuro": [
       {
-        "uid": "e8420b6",
+        "uid": "12473b",
         "name": "Mirror Image",
         "description": "Teleport a short distance in the direction of the mouse cursor, creating 2 Mirror Images for 18 seconds with 100% of Samuro's current Health that Basic Attack enemies for 9 (+4% per level) damage. Whenever an Image takes damage, it deals that amount of damage to itself, effectively doubling the damage it takes.  Maximum 2 Mirror Images can be active at at time. Using Mirror Image removes most negative effects from Samuro.",
         "hotkey": "Q",
@@ -31,17 +31,17 @@
         "type": "basic"
       },
       {
-        "uid": "e173a9c",
+        "uid": "13e57d",
         "name": "Critical Strike",
         "description": "Samuro's next Basic Attack within 8 seconds will be a Critical Strike, dealing 50% increased damage. This also applies to Images, and does not break Wind Walk.  Passive: Samuro and his Images deal a Critical Strike on every 4th Basic Attack.",
         "hotkey": "W",
         "abilityId": "Samuro|W1",
-        "cooldown": 10,
+        "cooldown": 410,
         "icon": "storm_ui_icon_samuro_criticalstrike.png",
         "type": "basic"
       },
       {
-        "uid": "6ad1df4",
+        "uid": "a5acdc",
         "name": "Wind Walk",
         "description": "Grant Samuro Stealth for up to 10 seconds or until he attacks, uses an Ability, or takes damage.  While Stealthed, Samuro's Movement Speed is increased by 25% and he can pass through other units. Remaining stationary for at least 1.5 seconds while Stealthed grants Invisible.  Samuro is Unrevealable for the first 1 second of Wind Walk.",
         "hotkey": "E",
@@ -51,7 +51,25 @@
         "type": "basic"
       },
       {
-        "uid": "46ea882",
+        "uid": "913d37",
+        "name": "Select Samuro",
+        "description": "Select Samuro  Issue orders to Samuro only.",
+        "hotkey": 1,
+        "abilityId": "Samuro|11",
+        "icon": "storm_temp_war3_btnheroblademaster.png",
+        "type": "activable"
+      },
+      {
+        "uid": "10e268",
+        "name": "Select All",
+        "description": "Select All  Issue orders to Samuro and all Mirror Images.",
+        "hotkey": 2,
+        "abilityId": "Samuro|21",
+        "icon": "storm_ui_ingame_heroselect_btn_lostvikings.png",
+        "type": "activable"
+      },
+      {
+        "uid": "a6edad",
         "name": "Bladestorm",
         "description": "Cause a Bladestorm of destructive force around Samuro for 4 seconds, making him Unstoppable and dealing 235 (+4% per level) damage per second to nearby enemies.",
         "hotkey": "R",
@@ -61,18 +79,7 @@
         "type": "heroic"
       },
       {
-        "uid": "a07a089",
-        "name": "Image Transmission",
-        "description": "Activate to switch places with a target Mirror Image, removing most negative effects from Samuro and the Mirror Image.  Advancing Strikes  Basic Attacks against enemy Heroes increase Samuro's Movement Speed by 25% for 2 seconds.",
-        "hotkey": "R",
-        "trait": true,
-        "abilityId": "Samuro|D1",
-        "cooldown": 25,
-        "icon": "storm_ui_icon_samuro_flowingstrikes.png",
-        "type": "trait"
-      },
-      {
-        "uid": "89972c2",
+        "uid": "ca46c2",
         "name": "Illusion Master",
         "description": "Mirror Images can be controlled individually or as a group and their damage is increased by 100%.  Passive: Image Transmission's cooldown is reduced to 10 seconds.",
         "hotkey": "R",
@@ -82,22 +89,14 @@
         "type": "heroic"
       },
       {
-        "uid": "e305f55",
-        "name": "Select Samuro",
-        "description": "Select Samuro  Issue orders to Samuro only.",
-        "hotkey": "1",
-        "abilityId": "Samuro|11",
-        "icon": "storm_temp_war3_btnheroblademaster.png",
-        "type": "activable"
-      },
-      {
-        "uid": "89be25e",
-        "name": "Select All",
-        "description": "Select All  Issue orders to Samuro and all Mirror Images.",
-        "hotkey": "2",
-        "abilityId": "Samuro|21",
-        "icon": "storm_ui_ingame_heroselect_btn_lostvikings.png",
-        "type": "activable"
+        "uid": "2aeacd",
+        "name": "Image Transmission",
+        "description": "Activate to switch places with a target Mirror Image, removing most negative effects from Samuro and the Mirror Image.  Advancing Strikes  Basic Attacks against enemy Heroes increase Samuro's Movement Speed by 25% for 2 seconds.",
+        "trait": true,
+        "abilityId": "Samuro|D1",
+        "cooldown": 25,
+        "icon": "storm_ui_icon_samuro_flowingstrikes.png",
+        "type": "trait"
       }
     ]
   },
@@ -359,8 +358,7 @@
         "description": "Samuro's Mirror Images no longer take additional damage, effecively increasing their health by 50% and their duration is increased to 36 seconds.",
         "icon": "storm_ui_icon_samuro_illusiondancer.png",
         "type": "Heroic",
-        "sort": 2,
-        "abilityId": "Samuro|Heroic"
+        "sort": 2
       },
       {
         "tooltipId": "SamuroWindStrider",
@@ -378,7 +376,7 @@
       {
         "tooltipId": "SamuroBlademastersPursuitTalent",
         "talentTreeId": "SamuroBlademastersPursuit",
-        "name": "Blademaster's Pursuit",
+        "name": "Blademaster’s Pursuit",
         "description": "Advancing Strikes grants an additional 15% Movement Speed for Samuro and his Mirror Images, and its duration is increased by 2 seconds.",
         "icon": "storm_ui_icon_samuro_flowingstrikes.png",
         "type": "Passive",

--- a/hero/sgthammer.json
+++ b/hero/sgthammer.json
@@ -189,9 +189,8 @@
         "icon": "storm_ui_icon_sgthammer_spidermines.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "SgtHammer|Q2",
+        "abilityId": "SgtHammer|Q1",
         "abilityLinks": [
-          "SgtHammer|Q2",
           "SgtHammer|Q1"
         ]
       },
@@ -261,9 +260,8 @@
         "icon": "storm_ui_icon_sgthammer_spidermines.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "SgtHammer|Q2",
+        "abilityId": "SgtHammer|Q1",
         "abilityLinks": [
-          "SgtHammer|Q2",
           "SgtHammer|Q1"
         ]
       },
@@ -351,9 +349,8 @@
         "icon": "storm_ui_icon_sgthammer_napalmstrike.png",
         "type": "Heroic",
         "sort": 2,
-        "abilityId": "SgtHammer|R3",
+        "abilityId": "SgtHammer|R1",
         "abilityLinks": [
-          "SgtHammer|R3",
           "SgtHammer|R1"
         ]
       },
@@ -365,9 +362,8 @@
         "icon": "storm_ui_icon_sgthammer_spidermines.png",
         "type": "Q",
         "sort": 3,
-        "abilityId": "SgtHammer|Q2",
+        "abilityId": "SgtHammer|Q1",
         "abilityLinks": [
-          "SgtHammer|Q2",
           "SgtHammer|Q1"
         ]
       },

--- a/hero/sgthammer.json
+++ b/hero/sgthammer.json
@@ -1,5 +1,5 @@
 {
-  "id": "14",
+  "id": 14,
   "shortName": "sgthammer",
   "attributeId": "Sgth",
   "cHeroId": "SgtHammer",
@@ -18,79 +18,78 @@
     "WaveClearer"
   ],
   "abilities": {
-    "Sgt. Hammer": [
+    "SgtHammer": [
       {
-        "uid": "2d5145f",
+        "uid": "52b5be",
         "name": "Spider Mines",
         "description": "Create 3 mines that arm after 1.25 seconds. Mines detonate when an enemy comes in range, dealing 96 (+4% per level) damage to nearby enemies and Slowing them by 25% for 1.5 seconds.  Siege Mode: Cast range increased by 100%.",
         "hotkey": "Q",
-        "abilityId": "Sgt. Hammer|Q1",
+        "abilityId": "SgtHammer|Q1",
         "cooldown": 14,
         "manaCost": 50,
         "icon": "storm_ui_icon_sgthammer_spidermines.png",
         "type": "basic"
       },
       {
-        "uid": "ff8e49f",
+        "uid": "0cd2d7",
         "name": "Concussive Blast",
         "description": "Deal 141 (+4% per level) damage to enemies in front of Sgt. Hammer and knock them back.  Siege Mode: Radius increased by 50%.",
         "hotkey": "W",
-        "abilityId": "Sgt. Hammer|W1",
+        "abilityId": "SgtHammer|W1",
         "cooldown": 12,
         "manaCost": 80,
         "icon": "storm_ui_icon_sgthammer_concussiveblast.png",
         "type": "basic"
       },
       {
-        "uid": "7c9e801",
+        "uid": "96ef87",
         "name": "Neosteel Plating",
         "description": "Gain 25 Armor for 2 seconds.  Siege Mode: Grants 100% more Armor.",
         "hotkey": "E",
-        "abilityId": "Sgt. Hammer|E1",
+        "abilityId": "SgtHammer|E1",
         "cooldown": 16,
         "manaCost": 60,
         "icon": "storm_ui_icon_sgthammer_neosteelplating.png",
         "type": "basic"
       },
       {
-        "uid": "7c907f5",
+        "uid": "603a80",
         "name": "Napalm Strike",
         "description": "Deals 164 (+4% per level) damage on impact, and leaves a napalm area that deals 50 (+4% per level) damage per second. Lasts for 4 seconds.",
         "hotkey": "R",
-        "abilityId": "Sgt. Hammer|R1",
+        "abilityId": "SgtHammer|R1",
         "cooldown": 6,
         "manaCost": 35,
         "icon": "storm_ui_icon_sgthammer_napalmstrike.png",
         "type": "heroic"
       },
       {
-        "uid": "3cddb88",
+        "uid": "9e7cc6",
         "name": "Blunt Force Gun",
         "description": "Fire a missile across the battlefield, dealing 500 (+3% per level) damage to non-Structure enemies in its path.",
         "hotkey": "R",
-        "abilityId": "Sgt. Hammer|R2",
+        "abilityId": "SgtHammer|R2",
         "cooldown": 70,
         "manaCost": 100,
         "icon": "storm_ui_icon_sgthammer_bluntforcegun.png",
         "type": "heroic"
       },
       {
-        "uid": "fc18aeb",
+        "uid": "2e51ef",
         "name": "Siege Mode",
         "description": "Activate to enter Siege Mode. While in Siege Mode, Basic Attacks deal 20% more damage, have 100% increased range, and deal 25% of their damage as splash damage around the target.",
-        "hotkey": "D",
         "trait": true,
-        "abilityId": "Sgt. Hammer|D1",
+        "abilityId": "SgtHammer|D1",
         "cooldown": 2,
         "icon": "storm_ui_icon_sgthammer_siegemode.png",
         "type": "trait"
       },
       {
-        "uid": "f1a3526",
+        "uid": "87fc4b",
         "name": "Thrusters",
         "description": "Increase Movement Speed by 60% for 4 seconds. Thrusters are always active while at the Hall of Storms. Activating Thrusters cancels Siege Mode.",
         "hotkey": "Z",
-        "abilityId": "Sgt. Hammer|Z1",
+        "abilityId": "SgtHammer|Z1",
         "cooldown": 30,
         "icon": "storm_ui_icon_sgthammer_mount.png",
         "type": "mount"
@@ -107,9 +106,9 @@
         "icon": "storm_ui_icon_sgthammer_siegemode_var2.png",
         "type": "Trait",
         "sort": 1,
-        "abilityId": "Sgt. Hammer|D1",
+        "abilityId": "SgtHammer|D1",
         "abilityLinks": [
-          "Sgt. Hammer|D1"
+          "SgtHammer|D1"
         ]
       },
       {
@@ -120,9 +119,9 @@
         "icon": "storm_ui_icon_sgthammer_siegemode.png",
         "type": "Trait",
         "sort": 2,
-        "abilityId": "Sgt. Hammer|D1",
+        "abilityId": "SgtHammer|D1",
         "abilityLinks": [
-          "Sgt. Hammer|D1"
+          "SgtHammer|D1"
         ]
       },
       {
@@ -134,9 +133,9 @@
         "type": "Active",
         "sort": 3,
         "cooldown": 90,
-        "abilityId": "Sgt. Hammer|D1",
+        "abilityId": "SgtHammer|Active",
         "abilityLinks": [
-          "Sgt. Hammer|D1"
+          "SgtHammer|D1"
         ]
       }
     ],
@@ -149,9 +148,9 @@
         "icon": "storm_ui_icon_sgthammer_concussiveblast.png",
         "type": "W",
         "sort": 1,
-        "abilityId": "Sgt. Hammer|W1",
+        "abilityId": "SgtHammer|W1",
         "abilityLinks": [
-          "Sgt. Hammer|W1"
+          "SgtHammer|W1"
         ]
       },
       {
@@ -162,9 +161,9 @@
         "icon": "storm_ui_icon_sgthammer_neosteelplating.png",
         "type": "E",
         "sort": 2,
-        "abilityId": "Sgt. Hammer|E1",
+        "abilityId": "SgtHammer|E1",
         "abilityLinks": [
-          "Sgt. Hammer|E1"
+          "SgtHammer|E1"
         ]
       },
       {
@@ -175,9 +174,9 @@
         "icon": "storm_ui_icon_sgthammer_siegemode.png",
         "type": "Trait",
         "sort": 3,
-        "abilityId": "Sgt. Hammer|D1",
+        "abilityId": "SgtHammer|D1",
         "abilityLinks": [
-          "Sgt. Hammer|D1"
+          "SgtHammer|D1"
         ]
       }
     ],
@@ -190,9 +189,10 @@
         "icon": "storm_ui_icon_sgthammer_spidermines.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "Sgt. Hammer|Q1",
+        "abilityId": "SgtHammer|Q2",
         "abilityLinks": [
-          "Sgt. Hammer|Q1"
+          "SgtHammer|Q2",
+          "SgtHammer|Q1"
         ]
       },
       {
@@ -203,9 +203,9 @@
         "icon": "storm_ui_icon_sgthammer_siegemode.png",
         "type": "Trait",
         "sort": 2,
-        "abilityId": "Sgt. Hammer|D1",
+        "abilityId": "SgtHammer|D1",
         "abilityLinks": [
-          "Sgt. Hammer|D1"
+          "SgtHammer|D1"
         ]
       },
       {
@@ -216,9 +216,9 @@
         "icon": "storm_ui_icon_sgthammer_siegemode_var1.png",
         "type": "Trait",
         "sort": 3,
-        "abilityId": "Sgt. Hammer|D1",
+        "abilityId": "SgtHammer|D1",
         "abilityLinks": [
-          "Sgt. Hammer|D1"
+          "SgtHammer|D1"
         ]
       }
     ],
@@ -232,9 +232,9 @@
         "type": "Heroic",
         "sort": 1,
         "cooldown": 70,
-        "abilityId": "Sgt. Hammer|R2",
+        "abilityId": "SgtHammer|R2",
         "abilityLinks": [
-          "Sgt. Hammer|R2"
+          "SgtHammer|R2"
         ]
       },
       {
@@ -246,9 +246,9 @@
         "type": "Heroic",
         "sort": 2,
         "cooldown": 6,
-        "abilityId": "Sgt. Hammer|R1",
+        "abilityId": "SgtHammer|R1",
         "abilityLinks": [
-          "Sgt. Hammer|R1"
+          "SgtHammer|R1"
         ]
       }
     ],
@@ -261,9 +261,10 @@
         "icon": "storm_ui_icon_sgthammer_spidermines.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "Sgt. Hammer|Q1",
+        "abilityId": "SgtHammer|Q2",
         "abilityLinks": [
-          "Sgt. Hammer|Q1"
+          "SgtHammer|Q2",
+          "SgtHammer|Q1"
         ]
       },
       {
@@ -274,9 +275,9 @@
         "icon": "storm_ui_icon_sgthammer_concussiveblast.png",
         "type": "W",
         "sort": 2,
-        "abilityId": "Sgt. Hammer|W1",
+        "abilityId": "SgtHammer|W1",
         "abilityLinks": [
-          "Sgt. Hammer|W1"
+          "SgtHammer|W1"
         ]
       },
       {
@@ -287,9 +288,9 @@
         "icon": "storm_ui_icon_sgthammer_hypercoolingengines.png",
         "type": "Z",
         "sort": 3,
-        "abilityId": "Sgt. Hammer|Z1",
+        "abilityId": "SgtHammer|Z1",
         "abilityLinks": [
-          "Sgt. Hammer|Z1"
+          "SgtHammer|Z1"
         ]
       }
     ],
@@ -302,9 +303,9 @@
         "icon": "storm_ui_icon_sgthammer_neosteelplating.png",
         "type": "E",
         "sort": 1,
-        "abilityId": "Sgt. Hammer|E1",
+        "abilityId": "SgtHammer|E1",
         "abilityLinks": [
-          "Sgt. Hammer|E1"
+          "SgtHammer|E1"
         ]
       },
       {
@@ -315,7 +316,7 @@
         "icon": "storm_ui_icon_talent_autoattack_damage.png",
         "type": "Passive",
         "sort": 2,
-        "abilityId": "Sgt. Hammer|Passive"
+        "abilityId": "SgtHammer|Passive"
       },
       {
         "tooltipId": "SgtHammerGiantKiller",
@@ -325,7 +326,7 @@
         "icon": "storm_ui_icon_talent_autoattack_searing.png",
         "type": "Passive",
         "sort": 3,
-        "abilityId": "Sgt. Hammer|Passive"
+        "abilityId": "SgtHammer|Passive"
       }
     ],
     "20": [
@@ -337,9 +338,9 @@
         "icon": "storm_ui_icon_sgthammer_bluntforcegun.png",
         "type": "Heroic",
         "sort": 1,
-        "abilityId": "Sgt. Hammer|R2",
+        "abilityId": "SgtHammer|R2",
         "abilityLinks": [
-          "Sgt. Hammer|R2"
+          "SgtHammer|R2"
         ]
       },
       {
@@ -350,9 +351,10 @@
         "icon": "storm_ui_icon_sgthammer_napalmstrike.png",
         "type": "Heroic",
         "sort": 2,
-        "abilityId": "Sgt. Hammer|R1",
+        "abilityId": "SgtHammer|R3",
         "abilityLinks": [
-          "Sgt. Hammer|R1"
+          "SgtHammer|R3",
+          "SgtHammer|R1"
         ]
       },
       {
@@ -363,9 +365,10 @@
         "icon": "storm_ui_icon_sgthammer_spidermines.png",
         "type": "Q",
         "sort": 3,
-        "abilityId": "Sgt. Hammer|Q1",
+        "abilityId": "SgtHammer|Q2",
         "abilityLinks": [
-          "Sgt. Hammer|Q1"
+          "SgtHammer|Q2",
+          "SgtHammer|Q1"
         ]
       },
       {
@@ -376,9 +379,9 @@
         "icon": "storm_ui_icon_sgthammer_siegemode.png",
         "type": "Trait",
         "sort": 4,
-        "abilityId": "Sgt. Hammer|D1",
+        "abilityId": "SgtHammer|D1",
         "abilityLinks": [
-          "Sgt. Hammer|D1"
+          "SgtHammer|D1"
         ]
       }
     ]

--- a/hero/sonya.json
+++ b/hero/sonya.json
@@ -1,5 +1,5 @@
 {
-  "id": "15",
+  "id": 15,
   "shortName": "sonya",
   "attributeId": "Barb",
   "cHeroId": "Barbarian",
@@ -23,7 +23,7 @@
   "abilities": {
     "Sonya": [
       {
-        "uid": "dc4c43c",
+        "uid": "e00f1a",
         "name": "Ancient Spear",
         "description": "Throw out a spear that pulls Sonya to the first enemy hit, dealing 173 (+4% per level) damage and briefly stunning them. If this hits an enemy, generate 40 Fury.",
         "hotkey": "Q",
@@ -33,7 +33,7 @@
         "type": "basic"
       },
       {
-        "uid": "ae73b5d",
+        "uid": "d5fd17",
         "name": "Seismic Slam",
         "description": "Deals 176 (+4% per level) damage to the target enemy, and 44 (+4% per level) to enemies behind the target.",
         "hotkey": "W",
@@ -44,7 +44,7 @@
         "type": "basic"
       },
       {
-        "uid": "73c7823",
+        "uid": "ff8206",
         "name": "Whirlwind",
         "description": "Deals 126 (+4% per level) damage a second to nearby enemies for 3 seconds, healing for 25% of damage dealt. Healing tripled versus Heroes.",
         "hotkey": "E",
@@ -55,7 +55,7 @@
         "type": "basic"
       },
       {
-        "uid": "241be03",
+        "uid": "8713b2",
         "name": "Leap",
         "description": "Leap into the air, dealing 135 (+4% per level) damage to nearby enemies, and stunning them for 1.25 seconds.",
         "hotkey": "R",
@@ -65,7 +65,7 @@
         "type": "heroic"
       },
       {
-        "uid": "0944b4a",
+        "uid": "a64223",
         "name": "Wrath of the Berserker",
         "description": "Increase damage dealt by 40%. Reduce the duration of Stuns, Roots, and Slows against Sonya by 50%. Lasts 15 seconds, and extends by 1 second for every 10 Fury gained.",
         "hotkey": "R",
@@ -75,7 +75,7 @@
         "type": "heroic"
       },
       {
-        "uid": "df02f0a",
+        "uid": "75d813",
         "name": "Fury",
         "description": "Use Fury instead of Mana, which is gained by taking damage or dealing Basic Attack damage. Using a Basic or Heroic Ability grants 10% Movement Speed for 4 seconds.",
         "trait": true,
@@ -110,6 +110,7 @@
         "sort": 2,
         "abilityId": "Sonya|Passive",
         "abilityLinks": [
+          "Sonya|D2",
           "Sonya|D1"
         ]
       },
@@ -270,8 +271,9 @@
         "icon": "storm_ui_icon_sonya_fury.png",
         "type": "Trait",
         "sort": 3,
-        "abilityId": "Sonya|D1",
+        "abilityId": "Sonya|D2",
         "abilityLinks": [
+          "Sonya|D2",
           "Sonya|D1"
         ]
       }

--- a/hero/sonya.json
+++ b/hero/sonya.json
@@ -110,7 +110,6 @@
         "sort": 2,
         "abilityId": "Sonya|Passive",
         "abilityLinks": [
-          "Sonya|D2",
           "Sonya|D1"
         ]
       },
@@ -271,9 +270,8 @@
         "icon": "storm_ui_icon_sonya_fury.png",
         "type": "Trait",
         "sort": 3,
-        "abilityId": "Sonya|D2",
+        "abilityId": "Sonya|D1",
         "abilityLinks": [
-          "Sonya|D2",
           "Sonya|D1"
         ]
       }

--- a/hero/stitches.json
+++ b/hero/stitches.json
@@ -1,5 +1,5 @@
 {
-  "id": "16",
+  "id": 16,
   "shortName": "stitches",
   "attributeId": "Stit",
   "cHeroId": "Stitches",
@@ -21,7 +21,7 @@
   "abilities": {
     "Stitches": [
       {
-        "uid": "43f3078",
+        "uid": "d1348e",
         "name": "Hook",
         "description": "Pull the first enemy hit towards Stitches and deal 91 (+4% per level) damage.",
         "hotkey": "Q",
@@ -32,7 +32,7 @@
         "type": "basic"
       },
       {
-        "uid": "7fb2054",
+        "uid": "4e38ee",
         "name": "Slam",
         "description": "Deal 104 (+4% per level) damage to enemies within the target area. Enemies in the inner impact area take 40% more damage and are Slowed by 40% for 1.5 seconds.",
         "hotkey": "W",
@@ -43,7 +43,7 @@
         "type": "basic"
       },
       {
-        "uid": "8da45d9",
+        "uid": "7348f7",
         "name": "Devour",
         "description": "Deal 319 (+4% per level) damage to non-Heroic units, or 114 (+4% per level) damage to Heroes. Restores 20% of Stitches's maximum Health.",
         "hotkey": "E",
@@ -54,7 +54,18 @@
         "type": "basic"
       },
       {
-        "uid": "6c67c81",
+        "uid": "c954e9",
+        "name": "Helping Hand",
+        "description": "Activate to use Hook that can hit allied Heroes. When used to pull allies, the cooldown of Hook is reduced by 50%.",
+        "hotkey": 1,
+        "abilityId": "Stitches|11",
+        "cooldown": 16,
+        "manaCost": 75,
+        "icon": "storm_ui_icon_stitches_hook_var1.png",
+        "type": "activable"
+      },
+      {
+        "uid": "3c0dd1",
         "name": "Putrid Bile",
         "description": "Emit bile that deals 37 (+4% per level) damage per second to enemies within, Slowing them by 35% for 1.5 seconds. Gain 20% Movement Speed while emitting bile. Lasts 8 seconds.",
         "hotkey": "R",
@@ -65,7 +76,7 @@
         "type": "heroic"
       },
       {
-        "uid": "613b9bd",
+        "uid": "df437e",
         "name": "Gorge",
         "description": "Consume an enemy Hero, trapping them for 4 seconds. When Gorge ends, the enemy Hero takes 274 (+4% per level) damage. The trapped Hero cannot move or act and doesn't take damage from other sources.",
         "hotkey": "R",
@@ -76,18 +87,7 @@
         "type": "heroic"
       },
       {
-        "uid": "462a5e4",
-        "name": "Helping Hand",
-        "description": "Activate to use Hook that can hit allied Heroes. When used to pull allies, the cooldown of Hook is reduced by 50%.",
-        "hotkey": "1",
-        "abilityId": "Stitches|11",
-        "cooldown": 16,
-        "manaCost": 75,
-        "icon": "storm_ui_icon_stitches_hook_var1.png",
-        "type": "activable"
-      },
-      {
-        "uid": "f12fad4",
+        "uid": "44c018",
         "name": "Vile Cleaver",
         "description": "Basic Attacks splash Vile Gas, poisoning nearby enemies for 45 (+4% per level) damage over 3 seconds. Re-applying Vile Gas increases its current duration to a maximum of 10 seconds.",
         "trait": true,
@@ -201,8 +201,9 @@
         "sort": 2,
         "abilityId": "Stitches|Passive",
         "abilityLinks": [
-          "Stitches|W1",
-          "Stitches|D1"
+          "Stitches|D2",
+          "Stitches|D1",
+          "Stitches|W1"
         ]
       },
       {
@@ -215,8 +216,9 @@
         "sort": 3,
         "abilityId": "Stitches|Passive",
         "abilityLinks": [
-          "Stitches|W1",
-          "Stitches|D1"
+          "Stitches|D2",
+          "Stitches|D1",
+          "Stitches|W1"
         ]
       }
     ],

--- a/hero/stitches.json
+++ b/hero/stitches.json
@@ -201,7 +201,6 @@
         "sort": 2,
         "abilityId": "Stitches|Passive",
         "abilityLinks": [
-          "Stitches|D2",
           "Stitches|D1",
           "Stitches|W1"
         ]
@@ -216,7 +215,6 @@
         "sort": 3,
         "abilityId": "Stitches|Passive",
         "abilityLinks": [
-          "Stitches|D2",
           "Stitches|D1",
           "Stitches|W1"
         ]

--- a/hero/stukov.json
+++ b/hero/stukov.json
@@ -1,5 +1,5 @@
 {
-  "id": "69",
+  "id": 69,
   "shortName": "stukov",
   "attributeId": "STUK",
   "cHeroId": "Stukov",
@@ -21,7 +21,7 @@
   "abilities": {
     "Stukov": [
       {
-        "uid": "e4aaf6b",
+        "uid": "7dec2e",
         "name": "Healing Pathogen",
         "description": "Infest an allied Hero with a Healing Pathogen that heals the target for 222 (+4% per level) Health over 4.5 seconds. Healing Pathogens can spread to a nearby allied Hero every 0.75 seconds.  Each cast of Healing Pathogen can only spread to each allied Hero 1 time.",
         "hotkey": "Q",
@@ -32,7 +32,7 @@
         "type": "basic"
       },
       {
-        "uid": "f42e57f",
+        "uid": "7264a2",
         "name": "Weighted Pustule",
         "description": "Hurl a pustule that impacts all enemy Heroes in its path, dealing 20 (+4% per level) damage and Slowing by 5%, increasing to 50% over 3 seconds. Deals an additional 80 (+4% per level) damage upon expiring or being removed.",
         "hotkey": "W",
@@ -43,7 +43,7 @@
         "type": "basic"
       },
       {
-        "uid": "d6ef0a1",
+        "uid": "24adc9",
         "name": "Lurking Arm",
         "description": "Channel at a target location, creating an area that deals 136 (+4% per level) damage per second to non-Structure enemies and Silences them. Deals 50% reduced damage to non-Heroes.  Does not cost Mana while Channeling, and lasts until canceled or interrupted.",
         "hotkey": "E",
@@ -54,18 +54,7 @@
         "type": "basic"
       },
       {
-        "uid": "16e2f04",
-        "name": "Flailing Swipe",
-        "description": "Swipe 3 times in front of Stukov over 1.75 seconds, dealing 48 (+4% per level) damage to enemies hit and knocking them away. Each swipe is larger than the previous.",
-        "hotkey": "R",
-        "abilityId": "Stukov|R2",
-        "cooldown": 60,
-        "manaCost": 60,
-        "icon": "storm_ui_icon_stukov_flailingswipe.png",
-        "type": "heroic"
-      },
-      {
-        "uid": "922f72e",
+        "uid": "da09fd",
         "name": "Massive Shove",
         "description": "Extend Stukov's arm. If it hits an enemy Hero, they are rapidly shoved until they collide with terrain, dealing 190 (+4% per level) damage and Stunning them for 0.5 seconds. Stukov gains 50 Armor while shoving an enemy.",
         "hotkey": "R",
@@ -76,10 +65,20 @@
         "type": "heroic"
       },
       {
-        "uid": "5ab03e7",
+        "uid": "33bf63",
+        "name": "Flailing Swipe",
+        "description": "Swipe 3 times in front of Stukov over 1.75 seconds, dealing 48 (+4% per level) damage to enemies hit and knocking them away. Each swipe is larger than the previous.",
+        "hotkey": "R",
+        "abilityId": "Stukov|R2",
+        "cooldown": 60,
+        "manaCost": 60,
+        "icon": "storm_ui_icon_stukov_flailingswipe.png",
+        "type": "heroic"
+      },
+      {
+        "uid": "f6d1f0",
         "name": "Bio-Kill Switch",
         "description": "Activate to detonate all of Stukov's Viruses. Each Healing Pathogen heals its target for 450 (+4% per level) Health, and each Weighted Pustule does 100 (+4% per level) damage and Slows its target by 70% for 2 seconds.  Can be cast while Channeling Lurking Arm.",
-        "hotkey": "D",
         "trait": true,
         "abilityId": "Stukov|D1",
         "cooldown": 16,

--- a/hero/sylvanas.json
+++ b/hero/sylvanas.json
@@ -264,9 +264,8 @@
         "icon": "storm_ui_icon_sylvanas_hauntingwave.png",
         "type": "E",
         "sort": 2,
-        "abilityId": "Sylvanas|E4",
+        "abilityId": "Sylvanas|E1",
         "abilityLinks": [
-          "Sylvanas|E4",
           "Sylvanas|E1"
         ]
       },

--- a/hero/sylvanas.json
+++ b/hero/sylvanas.json
@@ -1,5 +1,5 @@
 {
-  "id": "35",
+  "id": 35,
   "shortName": "sylvanas",
   "attributeId": "Sylv",
   "cHeroId": "Sylvanas",
@@ -23,7 +23,7 @@
   "abilities": {
     "Sylvanas": [
       {
-        "uid": "b0179a0",
+        "uid": "aac528",
         "name": "Withering Fire",
         "description": "Shoot the closest enemy up to 5 times over 1.5 seconds for 39 (+4% per level) damage, prioritizing Heroes. Cooldown is reset on getting a Takedown.",
         "hotkey": "Q",
@@ -34,7 +34,7 @@
         "type": "basic"
       },
       {
-        "uid": "a6babc6",
+        "uid": "27fcb1",
         "name": "Shadow Dagger",
         "description": "Throw a dagger at a target enemy that deals 30 (+4% per level) damage and an additional 150 (+4% per level) damage over 2.5 seconds. Damage dealt by Sylvanas to the initial target spreads Shadow Dagger to all nearby enemies.",
         "hotkey": "W",
@@ -45,7 +45,7 @@
         "type": "basic"
       },
       {
-        "uid": "ad3d91d",
+        "uid": "14fd98",
         "name": "Haunting Wave",
         "description": "Send forth a wave of banshees dealing 114 (+4% per level) damage to all targets. Reactivate to teleport to the banshees' location.",
         "hotkey": "E",
@@ -56,7 +56,7 @@
         "type": "basic"
       },
       {
-        "uid": "5ddce37",
+        "uid": "219f98",
         "name": "Wailing Arrow",
         "description": "Shoot an arrow that can be reactivated to deal 228 (+4% per level) damage and Silence enemies in an area for 2.5 seconds. The arrow detonates automatically if it reaches maximum range.",
         "hotkey": "R",
@@ -67,7 +67,7 @@
         "type": "heroic"
       },
       {
-        "uid": "2beb0f7",
+        "uid": "8aee91",
         "name": "Mind Control",
         "description": "After 0.25 seconds, fire a missile that Mind Controls the first enemy Hero hit. Heroes hit are Silenced, Slowed by 30%, and forced to walk towards Sylvanas for 1.75 seconds.",
         "hotkey": "R",
@@ -78,7 +78,7 @@
         "type": "heroic"
       },
       {
-        "uid": "c419fd8",
+        "uid": "019b21",
         "name": "Black Arrows",
         "description": "Activate to cause all Basic Attacks and Abilities to Stun Minions, non-Elite Mercenaries, and Structures for 3 seconds. Lasts for 10 seconds.   Banshee's Curse  Basic Attacks infect enemies with Banshee's Curse for 3 seconds, stacking up to 3 times. Deal 25% more damage to enemies with 3 stacks.",
         "trait": true,
@@ -264,8 +264,9 @@
         "icon": "storm_ui_icon_sylvanas_hauntingwave.png",
         "type": "E",
         "sort": 2,
-        "abilityId": "Sylvanas|E1",
+        "abilityId": "Sylvanas|E4",
         "abilityLinks": [
+          "Sylvanas|E4",
           "Sylvanas|E1"
         ]
       },

--- a/hero/tassadar.json
+++ b/hero/tassadar.json
@@ -225,9 +225,9 @@
         "type": "Heroic",
         "sort": 1,
         "cooldown": 100,
-        "abilityId": "Tassadar|R4",
+        "abilityId": "Tassadar|R1",
         "abilityLinks": [
-          "Tassadar|R4"
+          "Tassadar|R1"
         ]
       },
       {
@@ -334,9 +334,9 @@
         "icon": "storm_ui_icon_tassadar_archon.png",
         "type": "Heroic",
         "sort": 1,
-        "abilityId": "Tassadar|R4",
+        "abilityId": "Tassadar|R1",
         "abilityLinks": [
-          "Tassadar|R4"
+          "Tassadar|R1"
         ]
       },
       {

--- a/hero/tassadar.json
+++ b/hero/tassadar.json
@@ -1,12 +1,12 @@
 {
-  "id": "17",
+  "id": 17,
   "shortName": "tassadar",
   "attributeId": "Tass",
   "cHeroId": "Tassadar",
   "cUnitId": "HeroTassadar",
   "name": "Tassadar",
   "icon": "tassadar.png",
-  "role": "Specialist",
+  "role": "Specialist,Support",
   "expandedRole": "Support",
   "type": "Ranged",
   "releaseDate": "2014-03-13",
@@ -21,7 +21,7 @@
   "abilities": {
     "Tassadar": [
       {
-        "uid": "3301850",
+        "uid": "967f34",
         "name": "Plasma Shield",
         "description": "Grant an allied Hero, Minion, or Structure a Shield that absorbs 455 (+4% per level) damage over 4 seconds. If the target is a Hero, they heal for 40% of their Basic Attack damage done while Shielded.",
         "hotkey": "Q",
@@ -32,7 +32,7 @@
         "type": "basic"
       },
       {
-        "uid": "80154d4",
+        "uid": "cff869",
         "name": "Psionic Storm",
         "description": "Deal 82 (+4% per level) damage per second to enemies in target area for 3 seconds. Damage increases by 12% for each consecutive instance of damage, up to 60%.",
         "hotkey": "W",
@@ -43,7 +43,7 @@
         "type": "basic"
       },
       {
-        "uid": "11e1c4c",
+        "uid": "237223",
         "name": "Dimensional Shift",
         "description": "Tassadar becomes Invulnerable and Unrevealable for 2 seconds. While shifted, he has 25% increased Movement Speed.",
         "hotkey": "E",
@@ -54,7 +54,18 @@
         "type": "basic"
       },
       {
-        "uid": "7d97e21",
+        "uid": "642f46",
+        "name": "Archon",
+        "description": "Tassadar transforms into an Archon and gains a Plasma Shield. His Basic Attacks deal 158 (+4% per level) damage, slow the target by 30% for 1 second and splash for 79 (+4% per level) damage to enemies within 2.5 range. Lasts for 10 seconds.  Passive: Archon refreshes the cooldown of Dimensional Shift.",
+        "hotkey": "R",
+        "abilityId": "Tassadar|R1",
+        "cooldown": 100,
+        "manaCost": 80,
+        "icon": "storm_ui_icon_tassadar_archon.png",
+        "type": "heroic"
+      },
+      {
+        "uid": "3e5b72",
         "name": "Force Wall",
         "description": "Create a wall that blocks all units from moving through it for 2 seconds.  Passive: Increases the slow amount of Distortion Beam to 35%.",
         "hotkey": "R",
@@ -65,26 +76,14 @@
         "type": "heroic"
       },
       {
-        "uid": "fbc8f7a",
+        "uid": "fde047",
         "name": "Oracle",
         "description": "Activate to greatly increase Tassadar's vision radius, allow him to see over obstacles, and detect stealthed units. Lasts for 5 seconds.  Distortion Beam  Tassadar's Basic Attack is a beam that Slows enemy units by 25%.",
-        "hotkey": "D",
         "trait": true,
         "abilityId": "Tassadar|D1",
         "cooldown": 30,
         "icon": "storm_ui_icon_tassadar_oracle.png",
         "type": "trait"
-      },
-      {
-        "uid": "e2d5e27",
-        "name": "Archon",
-        "description": "Tassadar transforms into an Archon and gains a Plasma Shield. His Basic Attacks deal 158 (+4% per level) damage, slow the target by 30% for 1 second and splash for 79 (+4% per level) damage to enemies within 2.5 range. Lasts for 10 seconds.  Passive: Archon refreshes the cooldown of Dimensional Shift.",
-        "hotkey": "R",
-        "abilityId": "Tassadar|R1",
-        "cooldown": 100,
-        "manaCost": 80,
-        "icon": "storm_ui_icon_tassadar_archon.png",
-        "type": "heroic"
       }
     ]
   },
@@ -226,9 +225,9 @@
         "type": "Heroic",
         "sort": 1,
         "cooldown": 100,
-        "abilityId": "Tassadar|R1",
+        "abilityId": "Tassadar|R4",
         "abilityLinks": [
-          "Tassadar|R1"
+          "Tassadar|R4"
         ]
       },
       {
@@ -335,9 +334,9 @@
         "icon": "storm_ui_icon_tassadar_archon.png",
         "type": "Heroic",
         "sort": 1,
-        "abilityId": "Tassadar|R1",
+        "abilityId": "Tassadar|R4",
         "abilityLinks": [
-          "Tassadar|R1"
+          "Tassadar|R4"
         ]
       },
       {

--- a/hero/thebutcher.json
+++ b/hero/thebutcher.json
@@ -1,5 +1,5 @@
 {
-  "id": "38",
+  "id": 38,
   "shortName": "thebutcher",
   "attributeId": "Butc",
   "cHeroId": "Butcher",
@@ -20,68 +20,68 @@
     "SoloLaner"
   ],
   "abilities": {
-    "The Butcher": [
+    "TheButcher": [
       {
-        "uid": "31ba134",
+        "uid": "eff167",
         "name": "Hamstring",
         "description": "Deal 110 (+4% per level) damage and slow enemies by 50% fading over 2 seconds.  The Butcher's next Basic Attack will strike immediately.",
         "hotkey": "Q",
-        "abilityId": "The Butcher|Q1",
+        "abilityId": "TheButcher|Q1",
         "cooldown": 4,
         "manaCost": 40,
         "icon": "storm_ui_icon_butcher_hamstring.png",
         "type": "basic"
       },
       {
-        "uid": "fc04363",
+        "uid": "945d96",
         "name": "Butcher's Brand",
         "description": "Deal 37 (+4% per level) damage to an enemy and Brand them for 4 seconds. The Butcher's Basic Attacks against the Branded target heal him for 75% of the damage done.  Basic Attacks against Branded Heroes heal for double and extend the duration of the Brand by 0.5 seconds.",
         "hotkey": "W",
-        "abilityId": "The Butcher|W1",
+        "abilityId": "TheButcher|W1",
         "cooldown": 14,
         "manaCost": 60,
         "icon": "storm_ui_icon_butcher_tenderize.png",
         "type": "basic"
       },
       {
-        "uid": "db3d874",
+        "uid": "821300",
         "name": "Ruthless Onslaught",
         "description": "Charge at an enemy, becoming Unstoppable and gaining Movement Speed. If The Butcher reaches the target, they are stunned for 1 second and take 119 (+4% per level) damage.",
         "hotkey": "E",
-        "abilityId": "The Butcher|E1",
+        "abilityId": "TheButcher|E1",
         "cooldown": 15,
         "manaCost": 50,
         "icon": "storm_ui_icon_butcher_fullboar.png",
         "type": "basic"
       },
       {
-        "uid": "0889630",
-        "name": "Lamb to the Slaughter",
-        "description": "Throw a hitching post that attaches to the nearest enemy Hero after a 1 second delay. This deals 171 (+4% per level) damage and causes the enemy to be chained to the post and Silenced for 3 seconds.",
-        "hotkey": "R",
-        "abilityId": "The Butcher|R2",
-        "cooldown": 90,
-        "manaCost": 75,
-        "icon": "storm_ui_icon_butcher_lambtotheslaughter.png",
-        "type": "heroic"
-      },
-      {
-        "uid": "72dde49",
+        "uid": "b22bfe",
         "name": "Furnace Blast",
         "description": "After a 3 second delay, fire explodes around The Butcher dealing 500 (+4% per level) damage to enemies.  Can be cast while using Ruthless Onslaught.",
         "hotkey": "R",
-        "abilityId": "The Butcher|R1",
+        "abilityId": "TheButcher|R1",
         "cooldown": 60,
         "manaCost": 75,
         "icon": "storm_ui_icon_butcher_furnaceblast.png",
         "type": "heroic"
       },
       {
-        "uid": "d776a18",
+        "uid": "a1d875",
+        "name": "Lamb to the Slaughter",
+        "description": "Throw a hitching post that attaches to the nearest enemy Hero after a 1 second delay. This deals 171 (+4% per level) damage and causes the enemy to be chained to the post and Silenced for 3 seconds.",
+        "hotkey": "R",
+        "abilityId": "TheButcher|R2",
+        "cooldown": 90,
+        "manaCost": 75,
+        "icon": "storm_ui_icon_butcher_lambtotheslaughter.png",
+        "type": "heroic"
+      },
+      {
+        "uid": "168e6b",
         "name": "Fresh Meat",
         "description": "Upon dying, nearby enemy Minions drop 1 Fresh Meat and enemy Heroes drop 20 Fresh Meat. Fresh Meat can be picked up to gain 0.5 Attack Damage per Meat. The Butcher loses 15 Fresh Meat upon dying.  Quest: Collect 200 Fresh Meat.  Reward: Gain an additional 125 Attack Damage and 25% increased Attack Speed. Heroes continue to drop 10 Fresh Meat, Minions no longer drop Fresh Meat, and Fresh Meat is no longer lost on death.",
         "trait": true,
-        "abilityId": "The Butcher|D1",
+        "abilityId": "TheButcher|D1",
         "icon": "storm_ui_icon_butcher_freshmeat.png",
         "type": "trait"
       }
@@ -97,9 +97,9 @@
         "icon": "storm_ui_icon_butcher_hamstring.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "The Butcher|Q1",
+        "abilityId": "TheButcher|Q1",
         "abilityLinks": [
-          "The Butcher|Q1"
+          "TheButcher|Q1"
         ]
       },
       {
@@ -110,7 +110,7 @@
         "icon": "storm_ui_icon_talent_block.png",
         "type": "Passive",
         "sort": 2,
-        "abilityId": "The Butcher|Passive"
+        "abilityId": "TheButcher|Passive"
       },
       {
         "tooltipId": "ButcherHamstringChopMeatTalent",
@@ -120,9 +120,9 @@
         "icon": "storm_ui_icon_butcher_hamstring_var1.png",
         "type": "Q",
         "sort": 3,
-        "abilityId": "The Butcher|Q1",
+        "abilityId": "TheButcher|Q1",
         "abilityLinks": [
-          "The Butcher|Q1"
+          "TheButcher|Q1"
         ]
       }
     ],
@@ -135,9 +135,9 @@
         "icon": "storm_ui_icon_butcher_hamstring.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "The Butcher|Q1",
+        "abilityId": "TheButcher|Q1",
         "abilityLinks": [
-          "The Butcher|Q1"
+          "TheButcher|Q1"
         ]
       },
       {
@@ -148,9 +148,9 @@
         "icon": "storm_ui_icon_butcher_fullboar.png",
         "type": "E",
         "sort": 2,
-        "abilityId": "The Butcher|E1",
+        "abilityId": "TheButcher|E1",
         "abilityLinks": [
-          "The Butcher|E1"
+          "TheButcher|E1"
         ]
       },
       {
@@ -161,9 +161,9 @@
         "icon": "storm_ui_icon_butcher_hamstring_var1.png",
         "type": "Q",
         "sort": 3,
-        "abilityId": "The Butcher|Q1",
+        "abilityId": "TheButcher|Q1",
         "abilityLinks": [
-          "The Butcher|Q1"
+          "TheButcher|Q1"
         ]
       }
     ],
@@ -176,9 +176,9 @@
         "icon": "storm_ui_icon_butcher_tenderize.png",
         "type": "W",
         "sort": 1,
-        "abilityId": "The Butcher|W1",
+        "abilityId": "TheButcher|W1",
         "abilityLinks": [
-          "The Butcher|W1"
+          "TheButcher|W1"
         ]
       },
       {
@@ -189,9 +189,9 @@
         "icon": "storm_ui_icon_butcher_freshmeat.png",
         "type": "Trait",
         "sort": 2,
-        "abilityId": "The Butcher|D1",
+        "abilityId": "TheButcher|D1",
         "abilityLinks": [
-          "The Butcher|D1"
+          "TheButcher|D1"
         ]
       },
       {
@@ -202,9 +202,9 @@
         "icon": "storm_ui_icon_butcher_fullboar.png",
         "type": "E",
         "sort": 3,
-        "abilityId": "The Butcher|E1",
+        "abilityId": "TheButcher|E1",
         "abilityLinks": [
-          "The Butcher|E1"
+          "TheButcher|E1"
         ]
       }
     ],
@@ -218,9 +218,9 @@
         "type": "Heroic",
         "sort": 1,
         "cooldown": 60,
-        "abilityId": "The Butcher|R1",
+        "abilityId": "TheButcher|R1",
         "abilityLinks": [
-          "The Butcher|R1"
+          "TheButcher|R1"
         ]
       },
       {
@@ -232,9 +232,9 @@
         "type": "Heroic",
         "sort": 2,
         "cooldown": 90,
-        "abilityId": "The Butcher|R2",
+        "abilityId": "TheButcher|R2",
         "abilityLinks": [
-          "The Butcher|R2"
+          "TheButcher|R2"
         ]
       }
     ],
@@ -247,7 +247,7 @@
         "icon": "storm_ui_icon_talent_autoattack_aoe.png",
         "type": "Passive",
         "sort": 1,
-        "abilityId": "The Butcher|Passive"
+        "abilityId": "TheButcher|Passive"
       },
       {
         "tooltipId": "ButcherRuthlessOnslaughtSavageChargeTalent",
@@ -257,9 +257,9 @@
         "icon": "storm_ui_icon_butcher_fullboar.png",
         "type": "E",
         "sort": 2,
-        "abilityId": "The Butcher|E1",
+        "abilityId": "TheButcher|E1",
         "abilityLinks": [
-          "The Butcher|E1"
+          "TheButcher|E1"
         ]
       },
       {
@@ -270,9 +270,9 @@
         "icon": "storm_ui_icon_butcher_hamstring.png",
         "type": "Q",
         "sort": 3,
-        "abilityId": "The Butcher|Q1",
+        "abilityId": "TheButcher|Q1",
         "abilityLinks": [
-          "The Butcher|Q1"
+          "TheButcher|Q1"
         ]
       }
     ],
@@ -285,9 +285,9 @@
         "icon": "storm_ui_icon_butcher_hamstring.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "The Butcher|Q1",
+        "abilityId": "TheButcher|Q1",
         "abilityLinks": [
-          "The Butcher|Q1"
+          "TheButcher|Q1"
         ]
       },
       {
@@ -298,7 +298,7 @@
         "icon": "storm_ui_icon_butcher_enraged.png",
         "type": "Passive",
         "sort": 2,
-        "abilityId": "The Butcher|Passive"
+        "abilityId": "TheButcher|Passive"
       },
       {
         "tooltipId": "ButcherFreshBloodFrenzyMeatTalent",
@@ -308,7 +308,7 @@
         "icon": "storm_ui_icon_talent_autoattack_speed.png",
         "type": "Passive",
         "sort": 3,
-        "abilityId": "The Butcher|Passive"
+        "abilityId": "TheButcher|Passive"
       }
     ],
     "20": [
@@ -320,9 +320,9 @@
         "icon": "storm_ui_icon_butcher_furnaceblast.png",
         "type": "Heroic",
         "sort": 1,
-        "abilityId": "The Butcher|R1",
+        "abilityId": "TheButcher|R1",
         "abilityLinks": [
-          "The Butcher|R1"
+          "TheButcher|R1"
         ]
       },
       {
@@ -333,9 +333,9 @@
         "icon": "storm_ui_icon_butcher_lambtotheslaughter.png",
         "type": "Heroic",
         "sort": 2,
-        "abilityId": "The Butcher|R2",
+        "abilityId": "TheButcher|R2",
         "abilityLinks": [
-          "The Butcher|R2"
+          "TheButcher|R2"
         ]
       },
       {
@@ -346,7 +346,7 @@
         "icon": "storm_ui_icon_talent_autoattack_slow.png",
         "type": "Passive",
         "sort": 3,
-        "abilityId": "The Butcher|Passive"
+        "abilityId": "TheButcher|Passive"
       },
       {
         "tooltipId": "GenericBoltoftheStormTalent",
@@ -357,7 +357,7 @@
         "type": "Active",
         "sort": 4,
         "cooldown": 70,
-        "abilityId": "The Butcher|Active"
+        "abilityId": "TheButcher|Active"
       }
     ]
   }

--- a/hero/thrall.json
+++ b/hero/thrall.json
@@ -166,9 +166,8 @@
         "icon": "storm_ui_icon_thrall_frostwolfresilience.png",
         "type": "Trait",
         "sort": 3,
-        "abilityId": "Thrall|D2",
+        "abilityId": "Thrall|D1",
         "abilityLinks": [
-          "Thrall|D2",
           "Thrall|D1"
         ]
       }
@@ -262,9 +261,8 @@
         "type": "Trait",
         "sort": 2,
         "cooldown": 15,
-        "abilityId": "Thrall|D2",
+        "abilityId": "Thrall|D1",
         "abilityLinks": [
-          "Thrall|D2",
           "Thrall|D1"
         ]
       },

--- a/hero/thrall.json
+++ b/hero/thrall.json
@@ -1,5 +1,5 @@
 {
-  "id": "33",
+  "id": 33,
   "shortName": "thrall",
   "attributeId": "Thra",
   "cHeroId": "Thrall",
@@ -21,7 +21,7 @@
   "abilities": {
     "Thrall": [
       {
-        "uid": "8f41d1b",
+        "uid": "3a5ec4",
         "name": "Chain Lightning",
         "description": "Shock an enemy with lightning, dealing 162 (+4% per level) damage. The lightning then bounces 3 times to nearby enemies, dealing 81 (+4% per level) damage to each enemy hit.",
         "hotkey": "Q",
@@ -32,7 +32,7 @@
         "type": "basic"
       },
       {
-        "uid": "90c754b",
+        "uid": "44db9b",
         "name": "Feral Spirit",
         "description": "Unleash a Feral Spirit that deals 153 (+4% per level) damage to enemies in its path and Roots Heroes hit for 1 second. Each Hero hit increases the distance traveled by 25%.",
         "hotkey": "W",
@@ -43,7 +43,7 @@
         "type": "basic"
       },
       {
-        "uid": "85fd413",
+        "uid": "d4141b",
         "name": "Windfury",
         "description": "Increase Thrall's Movement Speed by 30% for 4 seconds. His next 3 Basic Attacks occur 100% faster and generate stacks of Frostwolf Resilience.",
         "hotkey": "E",
@@ -54,7 +54,7 @@
         "type": "basic"
       },
       {
-        "uid": "3ff166c",
+        "uid": "7364db",
         "name": "Sundering",
         "description": "After 0.5 seconds, sunder the earth in a long line, dealing 290 (+4% per level) damage and shoving enemies to the side, Stunning them for 1 second.",
         "hotkey": "R",
@@ -65,7 +65,7 @@
         "type": "heroic"
       },
       {
-        "uid": "c5d47e6",
+        "uid": "6cf062",
         "name": "Earthquake",
         "description": "After 0.5 seconds, summon a massive Earthquake that pulses every 4 seconds. Each pulse lasts 2 seconds, Slowing all enemies in the area by 50%, and deals 50 (+4% per level) damage to enemy Heroes. Does 3 pulses.",
         "hotkey": "R",
@@ -76,7 +76,7 @@
         "type": "heroic"
       },
       {
-        "uid": "2d8980d",
+        "uid": "44240f",
         "name": "Frostwolf Resilience",
         "description": "Dealing damage with Abilities grants 1 stack of Frostwolf Resilience. At 5 stacks, Thrall is instantly healed for 223 (+4% per level) Health.",
         "trait": true,
@@ -166,8 +166,9 @@
         "icon": "storm_ui_icon_thrall_frostwolfresilience.png",
         "type": "Trait",
         "sort": 3,
-        "abilityId": "Thrall|D1",
+        "abilityId": "Thrall|D2",
         "abilityLinks": [
+          "Thrall|D2",
           "Thrall|D1"
         ]
       }
@@ -261,8 +262,9 @@
         "type": "Trait",
         "sort": 2,
         "cooldown": 15,
-        "abilityId": "Thrall|D1",
+        "abilityId": "Thrall|D2",
         "abilityLinks": [
+          "Thrall|D2",
           "Thrall|D1"
         ]
       },

--- a/hero/tracer.json
+++ b/hero/tracer.json
@@ -1,5 +1,5 @@
 {
-  "id": "51",
+  "id": 51,
   "shortName": "tracer",
   "attributeId": "Tra0",
   "cHeroId": "Tracer",
@@ -19,7 +19,7 @@
   "abilities": {
     "Tracer": [
       {
-        "uid": "5169464",
+        "uid": "5b729b",
         "name": "Blink",
         "description": "Dash towards an area.  Stores up to 3 charges.",
         "hotkey": "Q",
@@ -29,7 +29,7 @@
         "type": "basic"
       },
       {
-        "uid": "cf20ed4",
+        "uid": "f32220",
         "name": "Melee",
         "description": "Deal 220 (+4% per level) damage to a nearby enemy, prioritizing Heroes. Gain 5% Pulse Bomb charge when using Melee against an enemy, and 10% against Heroes.",
         "hotkey": "W",
@@ -39,7 +39,7 @@
         "type": "basic"
       },
       {
-        "uid": "042f2c7",
+        "uid": "050d8e",
         "name": "Recall",
         "description": "Tracer returns to the position she was at 3 seconds ago, refilling her ammo, and removing all negative status effects from herself.",
         "hotkey": "E",
@@ -49,7 +49,7 @@
         "type": "basic"
       },
       {
-        "uid": "0afd191",
+        "uid": "9c5f5a",
         "name": "Pulse Bomb",
         "description": "Fire a short range bomb that can attach to an enemy if it hits them. The bomb explodes after 2 seconds dealing 360 (+6% per level) damage to them and 180 (+6% per level) damage to other nearby enemies.  This Ability is slowly charged over time by dealing damage to enemies with Basic Attacks and Melee.",
         "hotkey": "R",
@@ -58,10 +58,9 @@
         "type": "heroic"
       },
       {
-        "uid": "8320ce8",
+        "uid": "14276c",
         "name": "Reload",
         "description": "Tracer can Basic Attack while moving, and after attacking 10 times she needs to reload over 0.75 seconds. Tracer can manually reload early by activating Reload.",
-        "hotkey": "D",
         "trait": true,
         "abilityId": "Tracer|D1",
         "cooldown": 1,

--- a/hero/tychus.json
+++ b/hero/tychus.json
@@ -1,5 +1,5 @@
 {
-  "id": "23",
+  "id": 23,
   "shortName": "tychus",
   "attributeId": "Tych",
   "cHeroId": "Tychus",
@@ -20,7 +20,7 @@
   "abilities": {
     "Tychus": [
       {
-        "uid": "90ddab5",
+        "uid": "96407f",
         "name": "Overkill",
         "description": "Deal 552 (+4% per level) damage to the target and 276 (+4% per level) damage to nearby targets over 4 seconds. Reactivate to select a new target.  Can move and use Abilities while Channeling.",
         "hotkey": "Q",
@@ -31,7 +31,7 @@
         "type": "basic"
       },
       {
-        "uid": "db2eb48",
+        "uid": "4c628c",
         "name": "Frag Grenade",
         "description": "Lob a grenade that deals 256 (+4% per level) damage, knocking enemies away.",
         "hotkey": "W",
@@ -42,7 +42,7 @@
         "type": "basic"
       },
       {
-        "uid": "5013769",
+        "uid": "2c51d2",
         "name": "Run and Gun",
         "description": "Dash a short distance.",
         "hotkey": "E",
@@ -53,7 +53,7 @@
         "type": "basic"
       },
       {
-        "uid": "5043afa",
+        "uid": "b9ac21",
         "name": "Drakken Laser Drill",
         "description": "Call down a Laser Drill to attack nearby enemies, dealing 142 (+4% per level) damage every second. Reactivate to assign a new target. Lasts 22 seconds.",
         "hotkey": "R",
@@ -64,7 +64,7 @@
         "type": "heroic"
       },
       {
-        "uid": "dfe33bf",
+        "uid": "5ceb13",
         "name": "Commandeer Odin",
         "description": "Call down an Odin to pilot. The Odin deals increased Damage, has 100% increased Basic Attack range, and uses different Abilities. The Odin has 25 Armor and lasts 23 seconds.",
         "hotkey": "R",
@@ -75,7 +75,7 @@
         "type": "heroic"
       },
       {
-        "uid": "a378d63",
+        "uid": "084071",
         "name": "Minigun",
         "description": "Activate to have Basic Attacks against Heroes deal bonus damage equal to 2.5% of their maximum Health. Lasts 3 seconds.",
         "trait": true,
@@ -87,34 +87,73 @@
     ],
     "TychusOdinNoHealth": [
       {
-        "uid": "dbf0732",
+        "uid": "66ee35",
+        "name": "Laser Drill Issue Order",
+        "description": "Order the Laser Drill to attack a new target.",
+        "hotkey": "R",
+        "abilityId": "Tychus|R3",
+        "icon": "storm_ui_icon_tychus_laserdrillissueorder.png",
+        "type": "heroic"
+      },
+      {
+        "uid": "0e7619",
         "name": "Annihilate",
         "description": "Fire the Odin's cannons in a straight line, dealing 196 (+4% per level) damage to everything in the path.",
         "hotkey": "Q",
         "abilityId": "Tychus|Q2",
         "cooldown": 7,
         "icon": "storm_ui_icon_tychus_annihilate.png",
-        "type": "subunit"
+        "type": "basic"
       },
       {
-        "uid": "31f2f21",
+        "uid": "bdd102",
         "name": "Ragnarok Missiles",
         "description": "Launches a volley of missiles at target area, dealing 132 (+4% per level) damage and slowing enemy Movement Speed by 30% for 2 seconds.",
         "hotkey": "W",
         "abilityId": "Tychus|W2",
         "cooldown": 7,
         "icon": "storm_ui_icon_tychus_ragnarokmissiles.png",
-        "type": "subunit"
+        "type": "basic"
       },
       {
-        "uid": "944d7b3",
+        "uid": "78f782",
         "name": "Thrusters",
         "description": "Dash in target direction.",
         "hotkey": "E",
         "abilityId": "Tychus|E2",
         "cooldown": 8,
         "icon": "storm_ui_icon_tychus_thrusters.png",
-        "type": "subunit"
+        "type": "basic"
+      },
+      {
+        "uid": "f57681",
+        "name": "Minigun",
+        "description": "Activate to have Basic Attacks against Heroes deal bonus damage equal to 2.5% of their maximum Health. Lasts 3 seconds.",
+        "trait": true,
+        "abilityId": "Tychus|D2",
+        "cooldown": 12,
+        "icon": "storm_ui_icon_tychus_minigun.png",
+        "type": "trait"
+      },
+      {
+        "uid": "3e561e",
+        "name": "Overkill Retarget",
+        "description": "Focuses Overkill on a different target.",
+        "hotkey": "Q",
+        "abilityId": "Tychus|Q3",
+        "icon": "storm_ui_icon_tychus_overkill_target.png",
+        "type": "basic"
+      },
+      {
+        "uid": "33434d",
+        "name": "Run and Gun",
+        "description": "Dash a short distance.",
+        "hotkey": "E",
+        "abilityId": "Tychus|E3",
+        "cooldown": 10,
+        "manaCost": 50,
+        "icon": "storm_ui_icon_tychus_runandgun.png",
+        "type": "basic"
       }
     ]
   },
@@ -128,10 +167,10 @@
         "icon": "storm_ui_icon_tychus_runandgun.png",
         "type": "E",
         "sort": 1,
-        "abilityId": "Tychus|E1",
+        "abilityId": "Tychus|E3",
         "abilityLinks": [
-          "Tychus|E1",
-          "Tychus|E3"
+          "Tychus|E3",
+          "Tychus|E1"
         ]
       },
       {
@@ -142,11 +181,10 @@
         "icon": "storm_ui_icon_tychus_runandgun_a.png",
         "type": "E",
         "sort": 2,
-        "isQuest": true,
-        "abilityId": "Tychus|E1",
+        "abilityId": "Tychus|E3",
         "abilityLinks": [
-          "Tychus|E1",
-          "Tychus|E3"
+          "Tychus|E3",
+          "Tychus|E1"
         ]
       },
       {
@@ -157,10 +195,10 @@
         "icon": "storm_ui_icon_tychus_runandgun_b.png",
         "type": "E",
         "sort": 3,
-        "abilityId": "Tychus|E1",
+        "abilityId": "Tychus|E3",
         "abilityLinks": [
-          "Tychus|E1",
-          "Tychus|E3"
+          "Tychus|E3",
+          "Tychus|E1"
         ]
       }
     ],
@@ -174,10 +212,10 @@
         "type": "Trait",
         "sort": 1,
         "isQuest": true,
-        "abilityId": "Tychus|D2",
+        "abilityId": "Tychus|D1",
         "abilityLinks": [
-          "Tychus|D2",
-          "Tychus|D1"
+          "Tychus|D1",
+          "Tychus|D2"
         ]
       },
       {
@@ -188,10 +226,10 @@
         "icon": "storm_ui_icon_tychus_minigun_a.png",
         "type": "Trait",
         "sort": 2,
-        "abilityId": "Tychus|D2",
+        "abilityId": "Tychus|D1",
         "abilityLinks": [
-          "Tychus|D2",
-          "Tychus|D1"
+          "Tychus|D1",
+          "Tychus|D2"
         ]
       },
       {
@@ -283,10 +321,10 @@
         "icon": "storm_ui_icon_tychus_minigun.png",
         "type": "Trait",
         "sort": 1,
-        "abilityId": "Tychus|D2",
+        "abilityId": "Tychus|D1",
         "abilityLinks": [
-          "Tychus|D2",
-          "Tychus|D1"
+          "Tychus|D1",
+          "Tychus|D2"
         ]
       },
       {
@@ -391,10 +429,10 @@
         "icon": "storm_ui_icon_talent_autoattack_damage.png",
         "type": "Trait",
         "sort": 3,
-        "abilityId": "Tychus|D2",
+        "abilityId": "Tychus|D1",
         "abilityLinks": [
-          "Tychus|D2",
-          "Tychus|D1"
+          "Tychus|D1",
+          "Tychus|D2"
         ]
       },
       {
@@ -405,11 +443,11 @@
         "icon": "storm_ui_icon_tychus_runandgun.png",
         "type": "E",
         "sort": 4,
-        "abilityId": "Tychus|E1",
+        "abilityId": "Tychus|E3",
         "abilityLinks": [
+          "Tychus|E3",
           "Tychus|E1",
-          "Tychus|E2",
-          "Tychus|E3"
+          "Tychus|E2"
         ]
       }
     ]

--- a/hero/tychus.json
+++ b/hero/tychus.json
@@ -87,15 +87,6 @@
     ],
     "TychusOdinNoHealth": [
       {
-        "uid": "66ee35",
-        "name": "Laser Drill Issue Order",
-        "description": "Order the Laser Drill to attack a new target.",
-        "hotkey": "R",
-        "abilityId": "Tychus|R3",
-        "icon": "storm_ui_icon_tychus_laserdrillissueorder.png",
-        "type": "heroic"
-      },
-      {
         "uid": "0e7619",
         "name": "Annihilate",
         "description": "Fire the Odin's cannons in a straight line, dealing 196 (+4% per level) damage to everything in the path.",
@@ -134,15 +125,6 @@
         "cooldown": 12,
         "icon": "storm_ui_icon_tychus_minigun.png",
         "type": "trait"
-      },
-      {
-        "uid": "3e561e",
-        "name": "Overkill Retarget",
-        "description": "Focuses Overkill on a different target.",
-        "hotkey": "Q",
-        "abilityId": "Tychus|Q3",
-        "icon": "storm_ui_icon_tychus_overkill_target.png",
-        "type": "basic"
       },
       {
         "uid": "33434d",

--- a/hero/tyrael.json
+++ b/hero/tyrael.json
@@ -1,5 +1,5 @@
 {
-  "id": "18",
+  "id": 18,
   "shortName": "tyrael",
   "attributeId": "Tyrl",
   "cHeroId": "Tyrael",
@@ -23,7 +23,7 @@
   "abilities": {
     "Tyrael": [
       {
-        "uid": "747a20a",
+        "uid": "368e56",
         "name": "El'druin's Might",
         "description": "Throw El'druin to the target area, dealing 110 (+4% per level) damage to nearby enemies and Slowing them by 25% for 2.5 seconds. It can be reactivated within 5 seconds to teleport Tyrael to El'druin and Slow nearby enemies again.",
         "hotkey": "Q",
@@ -34,7 +34,7 @@
         "type": "basic"
       },
       {
-        "uid": "3cd93e1",
+        "uid": "c78476",
         "name": "Righteousness",
         "description": "Shields Tyrael for 336 (+4% per level) damage and nearby allied Heroes and Minions for 40% as much for 4 seconds.",
         "hotkey": "W",
@@ -45,7 +45,7 @@
         "type": "basic"
       },
       {
-        "uid": "112007d",
+        "uid": "3e3a5d",
         "name": "Smite",
         "description": "Rake target area for 150 (+4% per level) damage. Allies moving through the targeted area gain 25% increased Movement Speed for 2 seconds.",
         "hotkey": "E",
@@ -56,7 +56,7 @@
         "type": "basic"
       },
       {
-        "uid": "cc69be6",
+        "uid": "ad72bc",
         "name": "Judgment",
         "description": "After 0.75 seconds, charge an enemy Hero, dealing 150 (+4% per level) damage and Stunning them for 1.5 seconds. Nearby enemies are knocked away and take 75 (+4% per level) damage.",
         "hotkey": "R",
@@ -67,7 +67,7 @@
         "type": "heroic"
       },
       {
-        "uid": "ce5c0e9",
+        "uid": "c143ab",
         "name": "Sanctification",
         "description": "After 0.5 seconds create a field of holy energy that makes allied Heroes Invulnerable. Lasts 3 seconds.",
         "hotkey": "R",
@@ -78,7 +78,7 @@
         "type": "heroic"
       },
       {
-        "uid": "39e24c8",
+        "uid": "ffd447",
         "name": "Archangel's Wrath",
         "description": "Upon dying, become Invulnerable and explode for 550 (+4% per level) damage after 3.5 seconds.",
         "trait": true,
@@ -136,8 +136,9 @@
         "icon": "storm_ui_icon_tyrael_eldruinsmight_a.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "Tyrael|Q1",
+        "abilityId": "Tyrael|Q2",
         "abilityLinks": [
+          "Tyrael|Q2",
           "Tyrael|Q1"
         ]
       },
@@ -149,8 +150,9 @@
         "icon": "storm_ui_icon_tyrael_eldruinsmight_b.png",
         "type": "Q",
         "sort": 2,
-        "abilityId": "Tyrael|Q1",
+        "abilityId": "Tyrael|Q2",
         "abilityLinks": [
+          "Tyrael|Q2",
           "Tyrael|Q1"
         ]
       },
@@ -248,8 +250,9 @@
         "icon": "storm_ui_icon_tyrael_eldruinsmight_a.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "Tyrael|Q1",
+        "abilityId": "Tyrael|Q2",
         "abilityLinks": [
+          "Tyrael|Q2",
           "Tyrael|Q1"
         ]
       },
@@ -261,8 +264,9 @@
         "icon": "storm_ui_icon_tyrael_eldruinsmight_b.png",
         "type": "Q",
         "sort": 2,
-        "abilityId": "Tyrael|Q1",
+        "abilityId": "Tyrael|Q2",
         "abilityLinks": [
+          "Tyrael|Q2",
           "Tyrael|Q1"
         ]
       },
@@ -290,8 +294,9 @@
         "icon": "storm_ui_icon_tyrael_eldruinsmight_a.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "Tyrael|Q1",
+        "abilityId": "Tyrael|Q2",
         "abilityLinks": [
+          "Tyrael|Q2",
           "Tyrael|Q1"
         ]
       },
@@ -303,8 +308,9 @@
         "icon": "storm_ui_icon_tyrael_eldruinsmight_b.png",
         "type": "Q",
         "sort": 2,
-        "abilityId": "Tyrael|Q1",
+        "abilityId": "Tyrael|Q2",
         "abilityLinks": [
+          "Tyrael|Q2",
           "Tyrael|Q1"
         ]
       },

--- a/hero/tyrael.json
+++ b/hero/tyrael.json
@@ -136,9 +136,8 @@
         "icon": "storm_ui_icon_tyrael_eldruinsmight_a.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "Tyrael|Q2",
+        "abilityId": "Tyrael|Q1",
         "abilityLinks": [
-          "Tyrael|Q2",
           "Tyrael|Q1"
         ]
       },
@@ -150,9 +149,8 @@
         "icon": "storm_ui_icon_tyrael_eldruinsmight_b.png",
         "type": "Q",
         "sort": 2,
-        "abilityId": "Tyrael|Q2",
+        "abilityId": "Tyrael|Q1",
         "abilityLinks": [
-          "Tyrael|Q2",
           "Tyrael|Q1"
         ]
       },
@@ -250,9 +248,8 @@
         "icon": "storm_ui_icon_tyrael_eldruinsmight_a.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "Tyrael|Q2",
+        "abilityId": "Tyrael|Q1",
         "abilityLinks": [
-          "Tyrael|Q2",
           "Tyrael|Q1"
         ]
       },
@@ -264,9 +261,8 @@
         "icon": "storm_ui_icon_tyrael_eldruinsmight_b.png",
         "type": "Q",
         "sort": 2,
-        "abilityId": "Tyrael|Q2",
+        "abilityId": "Tyrael|Q1",
         "abilityLinks": [
-          "Tyrael|Q2",
           "Tyrael|Q1"
         ]
       },
@@ -294,9 +290,8 @@
         "icon": "storm_ui_icon_tyrael_eldruinsmight_a.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "Tyrael|Q2",
+        "abilityId": "Tyrael|Q1",
         "abilityLinks": [
-          "Tyrael|Q2",
           "Tyrael|Q1"
         ]
       },
@@ -308,9 +303,8 @@
         "icon": "storm_ui_icon_tyrael_eldruinsmight_b.png",
         "type": "Q",
         "sort": 2,
-        "abilityId": "Tyrael|Q2",
+        "abilityId": "Tyrael|Q1",
         "abilityLinks": [
-          "Tyrael|Q2",
           "Tyrael|Q1"
         ]
       },

--- a/hero/tyrande.json
+++ b/hero/tyrande.json
@@ -1,5 +1,5 @@
 {
-  "id": "19",
+  "id": 19,
   "shortName": "tyrande",
   "attributeId": "Tyrd",
   "cHeroId": "Tyrande",
@@ -23,7 +23,7 @@
   "abilities": {
     "Tyrande": [
       {
-        "uid": "e122256",
+        "uid": "3317cb",
         "name": "Light of Elune",
         "description": "Heal an ally Hero for 255 (+4% per level). Light of Elune's cooldown is reduced by 1.5 seconds every time Tyrande damages an enemy.  Stores up to 2 charges. Cooldown replenishes all charges at the same time.",
         "hotkey": "Q",
@@ -34,7 +34,7 @@
         "type": "basic"
       },
       {
-        "uid": "ceea873",
+        "uid": "5ebe4c",
         "name": "Sentinel",
         "description": "Send an Owl across the battleground revealing its path, dealing 120 (+4% per level) damage to the first Hero hit, and revealing them for 5 seconds.",
         "hotkey": "W",
@@ -45,7 +45,7 @@
         "type": "basic"
       },
       {
-        "uid": "c80b95e",
+        "uid": "b4597d",
         "name": "Lunar Flare",
         "description": "After 0.75 seconds, deal 150 (+4% per level) damage and Stun enemies in the target area for 0.75 seconds.",
         "hotkey": "E",
@@ -56,7 +56,7 @@
         "type": "basic"
       },
       {
-        "uid": "a76596b",
+        "uid": "7637b4",
         "name": "Shadowstalk",
         "description": "Grant all allied Heroes Stealth for 10 seconds and heal them for 380 (+4% per level) Health over 10 seconds. Remaining stationary for at least 1.5 seconds while Stealthed grants Invisible.",
         "hotkey": "R",
@@ -67,7 +67,7 @@
         "type": "heroic"
       },
       {
-        "uid": "608a430",
+        "uid": "7ca7f4",
         "name": "Starfall",
         "description": "Deal 88 (+4% per level) damage per second and Slow enemies by 20% in an area. Lasts 6 seconds.",
         "hotkey": "R",
@@ -78,10 +78,9 @@
         "type": "heroic"
       },
       {
-        "uid": "9b6716d",
+        "uid": "0ddc63",
         "name": "Hunter's Mark",
         "description": "Reveal a non-Structure enemy and reduce their Armor by 15 for 4 seconds.",
-        "hotkey": "D",
         "trait": true,
         "abilityId": "Tyrande|D1",
         "cooldown": 20,
@@ -127,10 +126,7 @@
         "type": "Active",
         "sort": 3,
         "cooldown": 30,
-        "abilityId": "Tyrande|D1",
-        "abilityLinks": [
-          "Tyrande|D1"
-        ]
+        "abilityId": "Tyrande|Active"
       }
     ],
     "4": [
@@ -157,7 +153,7 @@
         "type": "Active",
         "sort": 2,
         "cooldown": 25,
-        "abilityId": "Tyrande|W1",
+        "abilityId": "Tyrande|Active",
         "abilityLinks": [
           "Tyrande|W1"
         ]
@@ -171,7 +167,7 @@
         "type": "Active",
         "sort": 3,
         "cooldown": 45,
-        "abilityId": "Tyrande|D1",
+        "abilityId": "Tyrande|Active",
         "abilityLinks": [
           "Tyrande|D1"
         ]

--- a/hero/uther.json
+++ b/hero/uther.json
@@ -1,5 +1,5 @@
 {
-  "id": "20",
+  "id": 20,
   "shortName": "uther",
   "attributeId": "Uthe",
   "cHeroId": "Uther",
@@ -22,7 +22,7 @@
   "abilities": {
     "Uther": [
       {
-        "uid": "5a0a50a",
+        "uid": "8c3795",
         "name": "Holy Light",
         "description": "Heal target allied Hero for 362 (+4% per level) Health. When used on a target other than Uther, also heal Uther for 181 (+4% per level) Health.",
         "hotkey": "Q",
@@ -33,7 +33,7 @@
         "type": "basic"
       },
       {
-        "uid": "3467f2b",
+        "uid": "ec3cb3",
         "name": "Holy Radiance",
         "description": "Heal all allied Heroes and Minions in a line for 177 (+4% per level) Health, dealing 177 (+4% per level) damage to enemies.",
         "hotkey": "W",
@@ -44,7 +44,7 @@
         "type": "basic"
       },
       {
-        "uid": "1760769",
+        "uid": "d591f4",
         "name": "Hammer of Justice",
         "description": "Deal 109 (+4% per level) damage and Stun the target for 1 second.",
         "hotkey": "E",
@@ -55,7 +55,7 @@
         "type": "basic"
       },
       {
-        "uid": "c4e2106",
+        "uid": "7268b3",
         "name": "Divine Shield",
         "description": "Make an allied Hero Invulnerable and increase their Movement Speed by 20% for 3 seconds.",
         "hotkey": "R",
@@ -66,7 +66,7 @@
         "type": "heroic"
       },
       {
-        "uid": "f536b3b",
+        "uid": "d2e8a0",
         "name": "Divine Storm",
         "description": "Deal 170 (+4% per level) damage and Stun nearby enemies for 1.75 seconds.",
         "hotkey": "R",
@@ -77,26 +77,36 @@
         "type": "heroic"
       },
       {
-        "uid": "d98eea7",
+        "uid": "5b08da",
         "name": "Devotion",
         "description": "Allied Heroes affected by Uther's Basic Abilities gain 25 Armor for 2 seconds.  This effect does not stack with itself.  Eternal Vanguard  Upon dying, Uther becomes an Invulnerable spirit for up to 8 seconds. While in spirit form, Uther can heal allies with Flash of Light.",
         "trait": true,
         "abilityId": "Uther|D1",
-        "cooldown": 180,
         "icon": "storm_ui_icon_uther_eternaldevotion.png",
         "type": "trait"
       }
     ],
     "UtherEternalDevotion": [
       {
-        "uid": "eb21192",
+        "uid": "8e2bc8",
+        "name": "Holy Light",
+        "description": "Heal target allied Hero for 362 (+4% per level) Health. When used on a target other than Uther, also heal Uther for 181 (+4% per level) Health.",
+        "hotkey": "Q",
+        "abilityId": "Uther|Q2",
+        "cooldown": 12,
+        "manaCost": 80,
+        "icon": "storm_ui_icon_uther_holylight.png",
+        "type": "basic"
+      },
+      {
+        "uid": "c5c996",
         "name": "Flash of Light",
         "description": "Heal an ally for 230 (+4% per level) Health.",
         "hotkey": "Q",
-        "abilityId": "Uther|Q2",
-        "cooldown": 1.5,
+        "abilityId": "Uther|Q3",
+        "cooldown": 15,
         "icon": "storm_ui_icon_uther_flashoflight.png",
-        "type": "subunit"
+        "type": "basic"
       }
     ]
   },

--- a/hero/valeera.json
+++ b/hero/valeera.json
@@ -1,5 +1,5 @@
 {
-  "id": "62",
+  "id": 62,
   "shortName": "valeera",
   "attributeId": "VALE",
   "cHeroId": "Valeera",
@@ -21,7 +21,7 @@
   "abilities": {
     "Valeera": [
       {
-        "uid": "3737e22",
+        "uid": "b9555b",
         "name": "Sinister Strike",
         "description": "Dash forward, hitting all enemies in a line for 110 (+4% per level) damage. If Sinister Strike hits a Hero, Valeera stops dashing immediately and the cooldown is reduced to 1 second.  Awards 1 Combo Point.  Stealth: Ambush Heavily damage an enemy and reduce their Armor.",
         "hotkey": "Q",
@@ -32,7 +32,7 @@
         "type": "basic"
       },
       {
-        "uid": "3cb16e4",
+        "uid": "b02e4c",
         "name": "Blade Flurry",
         "description": "Deal 130 (+4% per level) damage in an area around Valeera.  Awards 1 Combo Point per enemy Hero hit.  Stealth: Cheap Shot Stun, Blind, and damage an enemy.",
         "hotkey": "W",
@@ -43,7 +43,7 @@
         "type": "basic"
       },
       {
-        "uid": "c37452b",
+        "uid": "85c754",
         "name": "Eviscerate",
         "description": "Eviscerate an enemy, dealing damage per Combo Point.  1 Point: 85 (+4% per level) 2 Points: 170 (+4% per level) 3 Points: 255 (+4% per level)  Stealth: Garrote Silence and damage an enemy over time.",
         "hotkey": "E",
@@ -54,17 +54,7 @@
         "type": "basic"
       },
       {
-        "uid": "0adf79f",
-        "name": "Smoke Bomb",
-        "description": "Create a cloud of smoke. While in the smoke, Valeera is Unrevealable, can pass through other units, and gains 30 Armor, reducing damage taken by 30%. Valeera can continue to attack and use abilities without being revealed. Lasts 5 seconds.  Using this Ability does not break Stealth.",
-        "hotkey": "R",
-        "abilityId": "Valeera|R2",
-        "cooldown": 60,
-        "icon": "storm_ui_icon_valeera_smokebomb.png",
-        "type": "heroic"
-      },
-      {
-        "uid": "b21b32d",
+        "uid": "ab77e0",
         "name": "Cloak of Shadows",
         "description": "Valeera is enveloped in a Cloak of Shadows, which immediately removes all damage over time effects from her. For 1.5 seconds, she becomes Unstoppable and gains 75 Spell Armor, reducing Ability Damage taken by 75%.  Using this Ability does not break Stealth.",
         "hotkey": "R",
@@ -74,10 +64,19 @@
         "type": "heroic"
       },
       {
-        "uid": "b2836c3",
+        "uid": "31b894",
+        "name": "Smoke Bomb",
+        "description": "Create a cloud of smoke. While in the smoke, Valeera is Unrevealable, can pass through other units, and gains 30 Armor, reducing damage taken by 30%. Valeera can continue to attack and use abilities without being revealed. Lasts 5 seconds.  Using this Ability does not break Stealth.",
+        "hotkey": "R",
+        "abilityId": "Valeera|R2",
+        "cooldown": 60,
+        "icon": "storm_ui_icon_valeera_smokebomb.png",
+        "type": "heroic"
+      },
+      {
+        "uid": "3b3e33",
         "name": "Vanish",
         "description": "Vanish from sight, becoming Stealthed, gaining 20% Movement Speed and access to new Abilities. For the first second, Valeera is Unrevealable and can pass through other units. Remaining stationary for at least 1.5 seconds while Stealthed grants Invisible.  After being Stealthed for 3 seconds, Ambush, Cheap Shot, and Garrote have 100% increased range, and cause Valeera to teleport to the target when used.",
-        "hotkey": "D",
         "trait": true,
         "abilityId": "Valeera|D1",
         "cooldown": 8,
@@ -87,7 +86,7 @@
     ],
     "ValeeraStealth": [
       {
-        "uid": "55af9b1",
+        "uid": "06bc5c",
         "name": "Ambush",
         "description": "Ambush an enemy, dealing 130 (+4% per level) damage and reducing their Armor by 10 for 5 seconds.  Awards 1 Combo Point.  Unstealth: Sinister Strike Dash forward, damaging enemies.",
         "hotkey": "Q",
@@ -95,10 +94,10 @@
         "cooldown": 1,
         "manaCost": 10,
         "icon": "storm_ui_icon_valeera_ambush.png",
-        "type": "subunit"
+        "type": "basic"
       },
       {
-        "uid": "dc7704a",
+        "uid": "0986df",
         "name": "Cheap Shot",
         "description": "Deal 30 (+4% per level) damage to an enemy, Stun them for 0.75 seconds, and Blind them for 2 seconds once Cheap Shot's Stun expires.  Awards 1 Combo Point.  Unstealth: Blade Flurry Deal damage in an area around Valeera.",
         "hotkey": "W",
@@ -106,10 +105,10 @@
         "cooldown": 1,
         "manaCost": 30,
         "icon": "storm_ui_icon_valeera_cheapshot.png",
-        "type": "subunit"
+        "type": "basic"
       },
       {
-        "uid": "07ca592",
+        "uid": "5e801f",
         "name": "Garrote",
         "description": "Deal 20 (+4% per level) damage to an enemy and an additional 140 (+4% per level) damage over 7 seconds, and Silence them for 2.5 seconds.  Awards 1 Combo Point.  Unstealth: Eviscerate High damage finishing move.",
         "hotkey": "E",
@@ -117,7 +116,17 @@
         "cooldown": 1,
         "manaCost": 30,
         "icon": "storm_ui_icon_valeera_garrote.png",
-        "type": "subunit"
+        "type": "basic"
+      },
+      {
+        "uid": "b54f24",
+        "name": "Cancel Stealth",
+        "description": "Cancels Stealth.",
+        "trait": true,
+        "abilityId": "Valeera|D2",
+        "cooldown": 1,
+        "icon": "hud_btn_bg_ability_cancel.png",
+        "type": "trait"
       }
     ]
   },
@@ -142,10 +151,10 @@
         "icon": "storm_ui_icon_valeera_vanish.png",
         "type": "Trait",
         "sort": 2,
-        "abilityId": "Valeera|D1",
+        "abilityId": "Valeera|D2",
         "abilityLinks": [
-          "Valeera|D1",
-          "Valeera|D2"
+          "Valeera|D2",
+          "Valeera|D1"
         ]
       },
       {
@@ -205,10 +214,10 @@
         "icon": "storm_ui_icon_valeera_vanish.png",
         "type": "Trait",
         "sort": 3,
-        "abilityId": "Valeera|D1",
+        "abilityId": "Valeera|D2",
         "abilityLinks": [
-          "Valeera|D1",
-          "Valeera|D2"
+          "Valeera|D2",
+          "Valeera|D1"
         ]
       },
       {
@@ -423,10 +432,10 @@
         "icon": "storm_ui_icon_valeera_vanish.png",
         "type": "Trait",
         "sort": 4,
-        "abilityId": "Valeera|D1",
+        "abilityId": "Valeera|D2",
         "abilityLinks": [
-          "Valeera|D1",
-          "Valeera|D2"
+          "Valeera|D2",
+          "Valeera|D1"
         ]
       }
     ]

--- a/hero/valla.json
+++ b/hero/valla.json
@@ -1,5 +1,5 @@
 {
-  "id": "21",
+  "id": 21,
   "shortName": "valla",
   "attributeId": "Demo",
   "cHeroId": "DemonHunter",
@@ -21,7 +21,7 @@
   "abilities": {
     "Valla": [
       {
-        "uid": "9d16f5f",
+        "uid": "dffcf8",
         "name": "Hungering Arrow",
         "description": "Fire an arrow that deals 140 (+4% per level) damage to the first target hit, then seeks up to 2 additional enemies, prioritizing Heroes, dealing 80 (+4% per level) damage. Can hit an enemy multiple times.",
         "hotkey": "Q",
@@ -32,7 +32,7 @@
         "type": "basic"
       },
       {
-        "uid": "0a51d89",
+        "uid": "512f24",
         "name": "Multishot",
         "description": "Deal 172 (+4% per level) damage to enemies within the target area.",
         "hotkey": "W",
@@ -43,7 +43,7 @@
         "type": "basic"
       },
       {
-        "uid": "6a34abe",
+        "uid": "85923d",
         "name": "Vault",
         "description": "Dash to the target area. Valla's next Basic Attack within 2 seconds deals 6% increased damage per stack of Hatred.",
         "hotkey": "E",
@@ -54,18 +54,7 @@
         "type": "basic"
       },
       {
-        "uid": "2968a43",
-        "name": "Rain of Vengeance",
-        "description": "Launch a wave of Shadow Beasts that deals 250 (+4% per level) damage and stuns enemies in the target area for 0.5 seconds.  Stores up to 2 charges.",
-        "hotkey": "R",
-        "abilityId": "Valla|R2",
-        "cooldown": 50,
-        "manaCost": 50,
-        "icon": "storm_ui_icon_valla_rainofvengeance.png",
-        "type": "heroic"
-      },
-      {
-        "uid": "93804e8",
+        "uid": "3c950f",
         "name": "Strafe",
         "description": "Rapidly attack enemies within 10 range for 60 (+4% per level) damage per hit, prioritizing Heroes over Minions. Valla is able to move and use Vault while strafing. Lasts for 4 seconds.",
         "hotkey": "R",
@@ -76,7 +65,18 @@
         "type": "heroic"
       },
       {
-        "uid": "cc16e46",
+        "uid": "4462d4",
+        "name": "Rain of Vengeance",
+        "description": "Launch a wave of Shadow Beasts that deals 250 (+4% per level) damage and stuns enemies in the target area for 0.5 seconds.  Stores up to 2 charges.",
+        "hotkey": "R",
+        "abilityId": "Valla|R2",
+        "cooldown": 50,
+        "manaCost": 50,
+        "icon": "storm_ui_icon_valla_rainofvengeance.png",
+        "type": "heroic"
+      },
+      {
+        "uid": "8d8ad7",
         "name": "Hatred",
         "description": "Basic Attacks grant a stack of Hatred, up to 10. Each Hatred stack increases Basic Attack damage by 8% and Movement Speed by 1%. Lasts 6 seconds.",
         "trait": true,
@@ -279,7 +279,7 @@
         "type": "Active",
         "sort": 3,
         "cooldown": 5,
-        "abilityId": "Valla|D1",
+        "abilityId": "Valla|Active",
         "abilityLinks": [
           "Valla|D1"
         ]

--- a/hero/varian.json
+++ b/hero/varian.json
@@ -136,7 +136,6 @@
         "isQuest": true,
         "abilityId": "Varian|Passive",
         "abilityLinks": [
-          "Varian|D2",
           "Varian|D1"
         ]
       }
@@ -266,9 +265,8 @@
         "icon": "storm_ui_icon_varian_mortalstrike.png",
         "type": "Trait",
         "sort": 2,
-        "abilityId": "Varian|D2",
+        "abilityId": "Varian|D1",
         "abilityLinks": [
-          "Varian|D2",
           "Varian|D1"
         ]
       },

--- a/hero/varian.json
+++ b/hero/varian.json
@@ -1,12 +1,12 @@
 {
-  "id": "59",
+  "id": 59,
   "shortName": "varian",
   "attributeId": "Vari",
   "cHeroId": "Varian",
   "cUnitId": "HeroVarian",
   "name": "Varian",
   "icon": "varian.png",
-  "role": "Multiclass",
+  "role": "Multiclass,Warrior,Assassin",
   "expandedRole": "Bruiser",
   "type": "Melee",
   "releaseDate": "2016-11-15",
@@ -21,7 +21,7 @@
   "abilities": {
     "Varian": [
       {
-        "uid": "e15f695",
+        "uid": "f74ce7",
         "name": "Lion's Fang",
         "description": "Create a shockwave that travels in a straight line, dealing 150 (+4% per level) damage and Slowing enemies by 35% for 1.5 seconds. Each enemy hit heals Varian for 35 (+4% per level), increased to 140 (+4% per level) against Heroes.",
         "hotkey": "Q",
@@ -32,7 +32,7 @@
         "type": "basic"
       },
       {
-        "uid": "7a8378b",
+        "uid": "846528",
         "name": "Parry",
         "description": "Parry all incoming Basic Attacks for 1.25 seconds, reducing their damage by 100%.  Stores up to 2 charges.",
         "hotkey": "W",
@@ -43,7 +43,7 @@
         "type": "basic"
       },
       {
-        "uid": "2ba5b0d",
+        "uid": "d692b4",
         "name": "Charge",
         "description": "Charge to the target enemy, dealing 50 (+4% per level) damage and Slowing them by 75% for 1 second.",
         "hotkey": "E",
@@ -54,9 +54,9 @@
         "type": "basic"
       },
       {
-        "uid": "f620e35",
+        "uid": "95aa28",
         "name": "Taunt",
-        "description": "Silence a target Hero and force them to attack Varian for 1.25 seconds.  Passive: Maximum Health and Health Regeneration increased by 30%.",
+        "description": "Silence a target Hero and force them to attack Varian for 1.25 seconds.  Passive: Maximum Health and Health Regeneration increased by 40%.",
         "hotkey": "R",
         "abilityId": "Varian|R1",
         "cooldown": 16,
@@ -65,7 +65,7 @@
         "type": "heroic"
       },
       {
-        "uid": "5ac8d0f",
+        "uid": "1e7f05",
         "name": "Colossus Smash",
         "description": "Smash a target enemy, dealing 160 (+4% per level) damage and lowering their Armor by 20 for 3 seconds, causing them to take 20% increased damage.  Passive: Base Attack Damage increased by 100%. Passive: Maximum Health and Health Regeneration reduced by 10%.",
         "hotkey": "R",
@@ -76,16 +76,16 @@
         "type": "heroic"
       },
       {
-        "uid": "b8832d1",
+        "uid": "002091",
         "name": "Twin Blades of Fury",
-        "description": "Basic Attacks reduce Heroic Strike's cooldown by 9 seconds, and increase Varian's Movement Speed by 30% for 2 seconds.  Passive: Attack Speed increased by 100%. Passive: Base Attack Damage reduced by 20%.",
+        "description": "Basic Attacks reduce Heroic Strike's cooldown by 9 seconds, and increase Varian's Movement Speed by 30% for 2 seconds.  Passive: Attack Speed increased by 100%. Passive: Base Attack Damage reduced by 25%.",
         "hotkey": "R",
         "abilityId": "Varian|R3",
         "icon": "storm_ui_icon_varian_twinbladesoffury.png",
         "type": "heroic"
       },
       {
-        "uid": "4d4cc92",
+        "uid": "9109fa",
         "name": "Heroic Strike",
         "description": "Every 18 seconds, Varian's next Basic Attack deals 125 (+4% per level) bonus Spell Damage. Basic Attacks reduce this cooldown by 2 seconds.",
         "trait": true,
@@ -116,7 +116,7 @@
         "tooltipId": "VarianParryOverpower",
         "talentTreeId": "VarianParryOverpower",
         "name": "Overpower",
-        "description": "When Parry blocks a Hero's Basic Attack, Heroic Strike's cooldown is refreshed and the next one does 30% more damage.",
+        "description": "When Parry blocks a Hero's Basic Attack, Heroic Strike's cooldown is refreshed and the next one does 40% more damage.",
         "icon": "storm_ui_icon_varian_parry.png",
         "type": "W",
         "sort": 2,
@@ -136,6 +136,7 @@
         "isQuest": true,
         "abilityId": "Varian|Passive",
         "abilityLinks": [
+          "Varian|D2",
           "Varian|D1"
         ]
       }
@@ -145,7 +146,7 @@
         "tooltipId": "VarianTaunt",
         "talentTreeId": "VarianTaunt",
         "name": "Taunt",
-        "description": "Silence a target Hero and force them to attack Varian for 1.25 seconds.  Passive: Maximum Health and Health Regeneration increased by 30%.",
+        "description": "Silence a target Hero and force them to attack Varian for 1.25 seconds.  Passive: Maximum Health and Health Regeneration increased by 40%.",
         "icon": "storm_ui_icon_varian_taunt.png",
         "type": "Heroic",
         "sort": 1,
@@ -173,14 +174,11 @@
         "tooltipId": "VarianTwinBladesOfFury",
         "talentTreeId": "VarianTwinBladesOfFury",
         "name": "Twin Blades of Fury",
-        "description": "Basic Attacks reduce Heroic Strike's cooldown by 9 seconds, and increase Varian's Movement Speed by 30% for 2 seconds.  Passive: Attack Speed increased by 100%. Passive: Base Attack Damage reduced by 20%.",
+        "description": "Basic Attacks reduce Heroic Strike's cooldown by 9 seconds, and increase Varian's Movement Speed by 30% for 2 seconds.  Passive: Attack Speed increased by 100%. Passive: Base Attack Damage reduced by 25%.",
         "icon": "storm_ui_icon_varian_twinbladesoffury.png",
         "type": "Heroic",
         "sort": 3,
-        "abilityId": "Varian|R3",
-        "abilityLinks": [
-          "Varian|R3"
-        ]
+        "abilityLinks": []
       }
     ],
     "7": [
@@ -188,7 +186,7 @@
         "tooltipId": "VarianLionsFangLionheart",
         "talentTreeId": "VarianLionsFangLionheart",
         "name": "Lionheart",
-        "description": "Increase Lion's Fang's healing from Heroes by 50%.",
+        "description": "Increase Lion's Fang's healing from Heroes by 75%.",
         "icon": "storm_ui_icon_varian_lionsfang.png",
         "type": "Q",
         "sort": 1,
@@ -268,8 +266,9 @@
         "icon": "storm_ui_icon_varian_mortalstrike.png",
         "type": "Trait",
         "sort": 2,
-        "abilityId": "Varian|D1",
+        "abilityId": "Varian|D2",
         "abilityLinks": [
+          "Varian|D2",
           "Varian|D1"
         ]
       },
@@ -294,7 +293,7 @@
         "icon": "storm_ui_icon_varian_bannerofstormwind.png",
         "type": "Active",
         "sort": 1,
-        "cooldown": 45,
+        "cooldown": 25,
         "abilityId": "Varian|Active"
       },
       {
@@ -316,7 +315,7 @@
         "icon": "storm_ui_icon_varian_bannerofdalaran.png",
         "type": "Active",
         "sort": 3,
-        "cooldown": 45,
+        "cooldown": 25,
         "abilityId": "Varian|Active"
       }
     ],
@@ -364,16 +363,12 @@
         "tooltipId": "VarianBannersGloryToTheAlliance",
         "talentTreeId": "VarianBannersGloryToTheAlliance",
         "name": "Glory to the Alliance",
-        "description": "Banner now also increases health regeneration and all healing received for nearby allied Heroes by 50%, and the cooldown is reduced by 20 seconds.",
+        "description": "Banner now also increases health regeneration and all healing received for nearby allied Heroes by 50%, and the cooldown is reduced by 50%.",
         "icon": "storm_ui_icon_varian_glorytothealliance.png",
         "type": "Passive",
         "sort": 4,
         "abilityId": "Varian|Passive",
-        "abilityLinks": [
-          "Varian|11",
-          "Varian|12",
-          "Varian|13"
-        ]
+        "abilityLinks": []
       },
       {
         "tooltipId": "VarianDemoralizingShout",

--- a/hero/whitemane.json
+++ b/hero/whitemane.json
@@ -1,5 +1,5 @@
 {
-  "id": "81",
+  "id": 81,
   "shortName": "whitemane",
   "attributeId": "WHIT",
   "cHeroId": "Whitemane",
@@ -20,7 +20,7 @@
   "abilities": {
     "Whitemane": [
       {
-        "uid": "05c4e67",
+        "uid": "9fab17",
         "name": "Desperate Plea",
         "description": "Heal an allied Hero for 140 (+4% per level) and gain Desperation for 4 seconds.  Desperation increases Desperate Plea's Mana cost by 45, and stacks up to 3 times.  Current Mana Cost: 45",
         "hotkey": "Q",
@@ -30,9 +30,9 @@
         "type": "basic"
       },
       {
-        "uid": "9abab82",
+        "uid": "56560e",
         "name": "Inquisition",
-        "description": "Channel on an enemy Hero for up to 3 seconds, dealing 47 (+4% per level) damage every 0.5 seconds and Slowing them by 30%.  Shares a cooldown with Clemency.",
+        "description": "Channel on an enemy Hero for up to 3 seconds, dealing 47 (+4% per level) damage every 0.5 seconds and Slowing them by 30%. Removes a stack of Desperation.  Shares a cooldown with Clemency.",
         "hotkey": "W",
         "abilityId": "Whitemane|W1",
         "cooldown": 14,
@@ -40,7 +40,7 @@
         "type": "basic"
       },
       {
-        "uid": "83d34aa",
+        "uid": "68420a",
         "name": "Searing Lash",
         "description": "After 0.5 seconds, smite enemies in a straight line for 82 (+4% per level) damage.  If the first strike hits an enemy Hero, a second strike will occur after a short delay.",
         "hotkey": "E",
@@ -50,7 +50,17 @@
         "type": "basic"
       },
       {
-        "uid": "e6b8d35",
+        "uid": "c5b7e1",
+        "name": "Clemency",
+        "description": "Activate to cast Inquisition on an allied Hero, healing them for up to 329 (+4% per level) over 3 seconds while Channeling. Removes a stack of Desperation  Shares a cooldown with Inquisition.",
+        "hotkey": 1,
+        "abilityId": "Whitemane|11",
+        "cooldown": 12,
+        "icon": "storm_ui_icon_whitemane_clemency.png",
+        "type": "activable"
+      },
+      {
+        "uid": "7ccf85",
         "name": "Scarlet Aegis",
         "description": "Bolster the spirits of nearby allied Heroes, healing them for 250 (+4% per level) and granting them 40 Armor for 4 seconds.",
         "hotkey": "R",
@@ -60,7 +70,7 @@
         "type": "heroic"
       },
       {
-        "uid": "3c0468a",
+        "uid": "61f9c2",
         "name": "Divine Reckoning",
         "description": "After 1 second, consecrate an area for 4 seconds, dealing 50 (+4% per level) damage every 0.5 seconds to enemies inside. 25% of the damage dealt to Heroes is returned as Mana.",
         "hotkey": "R",
@@ -70,24 +80,14 @@
         "type": "heroic"
       },
       {
-        "uid": "e003ec1",
+        "uid": "5cbe24",
         "name": "Zeal",
-        "description": "Whitemane's healing Abilities apply Zeal for 8 seconds.  Allies with Zeal are healed for 100% of the damage Whitemane deals to Heroes.",
+        "description": "Whitemane's healing Abilities apply Zeal for 8 seconds. Allies with Zeal are healed for 100% of the damage Whitemane deals to Heroes.  Activate to gain 25% Spell Power and lose 25 Armor for 5 seconds.",
         "trait": true,
         "abilityId": "Whitemane|D1",
+        "cooldown": 60,
         "icon": "storm_ui_icon_whitemane_zeal.png",
         "type": "trait"
-      },
-      {
-        "uid": "396cead",
-        "name": "Clemency",
-        "description": "Activate to cast Inquisition on an allied Hero, healing them for up to 329 (+4% per level) over 3 seconds while Channeling.  Shares a cooldown with Inquisition.",
-        "hotkey": "1",
-        "abilityId": "Whitemane|11",
-        "cooldown": 12,
-        "manaCost": 75,
-        "icon": "storm_ui_icon_whitemane_clemency.png",
-        "type": "activable"
       }
     ]
   },
@@ -275,13 +275,13 @@
         "tooltipId": "WhitemaneSaintlyGreatstaff",
         "talentTreeId": "WhitemaneSaintlyGreatstaff",
         "name": "Saintly Greatstaff",
-        "description": "Zeal healing from Basic Attacks is increased by 100%.",
-        "icon": "storm_ui_icon_whitemane_zeal.png",
-        "type": "Trait",
+        "description": "Enemy Heroes hit by Searing Lash are marked for 3 seconds. Basic Attacks against them deal an additional 50 (+4% per level) Spell damage and remove the mark.",
+        "icon": "storm_ui_icon_whitemane_lash_alt_1.png",
+        "type": "E",
         "sort": 3,
-        "abilityId": "Whitemane|D1",
+        "abilityId": "Whitemane|E1",
         "abilityLinks": [
-          "Whitemane|D1"
+          "Whitemane|E1"
         ]
       }
     ],
@@ -354,15 +354,18 @@
         ]
       },
       {
-        "tooltipId": "WhitemaneFanaticalPower",
-        "talentTreeId": "WhitemaneFanaticalPower",
-        "name": "Fanatical Power",
-        "description": "Activate to cast a permanent Desperate Plea on an allied Hero that costs no Mana and doesn't grant Desperation. Only one can be active at a time and has global cast range.",
-        "icon": "storm_ui_icon_whitemane_desperation.png",
-        "type": "Q",
+        "tooltipId": "WhitemaneGuidingLight",
+        "talentTreeId": "WhitemaneGuidingLight",
+        "name": "Guiding Light",
+        "description": "Activate to cast a permanent Zeal on an allied Hero that costs no Mana and doesn't grant Desperation. Only one can be active at a time and has global cast range.",
+        "icon": "storm_ui_icon_whitemane_zeal.png",
+        "type": "Active",
         "sort": 3,
         "cooldown": 30,
-        "abilityId": "Whitemane|Q"
+        "abilityId": "Whitemane|Active",
+        "abilityLinks": [
+          "Whitemane|Q1"
+        ]
       },
       {
         "tooltipId": "WhitemanePurgeTheWicked",

--- a/hero/xul.json
+++ b/hero/xul.json
@@ -150,9 +150,9 @@
         "type": "Q",
         "sort": 1,
         "isQuest": true,
-        "abilityId": "Xul|Q2",
+        "abilityId": "Xul|Q1",
         "abilityLinks": [
-          "Xul|Q2"
+          "Xul|Q1"
         ]
       },
       {
@@ -163,9 +163,8 @@
         "icon": "storm_ui_icon_necromancer_cursedstrikes_off.png",
         "type": "W",
         "sort": 2,
-        "abilityId": "Xul|W2",
+        "abilityId": "Xul|W1",
         "abilityLinks": [
-          "Xul|W2",
           "Xul|W1"
         ]
       },
@@ -193,9 +192,8 @@
         "icon": "storm_ui_icon_necromancer_cursedstrikes_off.png",
         "type": "W",
         "sort": 1,
-        "abilityId": "Xul|W2",
+        "abilityId": "Xul|W1",
         "abilityLinks": [
-          "Xul|W2",
           "Xul|W1"
         ]
       },
@@ -207,9 +205,8 @@
         "icon": "storm_ui_icon_necromancer_cursedstrikes_b.png",
         "type": "W",
         "sort": 2,
-        "abilityId": "Xul|W2",
+        "abilityId": "Xul|W1",
         "abilityLinks": [
-          "Xul|W2",
           "Xul|W1"
         ]
       },
@@ -266,9 +263,9 @@
         "icon": "storm_ui_icon_necromancer_reap.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "Xul|Q2",
+        "abilityId": "Xul|Q1",
         "abilityLinks": [
-          "Xul|Q2"
+          "Xul|Q1"
         ]
       },
       {
@@ -279,9 +276,8 @@
         "icon": "storm_ui_icon_necromancer_cursedstrikes_off.png",
         "type": "W",
         "sort": 2,
-        "abilityId": "Xul|W2",
+        "abilityId": "Xul|W1",
         "abilityLinks": [
-          "Xul|W2",
           "Xul|W1"
         ]
       },
@@ -370,9 +366,9 @@
         "icon": "storm_ui_icon_necromancer_reap.png",
         "type": "Q",
         "sort": 3,
-        "abilityId": "Xul|Q2",
+        "abilityId": "Xul|Q1",
         "abilityLinks": [
-          "Xul|Q2"
+          "Xul|Q1"
         ]
       },
       {

--- a/hero/xul.json
+++ b/hero/xul.json
@@ -1,5 +1,5 @@
 {
-  "id": "49",
+  "id": 49,
   "shortName": "xul",
   "attributeId": "Necr",
   "cHeroId": "Necromancer",
@@ -23,7 +23,7 @@
   "abilities": {
     "Xul": [
       {
-        "uid": "7fd87e6",
+        "uid": "88b979",
         "name": "Spectral Scythe",
         "description": "Summon a scythe that travels to Xul after 1 second, dealing 240 (+4% per level) damage to enemies.",
         "hotkey": "Q",
@@ -34,7 +34,7 @@
         "type": "basic"
       },
       {
-        "uid": "08bf2ab",
+        "uid": "51a237",
         "name": "Cursed Strikes",
         "description": "Xul's Basic Attacks deal damage in a wide area and reduce the Attack Speed of Heroes and Summons by 40% for 2 seconds. Lasts 4 seconds once triggered.",
         "hotkey": "W",
@@ -45,7 +45,7 @@
         "type": "basic"
       },
       {
-        "uid": "a26161f",
+        "uid": "aff545",
         "name": "Bone Prison",
         "description": "After a 2 second delay, deal 80 (+4% per level) damage and Root the target enemy Hero for 1.75 seconds.  All nearby Skeletal Warriors will fixate on the target for their duration.",
         "hotkey": "E",
@@ -56,7 +56,17 @@
         "type": "basic"
       },
       {
-        "uid": "69a0bd3",
+        "uid": "7131a0",
+        "name": "Bone Armor",
+        "description": "Activate to gain a Shield equal to 25% of Xul's maximum Health for 3 seconds.",
+        "hotkey": 1,
+        "abilityId": "Xul|11",
+        "cooldown": 30,
+        "icon": "storm_ui_icon_necromancer_bonearmor.png",
+        "type": "activable"
+      },
+      {
+        "uid": "5cbead",
         "name": "Skeletal Mages",
         "description": "Vector Targeting Summon 4 Frost Mages in a line that attack nearby enemies for 47 (+4% per level) damage a second and Slow them by 30% for 2 seconds. Last up to 15 seconds.",
         "hotkey": "R",
@@ -67,7 +77,7 @@
         "type": "heroic"
       },
       {
-        "uid": "a8b7e99",
+        "uid": "c9f8ee",
         "name": "Poison Nova",
         "description": "After 0.5 seconds, release poisonous missiles that deal 570 (+4% per level) damage to all enemies hit over 10 seconds.",
         "hotkey": "R",
@@ -78,17 +88,7 @@
         "type": "heroic"
       },
       {
-        "uid": "9410c65",
-        "name": "Bone Armor",
-        "description": "Activate to gain a Shield equal to 25% of Xul's maximum Health for 3 seconds.",
-        "hotkey": "1",
-        "abilityId": "Xul|11",
-        "cooldown": 30,
-        "icon": "storm_ui_icon_necromancer_bonearmor.png",
-        "type": "activable"
-      },
-      {
-        "uid": "3dec1ba",
+        "uid": "6ca7a4",
         "name": "Raise Skeleton",
         "description": "When a nearby enemy Minion dies, it becomes a Skeletal Warrior with 225 (+4% per level) Health that attacks for 21 (+4% per level) damage and last up to 15 seconds. Up to 4 Skeletal Warriors can be active at once.",
         "trait": true,
@@ -150,9 +150,9 @@
         "type": "Q",
         "sort": 1,
         "isQuest": true,
-        "abilityId": "Xul|Q1",
+        "abilityId": "Xul|Q2",
         "abilityLinks": [
-          "Xul|Q1"
+          "Xul|Q2"
         ]
       },
       {
@@ -163,8 +163,9 @@
         "icon": "storm_ui_icon_necromancer_cursedstrikes_off.png",
         "type": "W",
         "sort": 2,
-        "abilityId": "Xul|W1",
+        "abilityId": "Xul|W2",
         "abilityLinks": [
+          "Xul|W2",
           "Xul|W1"
         ]
       },
@@ -192,8 +193,9 @@
         "icon": "storm_ui_icon_necromancer_cursedstrikes_off.png",
         "type": "W",
         "sort": 1,
-        "abilityId": "Xul|W1",
+        "abilityId": "Xul|W2",
         "abilityLinks": [
+          "Xul|W2",
           "Xul|W1"
         ]
       },
@@ -205,8 +207,9 @@
         "icon": "storm_ui_icon_necromancer_cursedstrikes_b.png",
         "type": "W",
         "sort": 2,
-        "abilityId": "Xul|W1",
+        "abilityId": "Xul|W2",
         "abilityLinks": [
+          "Xul|W2",
           "Xul|W1"
         ]
       },
@@ -263,9 +266,9 @@
         "icon": "storm_ui_icon_necromancer_reap.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "Xul|Q1",
+        "abilityId": "Xul|Q2",
         "abilityLinks": [
-          "Xul|Q1"
+          "Xul|Q2"
         ]
       },
       {
@@ -276,8 +279,9 @@
         "icon": "storm_ui_icon_necromancer_cursedstrikes_off.png",
         "type": "W",
         "sort": 2,
-        "abilityId": "Xul|W1",
+        "abilityId": "Xul|W2",
         "abilityLinks": [
+          "Xul|W2",
           "Xul|W1"
         ]
       },
@@ -366,9 +370,9 @@
         "icon": "storm_ui_icon_necromancer_reap.png",
         "type": "Q",
         "sort": 3,
-        "abilityId": "Xul|Q1",
+        "abilityId": "Xul|Q2",
         "abilityLinks": [
-          "Xul|Q1"
+          "Xul|Q2"
         ]
       },
       {

--- a/hero/yrel.json
+++ b/hero/yrel.json
@@ -99,9 +99,8 @@
         "icon": "storm_ui_icon_yrel_vindication.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "Yrel|Q2",
+        "abilityId": "Yrel|Q1",
         "abilityLinks": [
-          "Yrel|Q2",
           "Yrel|Q1"
         ]
       },
@@ -135,11 +134,9 @@
         "icon": "storm_ui_icon_yrel_avenging_wrath.png",
         "type": "E",
         "sort": 1,
-        "abilityId": "Yrel|E2",
+        "abilityId": "Yrel|E1",
         "abilityLinks": [
-          "Yrel|E2",
-          "Yrel|E1",
-          "Yrel|E3"
+          "Yrel|E1"
         ]
       },
       {
@@ -176,10 +173,8 @@
         "icon": "storm_ui_icon_yrel_righteous_hammer.png",
         "type": "W",
         "sort": 1,
-        "abilityId": "Yrel|W2",
+        "abilityId": "Yrel|W1",
         "abilityLinks": [
-          "Yrel|W2",
-          "Yrel|W3",
           "Yrel|W1"
         ]
       },
@@ -191,11 +186,9 @@
         "icon": "storm_ui_icon_yrel_avenging_wrath.png",
         "type": "E",
         "sort": 2,
-        "abilityId": "Yrel|E2",
+        "abilityId": "Yrel|E1",
         "abilityLinks": [
-          "Yrel|E2",
-          "Yrel|E1",
-          "Yrel|E3"
+          "Yrel|E1"
         ]
       },
       {
@@ -206,10 +199,7 @@
         "icon": "storm_ui_icon_yrel_divine_steed.png",
         "type": "Z",
         "sort": 3,
-        "abilityId": "Yrel|Z2",
-        "abilityLinks": [
-          "Yrel|Z2"
-        ]
+        "abilityLinks": []
       }
     ],
     "10": [
@@ -251,9 +241,8 @@
         "icon": "storm_ui_icon_yrel_vindication.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "Yrel|Q2",
+        "abilityId": "Yrel|Q1",
         "abilityLinks": [
-          "Yrel|Q2",
           "Yrel|Q1"
         ]
       },
@@ -265,11 +254,9 @@
         "icon": "storm_ui_icon_yrel_avenging_wrath.png",
         "type": "E",
         "sort": 2,
-        "abilityId": "Yrel|E2",
+        "abilityId": "Yrel|E1",
         "abilityLinks": [
-          "Yrel|E2",
-          "Yrel|E1",
-          "Yrel|E3"
+          "Yrel|E1"
         ]
       },
       {
@@ -292,10 +279,8 @@
         "icon": "storm_ui_icon_yrel_righteous_hammer.png",
         "type": "W",
         "sort": 1,
-        "abilityId": "Yrel|W2",
+        "abilityId": "Yrel|W1",
         "abilityLinks": [
-          "Yrel|W2",
-          "Yrel|W3",
           "Yrel|W1"
         ]
       },

--- a/hero/yrel.json
+++ b/hero/yrel.json
@@ -1,5 +1,5 @@
 {
-  "id": "80",
+  "id": 80,
   "shortName": "yrel",
   "attributeId": "YREL",
   "cHeroId": "Yrel",
@@ -23,7 +23,7 @@
   "abilities": {
     "Yrel": [
       {
-        "uid": "5507d18",
+        "uid": "7e0b4d",
         "name": "Vindication",
         "description": "Unleash holy energy around Yrel, dealing 42 (+4% per level) damage to nearby enemies and healing her for 96 (+4% per level).  Charging up this Ability increases its damage up to 140 (+4% per level), and healing up to 320 (+4% per level).",
         "hotkey": "Q",
@@ -34,7 +34,18 @@
         "type": "basic"
       },
       {
-        "uid": "1bf6888",
+        "uid": "00ae98",
+        "name": "Righteous Hammer",
+        "description": "Swing Yrel's hammer, dealing 38 (+4% per level) damage to enemies in front of her and knocking them away.  Charging up this Ability increases its knockback distance, and damage up to 125 (+4% per level). Enemies hit at maximum charge are Stunned for 0.75 seconds.",
+        "hotkey": "W",
+        "abilityId": "Yrel|W1",
+        "cooldown": 6,
+        "manaCost": 65,
+        "icon": "storm_ui_icon_yrel_righteous_hammer.png",
+        "type": "basic"
+      },
+      {
+        "uid": "ba08af",
         "name": "Avenging Wrath",
         "description": "Leap to a location, dealing 225 (+4% per level) damage to enemies in an area and Slowing them by 50% for 1 second.  Charging up this Ability increases its range.",
         "hotkey": "E",
@@ -45,7 +56,7 @@
         "type": "basic"
       },
       {
-        "uid": "2fd9342",
+        "uid": "2db2ae",
         "name": "Ardent Defender",
         "description": "Surround Yrel in a barrier for 3 seconds, absorbing all damage taken and healing her for 50% of the damage received.",
         "hotkey": "R",
@@ -56,7 +67,7 @@
         "type": "heroic"
       },
       {
-        "uid": "7390a4d",
+        "uid": "aa1789",
         "name": "Sacred Ground",
         "description": "Yrel sanctifies the ground around her, gaining 50 Armor until she leaves the area.",
         "hotkey": "R",
@@ -67,26 +78,14 @@
         "type": "heroic"
       },
       {
-        "uid": "ec75c9a",
+        "uid": "95b463",
         "name": "Divine Purpose",
         "description": "Activate to instantly charge Yrel's next Basic Ability at no mana cost.  Passive: Yrel's Basic Abilities charge up over 1.5 seconds, increasing in effectiveness, but reducing Yrel's Movement Speed by 25%.",
-        "hotkey": "D",
         "trait": true,
         "abilityId": "Yrel|D1",
         "cooldown": 8,
         "icon": "storm_ui_icon_yrel_divine_purpose.png",
         "type": "trait"
-      },
-      {
-        "uid": "ede1881",
-        "name": "Righteous Hammer",
-        "description": "Swing Yrel's hammer, dealing 38 (+4% per level) damage to enemies in front of her and knocking them away.  Charging up this Ability increases its knockback distance, and damage up to 125 (+4% per level). Enemies hit at maximum charge are Stunned for 0.75 seconds.",
-        "hotkey": "W",
-        "abilityId": "Yrel|W1",
-        "cooldown": 6,
-        "manaCost": 65,
-        "icon": "storm_ui_icon_yrel_righteous_hammer.png",
-        "type": "basic"
       }
     ]
   },
@@ -100,8 +99,9 @@
         "icon": "storm_ui_icon_yrel_vindication.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "Yrel|Q1",
+        "abilityId": "Yrel|Q2",
         "abilityLinks": [
+          "Yrel|Q2",
           "Yrel|Q1"
         ]
       },
@@ -135,9 +135,11 @@
         "icon": "storm_ui_icon_yrel_avenging_wrath.png",
         "type": "E",
         "sort": 1,
-        "abilityId": "Yrel|E1",
+        "abilityId": "Yrel|E2",
         "abilityLinks": [
-          "Yrel|E1"
+          "Yrel|E2",
+          "Yrel|E1",
+          "Yrel|E3"
         ]
       },
       {
@@ -174,8 +176,9 @@
         "icon": "storm_ui_icon_yrel_righteous_hammer.png",
         "type": "W",
         "sort": 1,
-        "abilityId": "Yrel|W3",
+        "abilityId": "Yrel|W2",
         "abilityLinks": [
+          "Yrel|W2",
           "Yrel|W3",
           "Yrel|W1"
         ]
@@ -188,9 +191,11 @@
         "icon": "storm_ui_icon_yrel_avenging_wrath.png",
         "type": "E",
         "sort": 2,
-        "abilityId": "Yrel|E1",
+        "abilityId": "Yrel|E2",
         "abilityLinks": [
-          "Yrel|E1"
+          "Yrel|E2",
+          "Yrel|E1",
+          "Yrel|E3"
         ]
       },
       {
@@ -201,7 +206,10 @@
         "icon": "storm_ui_icon_yrel_divine_steed.png",
         "type": "Z",
         "sort": 3,
-        "abilityId": "Yrel|Z"
+        "abilityId": "Yrel|Z2",
+        "abilityLinks": [
+          "Yrel|Z2"
+        ]
       }
     ],
     "10": [
@@ -243,8 +251,9 @@
         "icon": "storm_ui_icon_yrel_vindication.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "Yrel|Q1",
+        "abilityId": "Yrel|Q2",
         "abilityLinks": [
+          "Yrel|Q2",
           "Yrel|Q1"
         ]
       },
@@ -256,9 +265,11 @@
         "icon": "storm_ui_icon_yrel_avenging_wrath.png",
         "type": "E",
         "sort": 2,
-        "abilityId": "Yrel|E1",
+        "abilityId": "Yrel|E2",
         "abilityLinks": [
-          "Yrel|E1"
+          "Yrel|E2",
+          "Yrel|E1",
+          "Yrel|E3"
         ]
       },
       {
@@ -281,8 +292,9 @@
         "icon": "storm_ui_icon_yrel_righteous_hammer.png",
         "type": "W",
         "sort": 1,
-        "abilityId": "Yrel|W3",
+        "abilityId": "Yrel|W2",
         "abilityLinks": [
+          "Yrel|W2",
           "Yrel|W3",
           "Yrel|W1"
         ]

--- a/hero/zagara.json
+++ b/hero/zagara.json
@@ -1,5 +1,5 @@
 {
-  "id": "27",
+  "id": 27,
   "shortName": "zagara",
   "attributeId": "Zaga",
   "cHeroId": "Zagara",
@@ -21,7 +21,7 @@
   "abilities": {
     "Zagara": [
       {
-        "uid": "13bfb31",
+        "uid": "5a2c02",
         "name": "Baneling Barrage",
         "description": "Launch 1 Baneling that deals 86 (+4% per level) damage to enemies it hits.  Stores up to 4 charges.",
         "hotkey": "Q",
@@ -32,7 +32,7 @@
         "type": "basic"
       },
       {
-        "uid": "ad0d2bd",
+        "uid": "daa2e2",
         "name": "Hunter Killer",
         "description": "Summon a Hydralisk to attack a single target, dealing 71 (+5% per level) damage per second. Lasts 8 seconds.",
         "hotkey": "W",
@@ -43,7 +43,7 @@
         "type": "basic"
       },
       {
-        "uid": "5e5990a",
+        "uid": "340714",
         "name": "Infested Drop",
         "description": "Bombard target area with a Zerg Drop Pod for 140 (+4% per level) damage.  The pod spawns 2 Roachlings that deal 27 (+4% per level) damage per second and last for 8 seconds.",
         "hotkey": "E",
@@ -54,7 +54,7 @@
         "type": "basic"
       },
       {
-        "uid": "6097873",
+        "uid": "7d9fbd",
         "name": "Nydus Network",
         "description": "Summon a Nydus Worm on Creep anywhere that Zagara has vision. Zagara can enter a Nydus Worm and travel to any other Nydus Worm by right-clicking near it. While inside a Nydus Worm, Zagara regenerates 10% Health and Mana per second.  Stores up to 2 charges. Maximum of 4 Nydus Worms at a time.  Passive: Creep spreads 15% farther.  Passive: While on Creep, each Basic Attack reduces all of Zagara's cooldowns by 0.4 seconds.",
         "hotkey": "R",
@@ -65,7 +65,7 @@
         "type": "heroic"
       },
       {
-        "uid": "b67da9b",
+        "uid": "311ea7",
         "name": "Devouring Maw",
         "description": "Summon a Devouring Maw that devours enemies for 4 seconds. Devoured enemies cannot fight and take 88 (+4% per level) damage per second.  Usable on Unstoppable enemies.",
         "hotkey": "R",
@@ -76,10 +76,9 @@
         "type": "heroic"
       },
       {
-        "uid": "db8b00f",
+        "uid": "d4b96a",
         "name": "Creep Tumor",
         "description": "Lay a Creep Tumor that generates Creep. While on Creep, Zagara gains 20% additional attack range and both Zagara and her summons move 20% faster. Tumors last 240 seconds and reveal the surrounding area while active.  Stores up to 3 charges.",
-        "hotkey": "D",
         "trait": true,
         "abilityId": "Zagara|D1",
         "cooldown": 18,
@@ -136,7 +135,7 @@
         "icon": "storm_ui_icon_talent_autoattack_range.png",
         "type": "Active",
         "sort": 1,
-        "cooldown": 30,
+        "cooldown": 430,
         "abilityId": "Zagara|Active"
       },
       {

--- a/hero/zarya.json
+++ b/hero/zarya.json
@@ -1,5 +1,5 @@
 {
-  "id": "57",
+  "id": 57,
   "shortName": "zarya",
   "attributeId": "Zary",
   "cHeroId": "Zarya",
@@ -20,7 +20,7 @@
   "abilities": {
     "Zarya": [
       {
-        "uid": "bbf6e60",
+        "uid": "0458c3",
         "name": "Particle Grenade",
         "description": "Launch a particle grenade that deals 75 (+4% per level) damage to enemies within the area. Deals 50% damage to Structures.  Stores up to 4 charges.",
         "hotkey": "Q",
@@ -30,7 +30,7 @@
         "type": "basic"
       },
       {
-        "uid": "3d2b3fd",
+        "uid": "7b0a5e",
         "name": "Personal Barrier",
         "description": "Gain a Shield that absorbs 560 (+4% per level) damage for 3 seconds.",
         "hotkey": "W",
@@ -40,7 +40,7 @@
         "type": "basic"
       },
       {
-        "uid": "54bc2db",
+        "uid": "f5b6eb",
         "name": "Shield Ally",
         "description": "Grants an allied Hero a Shield that absorbs 420 (+4% per level) damage for 3 seconds.",
         "hotkey": "E",
@@ -50,17 +50,7 @@
         "type": "basic"
       },
       {
-        "uid": "0c2ce1e",
-        "name": "Expulsion Zone",
-        "description": "Launch a gravity bomb that deals 124 (+4% per level) damage and creates an expulsion zone for 3.5 seconds. Enemies who enter the affected area are knocked back and have their Movement Speed reduced by 50% for 1 second.",
-        "hotkey": "R",
-        "abilityId": "Zarya|R2",
-        "cooldown": 45,
-        "icon": "storm_ui_icon_zarya_expulsionzone.png",
-        "type": "heroic"
-      },
-      {
-        "uid": "7847566",
+        "uid": "85436d",
         "name": "Graviton Surge",
         "description": "Launch a gravity bomb that detonates after 1 second and draws enemy Heroes toward the center for 2.5 seconds.",
         "hotkey": "R",
@@ -70,7 +60,17 @@
         "type": "heroic"
       },
       {
-        "uid": "25511a4",
+        "uid": "899d83",
+        "name": "Expulsion Zone",
+        "description": "Launch a gravity bomb that deals 124 (+4% per level) damage and creates an expulsion zone for 3.5 seconds. Enemies who enter the affected area are knocked back and have their Movement Speed reduced by 50% for 1 second.",
+        "hotkey": "R",
+        "abilityId": "Zarya|R2",
+        "cooldown": 45,
+        "icon": "storm_ui_icon_zarya_expulsionzone.png",
+        "type": "heroic"
+      },
+      {
+        "uid": "34afa1",
         "name": "Energy",
         "description": "Each time Zarya's Personal Barrier or Shield Ally absorbs 9 (+4% per level) damage, her Energy is increased by 1. Each point of Energy increases Zarya's damage by 2%. After 0.5 seconds, Energy decays by 3 per second.",
         "trait": true,

--- a/hero/zeratul.json
+++ b/hero/zeratul.json
@@ -1,5 +1,5 @@
 {
-  "id": "22",
+  "id": 22,
   "shortName": "zeratul",
   "attributeId": "Zera",
   "cHeroId": "Zeratul",
@@ -23,7 +23,7 @@
   "abilities": {
     "Zeratul": [
       {
-        "uid": "84b5f86",
+        "uid": "485b63",
         "name": "Cleave",
         "description": "Deal 200 (+4% per level) damage to nearby enemies.",
         "hotkey": "Q",
@@ -34,7 +34,7 @@
         "type": "basic"
       },
       {
-        "uid": "85e6886",
+        "uid": "da7208",
         "name": "Singularity Spike",
         "description": "Flings a Singularity Spike that sticks to the first enemy hit. Deals 240 (+4% per level) damage after 1 second and Slows the enemy by 40% for 3 seconds.",
         "hotkey": "W",
@@ -45,7 +45,7 @@
         "type": "basic"
       },
       {
-        "uid": "feba377",
+        "uid": "de8ad5",
         "name": "Blink",
         "description": "Teleport to the target location.  Using this Ability does not break Stealth.",
         "hotkey": "E",
@@ -56,7 +56,17 @@
         "type": "basic"
       },
       {
-        "uid": "85e2282",
+        "uid": "f2f9e4",
+        "name": "Vorpal Blade",
+        "description": "Activate to teleport to Zeratul's last non-structure Basic Attack target within 3 seconds. The target is revealed during these 3 seconds.",
+        "hotkey": 1,
+        "abilityId": "Zeratul|11",
+        "cooldown": 15,
+        "icon": "storm_ui_icon_zeratul_vorpalblade.png",
+        "type": "activable"
+      },
+      {
+        "uid": "af8a60",
         "name": "Might Of The Nerazim",
         "description": "Activate to cast an untalented version of Zeratul's most recently used Basic Ability, dealing 50% less damage.  Passive: After using an Ability, Zeratul's next Basic Attack within 6 seconds deals 30% more damage.",
         "hotkey": "R",
@@ -67,7 +77,7 @@
         "type": "heroic"
       },
       {
-        "uid": "e51880f",
+        "uid": "6e5ef5",
         "name": "Void Prison",
         "description": "Slows time in an area to a near standstill, placing allies and enemies in Time Stop for 5 seconds. Zeratul is not affected.",
         "hotkey": "R",
@@ -78,23 +88,13 @@
         "type": "heroic"
       },
       {
-        "uid": "b018c6d",
+        "uid": "631568",
         "name": "Permanent Cloak",
         "description": "Gain Stealth when out of combat for 3 seconds. Taking damage, attacking, using Abilities, or Channeling ends Stealth. Remaining stationary for at least 1.5 seconds while Stealthed grants Invisible.",
         "trait": true,
         "abilityId": "Zeratul|D1",
         "icon": "storm_ui_icon_zeratul_cloak.png",
         "type": "trait"
-      },
-      {
-        "uid": "9af1420",
-        "name": "Vorpal Blade",
-        "description": "Activate to teleport to Zeratul's last non-structure Basic Attack target within 3 seconds. The target is revealed during these 3 seconds.",
-        "hotkey": "1",
-        "abilityId": "Zeratul|11",
-        "cooldown": 15,
-        "icon": "storm_ui_icon_zeratul_vorpalblade.png",
-        "type": "activable"
       }
     ]
   },
@@ -341,7 +341,7 @@
       {
         "tooltipId": "ZeratulGiftoftheXelNaga",
         "talentTreeId": "ZeratulGiftoftheXelNaga",
-        "name": "Gift of the Xel'Naga",
+        "name": "Gift of the Xel’Naga",
         "description": "Allies are no longer affected by Void Prison, and enemies are slowed by 50% for 3 seconds once Void Prison ends.",
         "icon": "storm_ui_icon_zeratul_voidprison.png",
         "type": "Heroic",

--- a/hero/zuljin.json
+++ b/hero/zuljin.json
@@ -118,9 +118,8 @@
         "icon": "storm_ui_icon_zuljin_berzerker.png",
         "type": "Trait",
         "sort": 2,
-        "abilityId": "Zuljin|D2",
+        "abilityId": "Zuljin|D1",
         "abilityLinks": [
-          "Zuljin|D2",
           "Zuljin|D1"
         ]
       },
@@ -214,9 +213,8 @@
         "icon": "storm_ui_icon_zuljin_berzerker.png",
         "type": "Trait",
         "sort": 3,
-        "abilityId": "Zuljin|D2",
+        "abilityId": "Zuljin|D1",
         "abilityLinks": [
-          "Zuljin|D2",
           "Zuljin|D1"
         ]
       }

--- a/hero/zuljin.json
+++ b/hero/zuljin.json
@@ -1,5 +1,5 @@
 {
-  "id": "61",
+  "id": 61,
   "shortName": "zuljin",
   "attributeId": "ZULJ",
   "cHeroId": "Zuljin",
@@ -18,80 +18,80 @@
     "RoleCaster"
   ],
   "abilities": {
-    "Zul'jin": [
+    "Zuljin": [
       {
-        "uid": "8f82b28",
+        "uid": "824aa7",
         "name": "Grievous Throw",
         "description": "Zul'jin throws an axe forward, dealing 125 (+4% per level) damage to the first 2 enemies hit and marking them for 6 seconds. Marked enemies take 50% bonus damage from Zul'jin's next 3 Basic Attacks against them.",
         "hotkey": "Q",
-        "abilityId": "Zul'jin|Q1",
+        "abilityId": "Zuljin|Q1",
         "cooldown": 8,
         "manaCost": 40,
         "icon": "storm_ui_icon_zuljin_grievousthrow.png",
         "type": "basic"
       },
       {
-        "uid": "a79ad17",
+        "uid": "d4a20f",
         "name": "Twin Cleave",
         "description": "Throw 2 axes in a large, circular arc, dealing 112 (+4% per level) damage and Slowing affected enemies by 15% per axe for 2 seconds.",
         "hotkey": "W",
-        "abilityId": "Zul'jin|W1",
+        "abilityId": "Zuljin|W1",
         "cooldown": 10,
         "manaCost": 60,
         "icon": "storm_ui_icon_zuljin_twincleave.png",
         "type": "basic"
       },
       {
-        "uid": "99ea734",
+        "uid": "553721",
         "name": "Regeneration",
         "description": "Zul'jin channels to regenerate 30% of his maximum Health over 4 seconds. Moving while channeling or taking damage will interrupt this effect.",
         "hotkey": "E",
-        "abilityId": "Zul'jin|E1",
+        "abilityId": "Zuljin|E1",
         "cooldown": 15,
         "manaCost": 75,
         "icon": "storm_ui_icon_zuljin_regeneration.png",
         "type": "basic"
       },
       {
-        "uid": "ed061bd",
+        "uid": "09987f",
+        "name": "Amani Rage",
+        "description": "Activate to cause Zul'jin to instantly lose 50% of his current Health and heal for that amount over 10 seconds.",
+        "hotkey": 1,
+        "abilityId": "Zuljin|11",
+        "cooldown": 30,
+        "icon": "storm_ui_icon_zuljin_davoodooshuffle.png",
+        "type": "activable"
+      },
+      {
+        "uid": "28f03c",
         "name": "Taz'dingo!",
         "description": "For the next 4 seconds, Zul'jin is Unkillable, and cannot be reduced to less than 1 Health. Taz'dingo!",
         "hotkey": "R",
-        "abilityId": "Zul'jin|R1",
+        "abilityId": "Zuljin|R1",
         "cooldown": 90,
         "manaCost": 75,
         "icon": "storm_ui_icon_zuljin_tazdingo.png",
         "type": "heroic"
       },
       {
-        "uid": "41c1dda",
+        "uid": "06d05f",
         "name": "Guillotine",
         "description": "Zul'jin launches a massive axe into the air that drops on the targeted area, dealing 330 (+4% per level) damage plus bonus damage the lower his Health is.",
         "hotkey": "R",
-        "abilityId": "Zul'jin|R2",
+        "abilityId": "Zuljin|R2",
         "cooldown": 40,
         "manaCost": 70,
         "icon": "storm_ui_icon_zuljin_guillotine.png",
         "type": "heroic"
       },
       {
-        "uid": "dd74a5f",
+        "uid": "6241a7",
         "name": "Berserker",
         "description": "Activate to increase Basic Attack damage by 25% but consume 2% maximum Health per attack.  Passive: Zul'jin attacks 1% faster for every 1% of maximum Health missing.  You Want Axe?  Quest: Every 5 Basic Attacks against Heroes permanently increases Basic Attack damage by 1.  Reward: After attacking Heroes 75 times, Basic Attack range is increased by 1.1.  Reward: After attacking Heroes 150 times, Twin Cleave now revolves twice.",
         "trait": true,
-        "abilityId": "Zul'jin|D1",
+        "abilityId": "Zuljin|D1",
         "icon": "storm_ui_icon_zuljin_berzerker.png",
         "type": "trait"
-      },
-      {
-        "uid": "8607d21",
-        "name": "Amani Rage",
-        "description": "Activate to cause Zul'jin to instantly lose 50% of his current Health and heal for that amount over 10 seconds.",
-        "hotkey": "1",
-        "abilityId": "Zul'jin|11",
-        "cooldown": 30,
-        "icon": "storm_ui_icon_zuljin_davoodooshuffle.png",
-        "type": "activable"
       }
     ]
   },
@@ -105,9 +105,9 @@
         "icon": "storm_ui_icon_zuljin_grievousthrow.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "Zul'jin|Q1",
+        "abilityId": "Zuljin|Q1",
         "abilityLinks": [
-          "Zul'jin|Q1"
+          "Zuljin|Q1"
         ]
       },
       {
@@ -118,9 +118,10 @@
         "icon": "storm_ui_icon_zuljin_berzerker.png",
         "type": "Trait",
         "sort": 2,
-        "abilityId": "Zul'jin|D1",
+        "abilityId": "Zuljin|D2",
         "abilityLinks": [
-          "Zul'jin|D1"
+          "Zuljin|D2",
+          "Zuljin|D1"
         ]
       },
       {
@@ -132,7 +133,7 @@
         "type": "Passive",
         "sort": 3,
         "isQuest": true,
-        "abilityId": "Zul'jin|Passive"
+        "abilityId": "Zuljin|Passive"
       }
     ],
     "4": [
@@ -144,9 +145,9 @@
         "icon": "storm_ui_icon_zuljin_regeneration.png",
         "type": "E",
         "sort": 1,
-        "abilityId": "Zul'jin|E1",
+        "abilityId": "Zuljin|E1",
         "abilityLinks": [
-          "Zul'jin|E1"
+          "Zuljin|E1"
         ]
       },
       {
@@ -158,9 +159,9 @@
         "type": "Active",
         "sort": 2,
         "cooldown": 10,
-        "abilityId": "Zul'jin|E1",
+        "abilityId": "Zuljin|Active",
         "abilityLinks": [
-          "Zul'jin|E1"
+          "Zuljin|E1"
         ]
       },
       {
@@ -171,9 +172,9 @@
         "icon": "storm_ui_icon_zuljin_davoodooshuffle.png",
         "type": "Active",
         "sort": 3,
-        "abilityId": "Zul'jin|11",
+        "abilityId": "Zuljin|Active",
         "abilityLinks": [
-          "Zul'jin|11"
+          "Zuljin|11"
         ]
       }
     ],
@@ -186,9 +187,9 @@
         "icon": "storm_ui_icon_zuljin_grievousthrow.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "Zul'jin|Q1",
+        "abilityId": "Zuljin|Q1",
         "abilityLinks": [
-          "Zul'jin|Q1"
+          "Zuljin|Q1"
         ]
       },
       {
@@ -200,9 +201,9 @@
         "type": "W",
         "sort": 2,
         "isQuest": true,
-        "abilityId": "Zul'jin|W1",
+        "abilityId": "Zuljin|W1",
         "abilityLinks": [
-          "Zul'jin|W1"
+          "Zuljin|W1"
         ]
       },
       {
@@ -213,9 +214,10 @@
         "icon": "storm_ui_icon_zuljin_berzerker.png",
         "type": "Trait",
         "sort": 3,
-        "abilityId": "Zul'jin|D1",
+        "abilityId": "Zuljin|D2",
         "abilityLinks": [
-          "Zul'jin|D1"
+          "Zuljin|D2",
+          "Zuljin|D1"
         ]
       }
     ],
@@ -229,9 +231,9 @@
         "type": "Heroic",
         "sort": 1,
         "cooldown": 90,
-        "abilityId": "Zul'jin|R1",
+        "abilityId": "Zuljin|R1",
         "abilityLinks": [
-          "Zul'jin|R1"
+          "Zuljin|R1"
         ]
       },
       {
@@ -243,9 +245,9 @@
         "type": "Heroic",
         "sort": 2,
         "cooldown": 40,
-        "abilityId": "Zul'jin|R2",
+        "abilityId": "Zuljin|R2",
         "abilityLinks": [
-          "Zul'jin|R2"
+          "Zuljin|R2"
         ]
       }
     ],
@@ -258,9 +260,9 @@
         "icon": "storm_ui_icon_zuljin_twincleave.png",
         "type": "W",
         "sort": 1,
-        "abilityId": "Zul'jin|W1",
+        "abilityId": "Zuljin|W1",
         "abilityLinks": [
-          "Zul'jin|W1"
+          "Zuljin|W1"
         ]
       },
       {
@@ -271,7 +273,7 @@
         "icon": "storm_ui_icon_talent_autoattack_base.png",
         "type": "Passive",
         "sort": 2,
-        "abilityId": "Zul'jin|Passive"
+        "abilityId": "Zuljin|Passive"
       },
       {
         "tooltipId": "ZuljinEnsnare",
@@ -282,7 +284,7 @@
         "type": "Active",
         "sort": 3,
         "cooldown": 45,
-        "abilityId": "Zul'jin|Active"
+        "abilityId": "Zuljin|Active"
       }
     ],
     "16": [
@@ -294,9 +296,9 @@
         "icon": "storm_ui_icon_zuljin_grievousthrow.png",
         "type": "Q",
         "sort": 1,
-        "abilityId": "Zul'jin|Q1",
+        "abilityId": "Zuljin|Q1",
         "abilityLinks": [
-          "Zul'jin|Q1"
+          "Zuljin|Q1"
         ]
       },
       {
@@ -307,9 +309,9 @@
         "icon": "storm_ui_icon_zuljin_twincleave.png",
         "type": "W",
         "sort": 2,
-        "abilityId": "Zul'jin|W1",
+        "abilityId": "Zuljin|W1",
         "abilityLinks": [
-          "Zul'jin|W1"
+          "Zuljin|W1"
         ]
       },
       {
@@ -320,7 +322,7 @@
         "icon": "storm_ui_icon_talent_autoattack_speed.png",
         "type": "Passive",
         "sort": 3,
-        "abilityId": "Zul'jin|Passive"
+        "abilityId": "Zuljin|Passive"
       }
     ],
     "20": [
@@ -332,9 +334,9 @@
         "icon": "storm_ui_icon_zuljin_tazdingo.png",
         "type": "Heroic",
         "sort": 1,
-        "abilityId": "Zul'jin|R1",
+        "abilityId": "Zuljin|R1",
         "abilityLinks": [
-          "Zul'jin|R1"
+          "Zuljin|R1"
         ]
       },
       {
@@ -345,9 +347,9 @@
         "icon": "storm_ui_icon_zuljin_guillotine.png",
         "type": "Heroic",
         "sort": 2,
-        "abilityId": "Zul'jin|R2",
+        "abilityId": "Zuljin|R2",
         "abilityLinks": [
-          "Zul'jin|R2"
+          "Zuljin|R2"
         ]
       },
       {
@@ -358,9 +360,9 @@
         "icon": "storm_ui_icon_zuljin_regeneration.png",
         "type": "E",
         "sort": 3,
-        "abilityId": "Zul'jin|E1",
+        "abilityId": "Zuljin|E1",
         "abilityLinks": [
-          "Zul'jin|E1"
+          "Zuljin|E1"
         ]
       }
     ]


### PR DESCRIPTION
*This is not safe to merge!*

This is an example of the current output from https://github.com/tattersoftware/heroes-convert. @stuaroo I'd like you to consider it for some of the things that will be different if we switch to the hosted data repo - minimal impact on consumers but changes nonetheless.

After I have a chance to tweak the process and get the output closer to the current repo format I'll send over another PR for 2.48.2.76781. After that is in place I think we should proceed with the destructive repo split to remove `raw/`.